### PR TITLE
Rewrite the process monitor

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -105,3 +105,40 @@ parser.finish()?
 ```
 
 `JsonParser.parse()` is unchanged.
+
+## Report a process's exit even when its pipes stay open
+
+`ProcessMonitor` reported a child's exit status only once the child's stdout and stderr had both reached end-of-file. A pipe reaches end-of-file only when every process holding its write end has closed it, so a child that left a grandchild holding its stdout or stderr open, or that exited while you still held its stdin open, was reported late or never, and the program could hang. The exit is now detected directly, from the operating system, and reported promptly regardless of what still holds the pipes.
+
+## ProcessMonitor.dispose no longer risks signaling an unrelated process
+
+Disposing a `ProcessMonitor` after its child had already exited could send a signal to whatever process the operating system had since assigned the child's old process id. It no longer signals a child that has been reaped.
+
+## ProcessMonitor no longer leaks file descriptors when a process fails to start
+
+A process that failed to start left the pipes that had been opened for it open. They are now closed.
+
+## Starting a process returns a result
+
+Starting a process now returns either a `ProcessMonitor` or a `ProcessError`, instead of always giving you a monitor. Replace the constructor with `StartProcess`:
+
+Before:
+
+```pony
+let pm = ProcessMonitor(sp_auth, bp_auth, consume notifier, path, args, vars)
+```
+
+After:
+
+```pony
+match StartProcess(sp_auth, bp_auth, consume notifier, path, args, vars)
+| let pm: ProcessMonitor => // a live child is running
+| let err: ProcessError  => // never started; err says why
+end
+```
+
+Failures that used to arrive through `ProcessNotify.failed` — no execute permission, a missing executable, and, on Linux, a kernel older than 5.3 — are now returned by `StartProcess` instead. The `ExecveError` that meant both "the file is missing" and "execve failed in the child" is split; the missing-file case is now `ExecutableNotFound`.
+
+## ProcessMonitor requires Linux 5.3 or newer
+
+On Linux, detecting a child's exit now uses `pidfd_open`, which requires kernel 5.3 or newer. On an older kernel, `StartProcess` returns an `UnsupportedKernel` error rather than starting a process it cannot monitor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix pony-lint running out of memory on repos with many packages ([PR #5809](https://github.com/ponylang/ponyc/pull/5809))
 - Readline preserves the in-progress line when browsing history ([PR #5816](https://github.com/ponylang/ponyc/pull/5816))
 - Fix slow stdin reads from redirected files on Windows ([PR #5815](https://github.com/ponylang/ponyc/pull/5815))
+- Report a process's exit even when its pipes stay open ([PR #5770](https://github.com/ponylang/ponyc/pull/5770))
+- ProcessMonitor.dispose no longer risks signaling an unrelated process ([PR #5770](https://github.com/ponylang/ponyc/pull/5770))
+- ProcessMonitor no longer leaks file descriptors when a process fails to start ([PR #5770](https://github.com/ponylang/ponyc/pull/5770))
 
 ### Added
 
@@ -21,6 +24,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - Replace the runtime allocator ([PR #5768](https://github.com/ponylang/ponyc/pull/5768))
 - Change how scheduler scaling works ([PR #5768](https://github.com/ponylang/ponyc/pull/5768))
 - Change JsonTokenParser to carry values on its tokens ([PR #5658](https://github.com/ponylang/ponyc/pull/5658))
+- Starting a process returns a result ([PR #5770](https://github.com/ponylang/ponyc/pull/5770))
+- ProcessMonitor requires Linux 5.3 or newer ([PR #5770](https://github.com/ponylang/ponyc/pull/5770))
 
 ## [0.68.0] - 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ On Windows, the minimum supported version is **Windows 11 / Windows Server 2022*
 build; earlier versions, including Windows 10, are unsupported and a Pony binary
 will not run on them.
 
+On Linux, the minimum supported version is **kernel 5.3**. Pony's process
+support detects a child's exit with `pidfd_open`, a system call added in that
+release; on an older kernel, starting a process returns an error. Earlier
+kernels are unsupported.
+
 ## More Information
 
 * [Installation](INSTALL.md)

--- a/packages/builtin/asio_event.pony
+++ b/packages/builtin/asio_event.pony
@@ -55,6 +55,24 @@ primitive AsioEvent
 
   fun signal(): U32 => 1 << 3
 
+  fun proc(): U32 =>
+    """
+    Subscribe for a process-exit event, which fires when the child exits. On
+    kqueue platforms the event's fd is the child's pid; on Windows its `nsec`
+    carries the child's process handle and its fd is unused. Must match
+    `ASIO_PROC` in the runtime's `asio.h`.
+    """
+    1 << 5
+
+  fun pipe(): U32 =>
+    """
+    Mark an event as a pipe that the Windows readiness backend peeks. A Windows
+    pipe has no readiness signal, so the backend peeks it and delivers
+    `ASIO_READ`/`ASIO_WRITE`. Combine with one direction flag (`read` or
+    `write`). Must match `ASIO_PIPE` in the runtime's `asio.h`.
+    """
+    1 << 6
+
   fun read_write(): U32 => read() or write()
 
   fun oneshot(): U32 => 1 << 8

--- a/packages/process/_pipe.pony
+++ b/packages/process/_pipe.pony
@@ -131,11 +131,21 @@ class _Pipe
   fun ref begin(owner: AsioEventNotify) =>
     """
     Prepare the pipe for read or write, and listening, after the far end has
-    been handed to the other process.
+    been handed to the other process. A none/placeholder pipe (no fds) creates
+    no event.
     """
-    ifdef posix then
-      let flags = if _outgoing then AsioEvent.write() else AsioEvent.read() end
-      event = @pony_asio_event_create(owner, near_fd, flags, 0, true)
+    if near_fd != -1 then
+      ifdef posix then
+        let flags =
+          if _outgoing then AsioEvent.write() else AsioEvent.read() end
+        event = @pony_asio_event_create(owner, near_fd, flags, 0, true)
+      elseif windows then
+        // The readiness backend peeks the pipe (it has no readiness signal) and
+        // delivers ASIO_READ/ASIO_WRITE. One direction flag, as on posix.
+        let flags = AsioEvent.pipe() or
+          (if _outgoing then AsioEvent.write() else AsioEvent.read() end)
+        event = @pony_asio_event_create(owner, near_fd, flags, 0, true)
+      end
     end
     close_far()
 
@@ -156,7 +166,7 @@ class _Pipe
       let len =
         @read(near_fd, read_buf.cpointer(offset),
           read_buf.size() - offset)
-      if len == -1 then // OS signals write error
+      if len == -1 then // OS signals read error
         (consume read_buf, len, @pony_os_errno())
       else
         (consume read_buf, len, 0)
@@ -253,17 +263,23 @@ class _Pipe
 
   fun ref close_near() =>
     """
-    Close the near end of the pipe--the end that this process is using
-    directly. Also handle unsubscribing the asio event (if there was one). File
-    descriptors should always be closed _after_ unsubscribing its event,
-    otherwise there is the possibility of reusing the file descriptor in
-    another thread and then unsubscribing the reused file descriptor here!
-    Unsubscribing and closing the file descriptor should be treated as one
-    operation.
+    Close the near end of the pipe--the end that this process is using directly,
+    and unsubscribe its asio event if there is one. On posix the fd is closed
+    here, after unsubscribing, so no other thread can reuse the fd number before
+    we have unsubscribed it. On Windows a subscribed pipe fd is closed by the
+    readiness backend instead: unsubscribe there is asynchronous and the backend
+    peeks the fd until it processes the unsubscribe, so closing the fd here could
+    race that peek. A pipe with no event--a failure path where begin() never
+    ran--is closed here on every platform.
     """
     if near_fd != -1 then
       if event isnt AsioEvent.none() then
         @pony_asio_event_unsubscribe(event)
+        ifdef windows then
+          // The backend closes the fd when it processes the unsubscribe.
+          near_fd = -1
+          return
+        end
       end
       @close(near_fd)
       near_fd = -1
@@ -274,5 +290,7 @@ class _Pipe
     close_near()
 
   fun ref dispose() =>
-    @pony_asio_event_destroy(event)
-    event = AsioEvent.none()
+    if event isnt AsioEvent.none() then
+      @pony_asio_event_destroy(event)
+      event = AsioEvent.none()
+    end

--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -2,6 +2,7 @@ use "signals"
 use "files"
 use @pony_os_errno[I32]()
 use @ponyint_wnohang[I32]() if posix
+use @ponyint_pidfd_open[I32](pid: I32) if linux
 use @ponyint_win_process_create[USize](appname: Pointer[U8] tag,
   cmdline: Pointer[U8] tag, environ: Pointer[U8] tag, wdir: Pointer[U8] tag,
   stdin_fd: U32, stdout_fd: U32, stderr_fd: U32,
@@ -66,6 +67,12 @@ primitive _EAGAIN
 // Invalid argument
 primitive _EINVAL
   fun apply(): I32 => 22
+
+// Function not implemented (kernel too old for pidfd_open)
+primitive _ENOSYS
+  fun apply(): I32 =>
+    ifdef linux then 38
+    else compile_error "no ENOSYS" end
 
 primitive _EXOSERR
   fun apply(): I32 => 71
@@ -156,35 +163,49 @@ type ProcessExitStatus is (Exited | Signaled)
   """
 
 primitive _StillRunning
+  """
+  The result of a non-blocking reap that found no exit to collect. From the
+  start-up probe this means the child is still running. After an exit signal it
+  means `waitpid` has not yet caught up to the OS's exit notification. What each
+  caller does with it — wait, retry, or report failure — is the caller's own.
+  """
 
 type _WaitResult is (ProcessExitStatus | WaitpidError | _StillRunning)
 
 
 interface _Process
-  fun kill()
+  fun box kill()
   fun ref wait(): _WaitResult
     """
-    Only polls, does not actually wait for the process to finish,
-    in order to not block a scheduler thread.
+    Non-blocking reap of the child. Collects the exit status if the child has
+    exited; does not block a scheduler thread.
     """
-
-
-class _ProcessNone is _Process
-  fun kill() => None
-  fun ref wait(): _WaitResult => Exited(255)
+  fun ref arm_exit_event(owner: AsioEventNotify): AsioEventID
+    """
+    Register the child's native exit event with the asio backend and return its
+    id. The event fires when the child exits.
+    """
+  fun ref close_exit_source(event: AsioEventID)
+    """
+    Unsubscribe the exit event and release the native exit source (the pidfd on
+    Linux). Idempotent.
+    """
 
 class _ProcessPosix is _Process
   let pid: I32
+  // Linux: a pidfd for the child, the exit source. BSD/macOS: -1, because
+  // kqueue keys its EVFILT_PROC exit filter on the pid, not on an fd.
+  var _exit_fd: I32 = -1
 
   new create(
     path: String,
     args: Array[String] val,
     vars: Array[String] val,
-    wdir: (FilePath | None),
-    err: _Pipe,
-    stdin: _Pipe,
-    stdout: _Pipe,
-    stderr: _Pipe) ?
+    wdir: (String val | None),
+    err_far_fd: U32,
+    stdin_far_fd: U32,
+    stdout_far_fd: U32,
+    stderr_far_fd: U32) ?
   =>
     // Prepare argp and envp ahead of fork() as it's not safe to allocate in
     // the child after fork() is called.
@@ -194,7 +215,31 @@ class _ProcessPosix is _Process
     pid = @fork()
     match pid
     | -1 => error
-    | 0 => _child_fork(path, argp, envp, wdir, err, stdin, stdout, stderr)
+    | 0 =>
+      _child_fork(path, argp, envp, wdir, err_far_fd, stdin_far_fd,
+        stdout_far_fd, stderr_far_fd)
+    end
+
+    // Parent. Open the child's exit source. On Linux that is a pidfd; a
+    // failure here is defensive (the factory already probed pidfd support), so
+    // clean up the child we just forked rather than leaking it as a zombie.
+    ifdef linux then
+      let fd = @ponyint_pidfd_open(pid)
+      if fd < 0 then
+        // Force-kill and reap the child we forked but cannot monitor. SIGKILL,
+        // not SIGTERM: the child may have already exec'd into a program that
+        // ignores SIGTERM, and the reap below blocks. Retry on EINTR.
+        @kill(pid, Sig.kill())
+        var wstatus: I32 = 0
+        while
+          (@waitpid(pid, addressof wstatus, 0) < 0)
+            and (@pony_os_errno() == _EINTR())
+        do
+          None
+        end
+        error
+      end
+      _exit_fd = fd
     end
 
   fun tag _make_argv(args: Array[String] box): Array[Pointer[U8] tag] =>
@@ -213,8 +258,11 @@ class _ProcessPosix is _Process
     path: String,
     argp: Array[Pointer[U8] tag],
     envp: Array[Pointer[U8] tag],
-    wdir: (FilePath | None),
-    err: _Pipe, stdin: _Pipe, stdout: _Pipe, stderr: _Pipe)
+    wdir: (String val | None),
+    err_far_fd: U32,
+    stdin_far_fd: U32,
+    stdout_far_fd: U32,
+    stderr_far_fd: U32)
   =>
     """
     We are now in the child process. We redirect STDIN, STDOUT and STDERR
@@ -224,17 +272,17 @@ class _ProcessPosix is _Process
     loaded. We've set the FD_CLOEXEC flag on all file descriptors to ensure
     that they are all closed automatically once @execve gets called.
     """
-    _dup2(stdin.far_fd, _STDINFILENO())   // redirect stdin
-    _dup2(stdout.far_fd, _STDOUTFILENO()) // redirect stdout
-    _dup2(stderr.far_fd, _STDERRFILENO()) // redirect stderr
+    _dup2(stdin_far_fd, _STDINFILENO())   // redirect stdin
+    _dup2(stdout_far_fd, _STDOUTFILENO()) // redirect stdout
+    _dup2(stderr_far_fd, _STDERRFILENO()) // redirect stderr
 
     var step: U8 = _StepChdir()
 
     match \exhaustive\ wdir
-    | let d: FilePath =>
-      let dir: Pointer[U8] tag = d.path.cstring()
+    | let d: String =>
+      let dir: Pointer[U8] tag = d.cstring()
       if 0 > @chdir(dir) then
-        @write(err.far_fd, addressof step, USize(1))
+        @write(err_far_fd, addressof step, USize(1))
         @_exit(_EXOSERR())
       end
     | None => None
@@ -244,7 +292,7 @@ class _ProcessPosix is _Process
     if 0 > @execve(path.cstring(), argp.cpointer(),
       envp.cpointer())
     then
-      @write(err.far_fd, addressof step, USize(1))
+      @write(err_far_fd, addressof step, USize(1))
       @_exit(_EXOSERR())
     end
 
@@ -263,16 +311,18 @@ class _ProcessPosix is _Process
       end
     end
 
-  fun kill() =>
+  fun box kill() =>
     """
     Terminate the process, first trying SIGTERM and if that fails, try SIGKILL.
+    Only ever called while the child is an unreaped zombie we own, so its pid
+    cannot have been recycled.
     """
     if pid > 0 then
       // Try a graceful termination
       if @kill(pid, Sig.term()) < 0 then
         match @pony_os_errno()
         | _EINVAL() => None // Invalid argument, shouldn't happen but
-                            // tryinng SIGKILL isn't likely to help.
+                            // trying SIGKILL isn't likely to help.
         | _ESRCH() => None  // No such process, child has terminated
         else
           // Couldn't SIGTERM, as a last resort SIGKILL
@@ -281,16 +331,49 @@ class _ProcessPosix is _Process
       end
     end
 
+  fun ref arm_exit_event(owner: AsioEventNotify): AsioEventID =>
+    ifdef linux then
+      // The pidfd goes readable when the child exits; register it as a plain
+      // read event. epoll delivers it like any other fd.
+      @pony_asio_event_create(owner, _exit_fd.u32(), AsioEvent.read(), 0, true)
+    elseif bsd or osx then
+      // kqueue's EVFILT_PROC keys on the pid; the backend reads ASIO_PROC and
+      // registers NOTE_EXIT.
+      @pony_asio_event_create(owner, pid.u32(), AsioEvent.proc(), 0, true)
+    else
+      compile_error "unsupported posix platform for process exit event"
+    end
+
+  fun ref close_exit_source(event: AsioEventID) =>
+    // Unsubscribe before closing the fd, the same discipline _Pipe.close_near
+    // uses: closing first would let another thread reuse the fd number before
+    // we unsubscribe it here.
+    if event isnt AsioEvent.none() then
+      @pony_asio_event_unsubscribe(event)
+    end
+    ifdef linux then
+      if _exit_fd != -1 then
+        @close(_exit_fd.u32())
+        _exit_fd = -1
+      end
+    end
+    // BSD/macOS: no fd to close; the EVFILT_PROC knote is removed by the
+    // unsubscribe above.
+
   fun ref wait(): _WaitResult =>
-    """Only polls, does not block."""
+    """
+    Non-blocking reap; retries waitpid on EINTR. We poll with WNOHANG and
+    without WUNTRACED, so waitpid reports an exit but not a stop.
+    """
     if pid > 0 then
       var wstatus: I32 = 0
-      let options: I32 = 0 or _WNOHANG()
-      // poll, do not block
-      match \exhaustive\ @waitpid(pid, addressof wstatus, options)
+      let options: I32 = _WNOHANG()
+      var r: I32 = @waitpid(pid, addressof wstatus, options)
+      while (r < 0) and (@pony_os_errno() == _EINTR()) do
+        r = @waitpid(pid, addressof wstatus, options)
+      end
+      match \exhaustive\ r
       | let err: I32 if err < 0 =>
-        // one could possibly do at some point:
-        //let wpe = WaitPidError(@pony_os_errno())
         WaitpidError
       | let exited_pid: I32 if exited_pid == pid => // our process changed state
         if _WaitPidStatus.exited(wstatus) then
@@ -298,11 +381,15 @@ class _ProcessPosix is _Process
         elseif _WaitPidStatus.signaled(wstatus) then
           Signaled(_WaitPidStatus.termsig(wstatus).u32())
         elseif _WaitPidStatus.stopped(wstatus) then
-          Signaled(_WaitPidStatus.stopsig(wstatus).u32())
+          // A stopped (not exited) child. We do not pass WUNTRACED, so waitpid
+          // does not report a stop and this is unreached; if it ever were,
+          // treat a stop as still running, never as an exit.
+          _StillRunning
         elseif _WaitPidStatus.continued(wstatus) then
           _StillRunning
         else
-          // *shrug*
+          // An unrecognized wait status; report it as an error rather than
+          // guess at an exit code.
           WaitpidError
         end
       | 0 => _StillRunning
@@ -326,7 +413,10 @@ primitive _WaitPidStatus
     (wstatus and 0xff00) >> 8
 
   fun signaled(wstatus: I32): Bool =>
-    ((termsig(wstatus) + 1) >> 1).i8() > 0
+    // Matches C's WIFSIGNALED: cast (termsig + 1) to a signed 8-bit value
+    // before shifting, so the 0x7f (stopped/continued) forms overflow to a
+    // negative value and are not counted as a terminating signal.
+    ((termsig(wstatus) + 1).i8() >> 1) > 0
 
   fun termsig(wstatus: I32): I32 =>
     (wstatus and 0x7f)
@@ -353,15 +443,15 @@ class _ProcessWindows is _Process
     path: String,
     args: Array[String] val,
     vars: Array[String] val,
-    wdir: (FilePath | None),
-    stdin: _Pipe,
-    stdout: _Pipe,
-    stderr: _Pipe)
+    wdir: (String val | None),
+    stdin_far_fd: U32,
+    stdout_far_fd: U32,
+    stderr_far_fd: U32)
   =>
     ifdef windows then
       let wdir_ptr =
         match \exhaustive\ wdir
-        | let wdir_fp: FilePath => wdir_fp.path.cstring()
+        | let wdir_str: String => wdir_str.cstring()
         | None => Pointer[U8] // NULL -> use parent directory
         end
       var error_code: U32 = 0
@@ -371,7 +461,7 @@ class _ProcessWindows is _Process
           _make_cmdline(args).cstring(),
           _make_environ(vars).cpointer(),
           wdir_ptr,
-          stdin.far_fd, stdout.far_fd, stderr.far_fd,
+          stdin_far_fd, stdout_far_fd, stderr_far_fd,
           addressof error_code, addressof error_message)
       process_error =
         if h_process == 0 then
@@ -380,7 +470,7 @@ class _ProcessWindows is _Process
           | _ERRORDIRECTORY() =>
             let wdirpath =
               match \exhaustive\ wdir
-              | let wdir_fp: FilePath => wdir_fp.path
+              | let wdir_str: String => wdir_str
               | None => "?"
               end
             ProcessError(ChdirError, "Failed to change directory to "
@@ -411,22 +501,54 @@ class _ProcessWindows is _Process
     cmdline
 
   fun tag _make_environ(vars: Array[String] val): Array[U8] =>
-    var size: USize = 0
+    """
+    Build the ANSI environment block for CreateProcess: each `name=value`
+    string terminated by a null, then a final null ending the block. An empty
+    environment is two nulls -- CreateProcess rejects a block that is a lone
+    null.
+    """
+    var size: USize = if vars.size() == 0 then 2 else 1 end
     for varr in vars.values() do
       size = size + varr.size() + 1 // name=value\0
     end
-    size = size + 1 // last \0
     var environ = Array[U8](size)
     for varr in vars.values() do
       environ.append(varr)
       environ.push(0)
     end
+    if vars.size() == 0 then
+      environ.push(0)
+    end
     environ.push(0)
     environ
 
-  fun kill() =>
+  fun box kill() =>
     if h_process != 0 then
       @ponyint_win_process_kill(h_process)
+    end
+
+  fun ref arm_exit_event(owner: AsioEventNotify): AsioEventID =>
+    ifdef windows then
+      // Register a wait on the child's process handle. The handle rides in the
+      // event's nsec slot; the readiness backend registers a wait on it and
+      // fires ASIO_READ when the child exits. Arming the event hands the
+      // handle's close to the backend (see close_exit_source and
+      // ponyint_win_process_wait).
+      @pony_asio_event_create(owner, 0, AsioEvent.proc(), h_process.u64(), true)
+    else
+      compile_error "unsupported platform"
+    end
+
+  fun ref close_exit_source(event: AsioEventID) =>
+    ifdef windows then
+      // Unsubscribe the exit event. The backend unregisters the wait and closes
+      // the process handle, so there is nothing to close here. Idempotent:
+      // unsubscribe is a no-op on an already-disposed event.
+      if event isnt AsioEvent.none() then
+        @pony_asio_event_unsubscribe(event)
+      end
+    else
+      compile_error "unsupported platform"
     end
 
   fun ref wait(): _WaitResult =>
@@ -443,9 +565,9 @@ class _ProcessWindows is _Process
           final_wait_result = wr
           wr
         | 1 => _StillRunning
-        | let code: I32 =>
-          // we might want to propagate that code to the user, but should it do
-          // for other errors too
+        else
+          // A wait error (the fixed -1 sentinel). We report WaitpidError,
+          // matching the posix path.
           final_wait_result = wr
           wr
         end

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -1,32 +1,53 @@
 use "pony_test"
 use "backpressure"
-use "capsicum"
 use "collections"
 use "files"
 use "itertools"
-use "time"
+use "promises"
 use "signals"
+use "time"
 
 actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
   fun tag tests(test: PonyTest) =>
-    // Tests below function across all systems and are listed alphabetically
+    // factory precondition failures (synchronous)
+    test(_TestFileExecCapabilityIsRequired)
+    test(_TestExecutableNotFound)
+    // real-process behaviour
+    test(_TestStdinStdout)
+    test(_TestStderr)
+    test(_TestExpect)
+    test(_TestWritevOrdering)
+    test(_TestPrintvOrdering)
+    test(_TestChdir)
     test(_TestBadChdir)
     test(_TestBadExec)
-    test(_TestChdir)
-    test(_TestExpect)
-    test(_TestFileExecCapabilityIsRequired)
-    test(_TestKillLongRunningChild)
-    test(_TestLongRunningChild)
-    test(_TestNonExecutablePathResultsInExecveError)
-    test(_TestPrintvOrdering)
-    test(_TestStderr)
-    test(_TestStdinStdout)
+    test(_TestWindowsEmptyEnvironment)
     test(_TestStdinWriteBuf)
+    test(_TestLongRunningChild)
+    test(_TestKillLongRunningChild)
     test(_TestWaitingOnClosedProcessTwice)
-    test(_TestWritevOrdering)
+    // exit detected independent of the child's pipes
+    test(_TestGrandchildDoesNotBlockExit)
+    test(_TestWindowsGrandchildDoesNotBlockExit)
+    test(_TestStdinOpenChildExits)
+    test(_TestGrandchildDeliversBufferedOutput)
+    test(_TestChildClosesOutputKeepsRunning)
+    test(_TestFloodingGrandchildDoesNotStallTeardown)
+    test(_TestManyStartsDoNotLeakFds)
+    // state-machine invariants via the injectable seam
+    test(_TestExitReportsExactlyOnce)
+    test(_TestExitSignalRetriesUntilReapable)
+    test(_TestRetryWhileDisposing)
+    test(_TestExitSignalReapErrorReportsFailed)
+    test(_TestDisposeThenExit)
+    test(_TestDoubleDispose)
+    test(_TestNoKillAfterReap)
+    test(_TestWriteAfterExitIsDropped)
+    // backpressure release (real process)
+    test(_TestBackpressureAppliedThenReleased)
 
 class \nodoc\ _PathResolver
   let _path: Array[FilePath] val
@@ -59,27 +80,11 @@ class \nodoc\ _PathResolver
       try
         let candidate = path_candidate.join(name)?
         if candidate.exists() then
-          // TODO: check if executable for current user
           return candidate
         end
       end
     end
     error
-
-primitive \nodoc\ _SleepCommand
-  fun path(path_resolver: _PathResolver): String ? =>
-    ifdef windows then
-      "C:\\Windows\\System32\\ping.exe"
-    else
-      path_resolver.resolve("sleep")?.path
-    end
-
-  fun args(seconds: USize): Array[String] val =>
-    ifdef windows then
-      ["ping"; "127.0.0.1"; "-n"; seconds.string()]
-    else
-      ["sleep"; seconds.string()]
-    end
 
 primitive \nodoc\ _CatCommand
   fun path(path_resolver: _PathResolver): String ? =>
@@ -96,30 +101,6 @@ primitive \nodoc\ _CatCommand
       ["cat"]
     end
 
-primitive \nodoc\ _EchoPath
-  fun apply(path_resolver: _PathResolver): String ? =>
-    ifdef windows then
-      "C:\\Windows\\System32\\cmd.exe" // Have to use "cmd /c echo ..."
-    else
-      path_resolver.resolve("echo")?.path
-    end
-
-primitive \nodoc\ _PwdPath
-  fun apply(): String =>
-    ifdef windows then
-      "C:\\Windows\\System32\\cmd.exe" // Have to use "cmd /c cd"
-    else
-      "/bin/pwd"
-    end
-
-primitive \nodoc\ _PwdArgs
-  fun apply(): Array[String] val =>
-    ifdef windows then
-      ["cmd"; "/c"; "cd"]
-    else
-      ["pwd"]
-    end
-
 class \nodoc\ iso _TestFileExecCapabilityIsRequired is UnitTest
   fun name(): String =>
     "process/TestFileExecCapabilityIsRequired"
@@ -128,8 +109,6 @@ class \nodoc\ iso _TestFileExecCapabilityIsRequired is UnitTest
     "process-monitor"
 
   fun apply(h: TestHelper) =>
-    let notifier: ProcessNotify iso = _ProcessClient(0, "", 1, h,
-      ProcessError(CapError))
     try
       let process_auth = StartProcessAuth(h.env.root)
       let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
@@ -142,19 +121,23 @@ class \nodoc\ iso _TestFileExecCapabilityIsRequired is UnitTest
           recover val FileCaps .> all() .> unset(FileExec) end)
       let args: Array[String] val = ["dontcare"]
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+      let notifier = _NoStartNotify(h)
 
-      let pm: ProcessMonitor =
-        ProcessMonitor(process_auth, backpressure_auth, consume notifier, path,
-          args, vars)
-      h.dispose_when_done(pm)
-      h.long_test(30_000_000_000)
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        h.fail("StartProcess should have returned an error")
+        pm.dispose()
+      | let err: ProcessError =>
+        h.assert_true(err.error_type is CapError)
+      end
     else
       h.fail("Could not create FilePath!")
     end
 
-class \nodoc\ iso _TestNonExecutablePathResultsInExecveError is UnitTest
+class \nodoc\ iso _TestExecutableNotFound is UnitTest
   fun name(): String =>
-    "process/_TestNonExecutablePathResultsInExecveError"
+    "process/ExecutableNotFound"
 
   fun exclusion_group(): String =>
     "process-monitor"
@@ -167,38 +150,20 @@ class \nodoc\ iso _TestNonExecutablePathResultsInExecveError is UnitTest
       let path = FilePath.mkdtemp(file_auth, "pony_execve_test")?
       let args: Array[String] val = []
       let vars: Array[String] val = []
+      let notifier = _NoStartNotify(h)
 
-      let notifier = _setup_notifier(h, path)
-      let pm: ProcessMonitor = ProcessMonitor(process_auth, backpressure_auth,
-        consume notifier, path, args, vars)
-      h.dispose_when_done(pm)
-      h.long_test(30_000_000_000)
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        h.fail("StartProcess should have returned an error")
+        pm.dispose()
+      | let err: ProcessError =>
+        h.assert_true(err.error_type is ExecutableNotFound)
+      end
+      path.remove()
     else
       h.fail("Could not create temporary FilePath!")
     end
-
-  fun _setup_notifier(h: TestHelper, path: FilePath): ProcessNotify iso^ =>
-    recover object is ProcessNotify
-      let _h: TestHelper = h
-      let _path: FilePath = path
-
-      fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
-        if err.error_type is ExecveError then
-          _h.complete(true)
-        else
-          _h.fail("Unexpected process error " + err.string())
-          _h.complete(false)
-        end
-        _cleanup()
-
-      fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
-        _h.fail("Dispose shouldn't have been called.")
-        _h.complete(false)
-        _cleanup()
-
-      fun _cleanup() =>
-        _path.remove()
-    end end
 
 class \nodoc\ iso _TestStdinStdout is UnitTest
   fun name(): String =>
@@ -221,27 +186,311 @@ class \nodoc\ iso _TestStdinStdout is UnitTest
       let args: Array[String] val = _CatCommand.args()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let pm: ProcessMonitor =
-        ProcessMonitor(process_auth, backpressure_auth, consume notifier, path,
-          args, vars)
-      pm.write(input)
-      pm.done_writing()  // closing stdin allows "cat" to terminate
-      h.dispose_when_done(pm)
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.write(input)
+        pm.done_writing() // closing stdin allows "cat" to terminate
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+      end
       h.long_test(30_000_000_000)
     else
       h.fail("Could not create FilePath!")
     end
 
+class \nodoc\ iso _TestLongRunningChild is UnitTest
+  fun name(): String => "process/long-running-child"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    let notifier =
+      object iso is ProcessNotify
+        fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+          h.fail(err.string())
+
+        fun ref dispose(process: ProcessMonitor ref,
+          child_exit_status: ProcessExitStatus)
+        =>
+          match child_exit_status
+          | Exited(0) => h.complete(true)
+          else
+            h.fail("process exited with " + child_exit_status.string())
+          end
+      end
+
+    let process_auth = StartProcessAuth(h.env.root)
+    let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+    let file_auth = FileAuth(h.env.root)
+
+    let path = FilePath(file_auth, _SleepPath())
+    let args = _SleepArgs(2)
+    let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+    match StartProcess(process_auth, backpressure_auth, consume notifier,
+      path, args, vars)
+    | let pm: ProcessMonitor =>
+      pm.done_writing()
+      h.dispose_when_done(pm)
+    | let err: ProcessError =>
+      h.fail("StartProcess failed: " + err.string())
+    end
+    h.long_test(10_000_000_000)
+
+class \nodoc\ iso _TestKillLongRunningChild is UnitTest
+  fun name(): String => "process/kill-long-running-child"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    let notifier =
+      object iso is ProcessNotify
+        fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+          h.fail(err.string())
+
+        fun ref dispose(process: ProcessMonitor ref,
+          child_exit_status: ProcessExitStatus)
+        =>
+          match child_exit_status
+          | Signaled(Sig.term()) =>
+            ifdef posix then h.complete(true)
+            else h.fail("should not happen on windows.") end
+          | Exited(0) =>
+            ifdef windows then h.complete(true)
+            else h.fail("should be signaled on posix.") end
+          else
+            h.fail("process exited with " + child_exit_status.string())
+            h.complete(false)
+          end
+      end
+
+    let process_auth = StartProcessAuth(h.env.root)
+    let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+    let file_auth = FileAuth(h.env.root)
+
+    let path = FilePath(file_auth, _SleepPath())
+    let args = _SleepArgs(2)
+    let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+    match StartProcess(process_auth, backpressure_auth, consume notifier,
+      path, args, vars)
+    | let pm: ProcessMonitor =>
+      pm.dispose()
+      pm.done_writing()
+    | let err: ProcessError =>
+      h.fail("StartProcess failed: " + err.string())
+    end
+    h.long_test(10_000_000_000)
+
+class \nodoc\ iso _TestGrandchildDoesNotBlockExit is UnitTest
+  """
+  #5764: the child backgrounds a long-lived grandchild that inherits
+  stdout/stderr, then exits. The pipes stay open for the grandchild's life,
+  but the exit must be reported promptly from the exit event. The timeout is
+  well under the grandchild's life, so a pass proves exit was detected without
+  waiting on the pipes closing.
+  """
+  fun name(): String => "process/grandchild-does-not-block-exit"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      // posix-only shell semantics; covered on posix.
+      h.complete(true)
+    else
+      let notifier =
+        object iso is ProcessNotify
+          fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+            h.fail("failed: " + err.string())
+            h.complete(false)
+
+          fun ref dispose(process: ProcessMonitor ref,
+            child_exit_status: ProcessExitStatus)
+          =>
+            match child_exit_status
+            | Exited(7) => h.complete(true)
+            else
+              h.fail("expected Exited(7), got " + child_exit_status.string())
+              h.complete(false)
+            end
+        end
+
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+      let path = FilePath(file_auth, "/bin/sh")
+      let args: Array[String] val = ["sh"; "-c"; "sleep 30 & exit 7"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.done_writing()
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+        h.complete(false)
+      end
+      // 10s is well under the grandchild's 30s life.
+      h.long_test(10_000_000_000)
+    end
+
+class \nodoc\ iso _TestWindowsGrandchildDoesNotBlockExit is UnitTest
+  """
+  #5764 on Windows. cmd launches a long-lived grandchild (ping) with `start /b`,
+  so ping inherits and holds cmd's stdout pipe, then cmd exits 7. The stdout
+  pipe stays open for ping's life, but the exit must be reported promptly from
+  the process-exit event. The 10s timeout is well under ping's ~30s life, so a
+  pass proves exit was detected from the OS, not from the stdout pipe closing.
+  """
+  fun name(): String => "process/windows-grandchild-does-not-block-exit"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      let notifier =
+        object iso is ProcessNotify
+          fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+            h.fail("failed: " + err.string())
+            h.complete(false)
+
+          fun ref dispose(process: ProcessMonitor ref,
+            child_exit_status: ProcessExitStatus)
+          =>
+            match child_exit_status
+            | Exited(7) => h.complete(true)
+            else
+              h.fail("expected Exited(7), got " + child_exit_status.string())
+              h.complete(false)
+            end
+        end
+
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+      let path = FilePath(file_auth, "C:\\Windows\\System32\\cmd.exe")
+      // `start /b` runs ping without a new console, so it inherits cmd's stdout
+      // pipe and keeps it open; cmd then exits 7. A populated environment is
+      // required: cmd's `start /b` hangs when the environment block is empty.
+      let args: Array[String] val =
+        ["cmd"; "/c"; "start /b ping -n 30 127.0.0.1 & exit 7"]
+      let vars: Array[String] val =
+        ["SystemRoot=C:\\Windows"; "PATH=C:\\Windows\\System32"]
+
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.done_writing()
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+        h.complete(false)
+      end
+      h.long_test(10_000_000_000)
+    else
+      // Windows-only; on posix there is nothing to run here.
+      h.complete(true)
+    end
+
+class \nodoc\ iso _TestWindowsEmptyEnvironment is UnitTest
+  """
+  A child starts with an empty environment. The Windows environment block for
+  no variables is two null bytes; CreateProcess rejects a lone null.
+  """
+  fun name(): String => "process/windows-empty-environment"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      let notifier =
+        object iso is ProcessNotify
+          fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+            h.fail("failed: " + err.string())
+            h.complete(false)
+
+          fun ref dispose(process: ProcessMonitor ref,
+            child_exit_status: ProcessExitStatus)
+          =>
+            match child_exit_status
+            | Exited(0) => h.complete(true)
+            else
+              h.fail("expected Exited(0), got " + child_exit_status.string())
+              h.complete(false)
+            end
+        end
+
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+      let path = FilePath(file_auth, "C:\\Windows\\System32\\cmd.exe")
+      let args: Array[String] val = ["cmd"; "/c"; "exit 0"]
+      let vars: Array[String] val = []
+
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.done_writing()
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+        h.complete(false)
+      end
+      h.long_test(10_000_000_000)
+    else
+      // Windows-only: the empty environment block is a Windows CreateProcess
+      // concern.
+      h.complete(true)
+    end
+
+class \nodoc\ iso _TestStdinOpenChildExits is UnitTest
+  """
+  #5748: the child exits on its own while we still hold its stdin open (we
+  never call done_writing). The exit must still be reported. This also
+  exercises the fast-exit probe: the child exits before, or racing with, the
+  exit event being armed.
+  """
+  fun name(): String => "process/stdin-open-child-exits"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.complete(true)
+    else
+      let notifier =
+        object iso is ProcessNotify
+          fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+            h.fail("failed: " + err.string())
+            h.complete(false)
+
+          fun ref dispose(process: ProcessMonitor ref,
+            child_exit_status: ProcessExitStatus)
+          =>
+            match child_exit_status
+            | Exited(7) => h.complete(true)
+            else
+              h.fail("expected Exited(7), got " + child_exit_status.string())
+              h.complete(false)
+            end
+        end
+
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+      let path = FilePath(file_auth, "/bin/sh")
+      let args: Array[String] val = ["sh"; "-c"; "exit 7"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        // Deliberately do NOT call done_writing(): stdin stays open.
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+        h.complete(false)
+      end
+      h.long_test(10_000_000_000)
+    end
+
 class \nodoc\ iso _TestStderr is UnitTest
-  var _pm: (ProcessMonitor | None) = None
+  fun name(): String => "process/STDERR"
+  fun exclusion_group(): String => "process-monitor"
 
-  fun name(): String =>
-    "process/STDERR"
-
-  fun exclusion_group(): String =>
-    "process-monitor"
-
-  fun ref apply(h: TestHelper) =>
+  fun apply(h: TestHelper) =>
     let errmsg =
       ifdef windows then
         "message-to-stderr\r\n"
@@ -270,12 +519,13 @@ class \nodoc\ iso _TestStderr is UnitTest
       end
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      _pm  = ProcessMonitor(process_auth, backpressure_auth, consume notifier,
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
         path, args, vars)
-      if _pm isnt None then // write to STDIN of the child process
-        let pm = _pm as ProcessMonitor
-        pm.done_writing() // closing stdin
+      | let pm: ProcessMonitor =>
+        pm.done_writing()
         h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
       end
       h.long_test(30_000_000_000)
     else
@@ -283,11 +533,8 @@ class \nodoc\ iso _TestStderr is UnitTest
     end
 
 class \nodoc\ iso _TestExpect is UnitTest
-  fun name(): String =>
-    "process/Expect"
-
-  fun exclusion_group(): String =>
-    "process-monitor"
+  fun name(): String => "process/Expect"
+  fun exclusion_group(): String => "process-monitor"
 
   fun apply(h: TestHelper) =>
     let notifier =
@@ -308,7 +555,9 @@ class \nodoc\ iso _TestExpect is UnitTest
           process.expect(if _expect == 2 then 4 else 2 end)
           _out.push(String.from_array(consume data))
 
-        fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
+        fun ref dispose(process: ProcessMonitor ref,
+          child_exit_status: ProcessExitStatus)
+        =>
           match child_exit_status
           | Exited(0) =>
             let expected: Array[String] val = ifdef windows then
@@ -322,8 +571,7 @@ class \nodoc\ iso _TestExpect is UnitTest
             _h.fail("child exited with: " + child_exit_status.string())
             _h.complete(false)
           end
-      end
-    end
+      end end
 
     try
       let process_auth = StartProcessAuth(h.env.root)
@@ -339,21 +587,22 @@ class \nodoc\ iso _TestExpect is UnitTest
       end
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let pm: ProcessMonitor = ProcessMonitor(process_auth, backpressure_auth,
-        consume notifier, path, args, vars)
-      pm.done_writing()  // closing stdin allows "echo" to terminate
-      h.dispose_when_done(pm)
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.done_writing()
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+      end
       h.long_test(30_000_000_000)
     else
       h.fail("Could not create FilePath!")
     end
 
 class \nodoc\ iso _TestWritevOrdering is UnitTest
-  fun name(): String =>
-    "process/WritevOrdering"
-
-  fun exclusion_group(): String =>
-    "process-monitor"
+  fun name(): String => "process/WritevOrdering"
+  fun exclusion_group(): String => "process-monitor"
 
   fun apply(h: TestHelper) =>
     let expected: USize = ifdef windows then 13 else 11 end
@@ -368,24 +617,23 @@ class \nodoc\ iso _TestWritevOrdering is UnitTest
       let args: Array[String] val = _CatCommand.args()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let pm: ProcessMonitor = ProcessMonitor(process_auth, backpressure_auth,
-        consume notifier, path, args, vars)
-      let params: Array[String] val = ["one"; "two"; "three"]
-
-      pm.writev(params)
-      pm.done_writing()  // closing stdin allows "cat" to terminate
-      h.dispose_when_done(pm)
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.writev(["one"; "two"; "three"])
+        pm.done_writing()
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+      end
       h.long_test(30_000_000_000)
     else
       h.fail("Could not create FilePath!")
     end
 
 class \nodoc\ iso _TestPrintvOrdering is UnitTest
-  fun name(): String =>
-    "process/PrintvOrdering"
-
-  fun exclusion_group(): String =>
-    "process-monitor"
+  fun name(): String => "process/PrintvOrdering"
+  fun exclusion_group(): String => "process-monitor"
 
   fun apply(h: TestHelper) =>
     let expected: USize = ifdef windows then 17 else 14 end
@@ -400,37 +648,164 @@ class \nodoc\ iso _TestPrintvOrdering is UnitTest
       let args: Array[String] val = _CatCommand.args()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let pm: ProcessMonitor = ProcessMonitor(process_auth, backpressure_auth,
-        consume notifier, path, args, vars)
-      let params: Array[String] val = ["one"; "two"; "three"]
-
-      pm.printv(params)
-      pm.done_writing()  // closing stdin allows "cat" to terminate
-      h.dispose_when_done(pm)
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.printv(["one"; "two"; "three"])
+        pm.done_writing()
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+      end
       h.long_test(30_000_000_000)
     else
       h.fail("Could not create FilePath!")
+    end
+
+class \nodoc\ _TestChdir is UnitTest
+  fun name(): String => "process/Chdir"
+  fun exclusion_group(): String => "process-monitor"
+
+  fun ref apply(h: TestHelper) =>
+    let process_auth = StartProcessAuth(h.env.root)
+    let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+    let file_auth = FileAuth(h.env.root)
+
+    let parent = Path.dir(Path.cwd())
+    let notifier: ProcessNotify iso = _ProcessClient(parent.size()
+      + (ifdef windows then 2 else 1 end), "", 0, h)
+
+    let path = FilePath(file_auth, _PwdPath())
+    let args: Array[String] val = _PwdArgs()
+    let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+    match StartProcess(process_auth, backpressure_auth, consume notifier,
+      path, args, vars, FilePath(file_auth, parent))
+    | let pm: ProcessMonitor =>
+      pm.done_writing()
+      h.dispose_when_done(pm)
+    | let err: ProcessError =>
+      h.fail("StartProcess failed: " + err.string())
+    end
+    h.long_test(30_000_000_000)
+
+class \nodoc\ _TestBadChdir is UnitTest
+  fun name(): String => "process/BadChdir"
+  fun exclusion_group(): String => "process-monitor"
+
+  fun ref apply(h: TestHelper) =>
+    let badpath = Path.abs(Path.random(10))
+    let process_auth = StartProcessAuth(h.env.root)
+    let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+    let file_auth = FileAuth(h.env.root)
+    let path = FilePath(file_auth, _PwdPath())
+    let args: Array[String] val = _PwdArgs()
+    let vars: Array[String] val = []
+    let bad_wdir = FilePath(file_auth, badpath)
+
+    ifdef windows then
+      // Windows CreateProcess fails synchronously for a bad working directory,
+      // so StartProcess returns the error rather than reporting it through the
+      // notifier; there is no fork/exec split to defer it to.
+      let notifier = _NoStartNotify(h)
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars, bad_wdir)
+      | let pm: ProcessMonitor =>
+        h.fail("StartProcess should have returned an error")
+        pm.dispose()
+      | let err: ProcessError =>
+        h.assert_true(err.error_type is ChdirError)
+      end
+    else
+      let notifier: ProcessNotify iso = _FailAndExitClient(h, ChdirError)
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars, bad_wdir)
+      | let pm: ProcessMonitor =>
+        pm.done_writing()
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+      end
+      h.long_test(30_000_000_000)
+    end
+
+class \nodoc\ _TestBadExec is UnitTest
+  let _bad_exec_sh_contents: String =
+    """
+    #!/usr/bin/please-dont-exist
+
+    true
+    """
+  var _tmp_dir: (FilePath | None) = None
+  var _bad_exec_path: (FilePath | None) = None
+
+  fun name(): String => "process/BadExec"
+  fun exclusion_group(): String => "process-monitor"
+
+  fun ref set_up(h: TestHelper) ? =>
+    let file_auth = FileAuth(h.env.root)
+    ifdef windows then
+      _bad_exec_path = FilePath(file_auth, "C:\\Windows\\system.ini")
+    else
+      let tmp_dir = FilePath.mkdtemp(file_auth,
+        "pony_stdlib_test_process_bad_exec")?
+      _tmp_dir = tmp_dir
+      let bad_exec_path = tmp_dir.join("_bad_exec.sh")?
+      _bad_exec_path = bad_exec_path
+      let file = File(bad_exec_path)
+      file.write(_bad_exec_sh_contents)
+      if not file.chmod(FileMode .> exec()) then error end
+    end
+
+  fun ref tear_down(h: TestHelper) =>
+    try (_tmp_dir as FilePath).remove() end
+
+  fun ref apply(h: TestHelper) =>
+    try
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let path = _bad_exec_path as FilePath
+
+      ifdef windows then
+        // Windows CreateProcess fails synchronously on a non-executable file,
+        // so StartProcess returns the error rather than reporting it through the
+        // notifier.
+        let notifier = _NoStartNotify(h)
+        match StartProcess(process_auth, backpressure_auth, consume notifier,
+          path, [], [])
+        | let pm: ProcessMonitor =>
+          h.fail("StartProcess should have returned an error")
+          pm.dispose()
+        | let err: ProcessError =>
+          h.assert_true(err.error_type is ExecveError)
+        end
+      else
+        let notifier: ProcessNotify iso = _FailAndExitClient(h, ExecveError)
+        match StartProcess(process_auth, backpressure_auth, consume notifier,
+          path, [], [])
+        | let pm: ProcessMonitor =>
+          pm.done_writing()
+          h.dispose_when_done(pm)
+        | let err: ProcessError =>
+          h.fail("StartProcess failed: " + err.string())
+        end
+        h.long_test(30_000_000_000)
+      end
+    else
+      h.fail("bad_exec_path not set!")
     end
 
 class \nodoc\ iso _TestStdinWriteBuf is UnitTest
   var _pm: (ProcessMonitor | None) = None
   let _test_start: U64 = Time.nanos()
 
-  fun name(): String =>
-    "process/STDIN-WriteBuf"
-
-  fun exclusion_group(): String =>
-    "process-monitor"
+  fun name(): String => "process/STDIN-WriteBuf"
+  fun exclusion_group(): String => "process-monitor"
 
   fun ref apply(h: TestHelper) =>
     let pipe_cap: USize = 65536
-
-    // create a message larger than pipe_cap bytes
     let message: Array[U8] val = recover Array[U8].init('\n', pipe_cap + 1) end
-
-    // Windows stdin will turn "\n" into "\r\n"
     let out_size = ifdef windows then message.size() * 2 else message.size() end
-
     let notifier: ProcessNotify iso = _ProcessClient(out_size, "", 0, h)
     try
       let process_auth = StartProcessAuth(h.env.root)
@@ -442,15 +817,15 @@ class \nodoc\ iso _TestStdinWriteBuf is UnitTest
       let args: Array[String] val = _CatCommand.args()
       let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      // fork the child process and attach a ProcessMonitor
-      _pm = ProcessMonitor(process_auth, backpressure_auth, consume notifier,
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
         path, args, vars)
-
-      if _pm isnt None then // write to STDIN of the child process
-        let pm = _pm as ProcessMonitor
+      | let pm: ProcessMonitor =>
+        _pm = pm
         pm.write(message)
-        pm.done_writing() // closing stdin allows "cat" to terminate
+        pm.done_writing()
         h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
       end
       h.long_test(30_000_000_000)
     else
@@ -459,324 +834,149 @@ class \nodoc\ iso _TestStdinWriteBuf is UnitTest
 
   fun timed_out(h: TestHelper) =>
     h.log("_TestStdinWriteBuf.timed_out: ran for " +
-     (Time.nanos() - _test_start).string() + " ns")
-    try
-      if _pm isnt None then // kill the child process and cleanup fd
-        h.log("_TestStdinWriteBuf.timed_out: calling pm.dispose()")
-        (_pm as ProcessMonitor).dispose()
-      end
-    else
-      h.fail("Error disposing of forked process in STDIN-WriteBuf test")
-    end
+      (Time.nanos() - _test_start).string() + " ns")
+    try (_pm as ProcessMonitor).dispose() end
 
-class \nodoc\ _TestChdir is UnitTest
-  fun name(): String =>
-    "process/Chdir"
+class \nodoc\ _TestWaitingOnClosedProcessTwice is UnitTest
+  """
+  #5765 regression, real process: dispose() twice must report the exit status
+  exactly once. We start a short-lived process, let it finish, then send two
+  dispose() messages and verify the notifier's dispose fires only once.
+  """
+  var _timers: (Timers | None) = None
 
-  fun exclusion_group(): String =>
-    "process-monitor"
-
-  fun ref apply(h: TestHelper) =>
-    let process_auth = StartProcessAuth(h.env.root)
-    let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
-    let file_auth = FileAuth(h.env.root)
-
-    let parent = Path.dir(Path.cwd())
-    // expect path length + \n
-    let notifier: ProcessNotify iso = _ProcessClient(parent.size()
-      + (ifdef windows then 2 else 1 end), "", 0, h)
-
-    let path = FilePath(file_auth, _PwdPath())
-    let args: Array[String] val = _PwdArgs()
-    let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
-
-    let pm: ProcessMonitor = ProcessMonitor(process_auth, backpressure_auth,
-      consume notifier, path, args, vars, FilePath(file_auth, parent))
-    pm.done_writing()
-    h.dispose_when_done(pm)
-    h.long_test(30_000_000_000)
-
-class \nodoc\ _TestBadChdir is UnitTest
-  fun name(): String =>
-    "process/BadChdir"
-
-  fun exclusion_group(): String =>
-    "process-monitor"
-
-  fun ref apply(h: TestHelper) =>
-    let badpath = Path.abs(Path.random(10))
-    let notifier: ProcessNotify iso =
-      _ProcessClient(0, "", _EXOSERR(), h, ProcessError(ChdirError))
-
-    let process_auth = StartProcessAuth(h.env.root)
-    let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
-    let file_auth = FileAuth(h.env.root)
-
-    let path = FilePath(file_auth, _PwdPath())
-    let args: Array[String] val = _PwdArgs()
-    let vars: Array[String] iso = recover Array[String](0) end
-
-    let pm: ProcessMonitor = ProcessMonitor(process_auth, backpressure_auth,
-      consume notifier, path, args, consume vars, FilePath(file_auth, badpath))
-    pm.done_writing()
-    h.dispose_when_done(pm)
-    h.long_test(30_000_000_000)
-
-class \nodoc\ _TestBadExec is UnitTest
-
-  let _bad_exec_sh_contents: String =
-    """
-    #!/usr/bin/please-dont-exist
-
-    true
-    """
-  var _tmp_dir: ( FilePath | None ) = None
-  var _bad_exec_path: ( FilePath | None ) = None
-
-  fun name(): String =>
-    "process/BadExec"
-
-  fun exclusion_group(): String =>
-    "process-monitor"
-
-
-  fun ref set_up(h: TestHelper) ? =>
-    let file_auth = FileAuth(h.env.root)
-
-    ifdef windows then
-      _bad_exec_path = FilePath(file_auth, "C:\\Windows\\system.ini")
-    else
-      let tmp_dir = FilePath.mkdtemp(file_auth,
-        "pony_stdlib_test_process_bad_exec")?
-      _tmp_dir = tmp_dir
-      let bad_exec_path = tmp_dir.join("_bad_exec.sh")?
-      _bad_exec_path = bad_exec_path
-
-      // create file with non-existing shebang in temporary directory
-      let file = File(bad_exec_path)
-      file.write(_bad_exec_sh_contents)
-      if not file.chmod(FileMode.>exec()) then error end
-    end
-
-  fun ref tear_down(h: TestHelper) =>
-    try
-      (_tmp_dir as FilePath).remove()
-    end
-
-  fun ref apply(h: TestHelper) =>
-    let notifier: ProcessNotify iso =
-      _ProcessClient(0, "", _EXOSERR(), h, ProcessError(ExecveError))
-    try
-      let process_auth = StartProcessAuth(h.env.root)
-      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
-
-      let path = _bad_exec_path as FilePath
-      let pm: ProcessMonitor =
-        ProcessMonitor(process_auth, backpressure_auth, consume notifier, path,
-          [], [])
-      pm.done_writing()
-      h.dispose_when_done(pm)
-      h.long_test(30_000_000_000)
-    else
-      h.fail("bad_exec_path not set!")
-    end
-
-class \nodoc\ iso _TestLongRunningChild is UnitTest
-  fun name(): String => "process/long-running-child"
-  fun exclusion_group(): String => "process-monitor"
-  fun apply(h: TestHelper) =>
-    let notifier =
-      object iso is ProcessNotify
-        fun ref created(process: ProcessMonitor ref) =>
-          h.log("created")
-
-        fun ref stdout(process: ProcessMonitor ref, data: Array[U8] iso) =>
-          h.log("[STDOUT] " + recover val String.from_iso_array(consume data) end)
-        fun ref stderr(process: ProcessMonitor ref, data: Array[U8] iso) =>
-          h.log("[STDERR] " + recover val String.from_iso_array(consume data) end)
-
-        fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
-          h.log(err.string())
-          h.fail("process failed.")
-
-        fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
-          match child_exit_status
-          | Exited(0) => h.complete(true)
-          else
-            h.fail("process exited with " + child_exit_status.string())
-          end
-      end
-
-    try
-      let process_auth = StartProcessAuth(h.env.root)
-      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
-      let file_auth = FileAuth(h.env.root)
-
-      let path_resolver = _PathResolver(h.env.vars, file_auth)
-      let path = FilePath(file_auth, _SleepCommand.path(path_resolver)?)
-      h.log(path.path)
-      let args = _SleepCommand.args(where seconds = 2)
-      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
-
-      let pm = ProcessMonitor(process_auth, backpressure_auth,
-        consume notifier, path, args, vars)
-      pm.done_writing()
-      h.dispose_when_done(pm)
-      h.long_test(10_000_000_000)
-    else
-      h.fail("failed to set up calling sleep/timeout.")
-    end
-
-class \nodoc\ iso _TestKillLongRunningChild is UnitTest
-  fun name(): String => "process/kill-long-running-child"
-  fun exclusion_group(): String => "process-monitor"
-  fun apply(h: TestHelper) =>
-    let notifier =
-      object iso is ProcessNotify
-        fun ref created(process: ProcessMonitor ref) =>
-          h.log("created")
-
-        fun ref stdout(process: ProcessMonitor ref, data: Array[U8] iso) =>
-          h.log("[STDOUT] " + recover val String.from_iso_array(consume data) end)
-        fun ref stderr(process: ProcessMonitor ref, data: Array[U8] iso) =>
-          h.log("[STDERR] " + recover val String.from_iso_array(consume data) end)
-
-        fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
-          h.log(err.string())
-          h.fail("process failed.")
-
-        fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
-          match child_exit_status
-          | Signaled(Sig.term()) =>
-            ifdef posix then
-              h.complete(true)
-            elseif windows then
-              h.fail("should not happen on windows.")
-            end
-          | Exited(0) =>
-            ifdef windows then
-              h.complete(true)
-            else
-              h.fail("should be signaled on posix.")
-            end
-          else
-            h.fail("process exited with " + child_exit_status.string())
-            h.complete(false)
-          end
-      end
-
-    try
-      let process_auth = StartProcessAuth(h.env.root)
-      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
-      let file_auth = FileAuth(h.env.root)
-
-      let path_resolver = _PathResolver(h.env.vars, file_auth)
-      let path = FilePath(file_auth, _SleepCommand.path(path_resolver)?)
-      h.log(path.path)
-      let args = _SleepCommand.args(where seconds = 2)
-      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
-
-      let pm = ProcessMonitor(process_auth, backpressure_auth,
-        consume notifier, path, args, vars)
-      pm.dispose()
-      pm.done_writing()
-      h.long_test(10_000_000_000)
-    else
-      h.fail("failed to set up calling sleep/timeout.")
-    end
-
-class \nodoc\ iso _TestWaitingOnClosedProcessTwice is UnitTest
   fun name(): String => "process/wait-on-closed-process-twice"
   fun exclusion_group(): String => "process-monitor"
-  fun apply(h: TestHelper) =>
-    try
-      let process_auth = StartProcessAuth(h.env.root)
-      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
-      let file_auth = FileAuth(h.env.root)
 
-      let path_resolver = _PathResolver(h.env.vars, file_auth)
-      let path = FilePath(file_auth, _SleepCommand.path(path_resolver)?)
-      h.log(path.path)
-      let args = _SleepCommand.args(where seconds = 1)
-      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+  fun ref tear_down(h: TestHelper) =>
+    try (_timers as Timers).dispose() end
 
-      // we want to make sure that ProcessMonitor is not checking the exit
-      // status of a process after it has already exited
-      // since it calls dispose() on its notifier after it has checked the
-      // exit status, we test whether or not we get more than 1 dispose()
+  fun ref apply(h: TestHelper) =>
+    let process_auth = StartProcessAuth(h.env.root)
+    let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+    let file_auth = FileAuth(h.env.root)
 
-      // we start a process that should take less than 5 seconds
-      // after 5 seconds we send 2 dispose() messages to it
-      // when we are notified of the first dispose() message, we check the exit
-      // status to make sure we've exited successfully, then we start a second
-      // timer that will check if we were notified of the 2nd dispose();
-      // we shouldn't have been
+    let path = FilePath(file_auth, _SleepPath())
+    let args = _SleepArgs(1)
+    let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
 
-      let timers = Timers
+    let timers = Timers
+    _timers = timers
 
-      let pn = object iso is ProcessNotify
-        var n: USize = 0
-        fun ref dispose(pm: ProcessMonitor ref, status: ProcessExitStatus) =>
-          n = n + 1
-          h.log("dispose() called " + n.string() + " time")
-          match status
-          | Exited(0) =>
-            h.log("child exited")
-          else
-            h.fail("child did not exit")
-            h.complete(false)
-            return
-          end
+    let pn = object iso is ProcessNotify
+      var n: USize = 0
+      fun ref dispose(pm: ProcessMonitor ref, status: ProcessExitStatus) =>
+        n = n + 1
+        h.log("dispose() called " + n.string() + " time")
+        match status
+        | Exited(0) => h.log("child exited")
+        else
+          h.fail("child did not exit cleanly")
+          h.complete(false)
+          return
+        end
 
-          if n == 1 then
-            let timer2 = Timer(
-              object iso is TimerNotify
-                fun ref apply(timer: Timer, count: U64): Bool =>
-                  h.log("timer2 called; n == " + n.string())
-                  if n == 1 then
-                    h.complete(true)
-                  else
-                    h.fail("notifier received dispose() more than once")
-                    h.complete(false)
-                  end
-                  true
-              end,
-              500_000_000, 0
-            )
-            timers(consume timer2)
-          end
-      end
-      let pm = ProcessMonitor(process_auth, backpressure_auth, consume pn, path,
-        args, vars)
+        if n == 1 then
+          let timer2 = Timer(
+            object iso is TimerNotify
+              fun ref apply(timer: Timer, count: U64): Bool =>
+                if n == 1 then
+                  h.complete(true)
+                else
+                  h.fail("notifier received dispose() more than once")
+                  h.complete(false)
+                end
+                true
+            end,
+            500_000_000, 0)
+          timers(consume timer2)
+        end
+    end
 
+    match StartProcess(process_auth, backpressure_auth, consume pn, path, args,
+      vars)
+    | let pm: ProcessMonitor =>
       let timer1 = Timer(
         object iso is TimerNotify
           fun ref apply(timer: Timer, count: U64): Bool =>
-            h.log("timer1 calling pm.dispose() twice")
             pm.dispose()
             pm.dispose()
             true
         end,
-        5_000_000_000, 0)
+        3_000_000_000, 0)
       timers(consume timer1)
+    | let err: ProcessError =>
+      h.fail("StartProcess failed: " + err.string())
+    end
+    h.long_test(10_000_000_000)
 
-      h.long_test(10_000_000_000)
+primitive \nodoc\ _EchoPath
+  fun apply(path_resolver: _PathResolver): String ? =>
+    ifdef windows then
+      "C:\\Windows\\System32\\cmd.exe"
     else
-      h.fail("process monitor threw an error")
+      path_resolver.resolve("echo")?.path
     end
 
+primitive \nodoc\ _PwdPath
+  fun apply(): String =>
+    ifdef windows then
+      "C:\\Windows\\System32\\cmd.exe"
+    else
+      "/bin/pwd"
+    end
+
+primitive \nodoc\ _PwdArgs
+  fun apply(): Array[String] val =>
+    ifdef windows then
+      ["cmd"; "/c"; "cd"]
+    else
+      ["pwd"]
+    end
+
+primitive \nodoc\ _SleepPath
+  fun apply(): String =>
+    ifdef windows then
+      "C:\\Windows\\System32\\ping.exe"
+    else
+      "/bin/sleep"
+    end
+
+primitive \nodoc\ _SleepArgs
+  fun apply(seconds: USize): Array[String] val =>
+    ifdef windows then
+      ["ping"; "127.0.0.1"; "-n"; seconds.string()]
+    else
+      ["sleep"; seconds.string()]
+    end
+
+class \nodoc\ _NoStartNotify is ProcessNotify
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref stdout(process: ProcessMonitor ref, data: Array[U8] iso) =>
+    _h.fail("stdout shouldn't be called")
+
+  fun ref stderr(process: ProcessMonitor ref, data: Array[U8] iso) =>
+    _h.fail("stderr shouldn't be called")
+
+  fun ref failed(process: ProcessMonitor ref, actual: ProcessError) =>
+    _h.fail("failed shouldn't be called")
+
+  fun ref dispose(process: ProcessMonitor ref,
+    child_exit_status: ProcessExitStatus)
+  =>
+    _h.fail("dispose shouldn't be called")
+
 class \nodoc\ _ProcessClient is ProcessNotify
-  """
-  Notifications for Process connections.
-  """
   let _out: USize
   let _err: String
   let _exit_code: I32
   let _h: TestHelper
   var _d_stdout_chars: USize = 0
   let _d_stderr: String ref = String
-  let _created: U64
-  var _first_data: U64 = 0
   let _expected_err: (ProcessError | None)
 
   new iso create(
@@ -791,36 +991,16 @@ class \nodoc\ _ProcessClient is ProcessNotify
     _exit_code = exit_code
     _expected_err = expected_err
     _h = h
-    _created = Time.nanos()
 
   fun ref stdout(process: ProcessMonitor ref, data: Array[U8] iso) =>
-    """
-    Called when new data is received on STDOUT of the forked process
-    """
     _h.log("\tReceived from stdout: " + data.size().string() + " bytes")
-    if (_first_data == 0) then
-      _first_data = Time.nanos()
-    end
     _d_stdout_chars = _d_stdout_chars + data.size()
-    _h.log("\tReceived so far: " + _d_stdout_chars.string() + " bytes")
-    _h.log("\tExpecting: " + _out.string() + " bytes")
-    if _out == _d_stdout_chars then
-      // we've received our total data
-      _h.complete(true)
-    end
 
   fun ref stderr(process: ProcessMonitor ref, data: Array[U8] iso) =>
-    """
-    Called when new data is received on STDERR of the forked process
-    """
     _h.log("\tReceived from stderr: " + data.size().string() + " bytes")
     _d_stderr.append(consume data)
 
   fun ref failed(process: ProcessMonitor ref, actual: ProcessError) =>
-    """
-    ProcessMonitor calls this if we run into errors with the
-    forked process.
-    """
     match _expected_err
     | let expected: ProcessError =>
       if actual.error_type is expected.error_type then
@@ -833,12 +1013,9 @@ class \nodoc\ _ProcessClient is ProcessNotify
       _h.fail(actual.string())
     end
 
-  fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
-    """
-    Called when ProcessMonitor terminates to cleanup ProcessNotify
-    We receive the exit code of the child process from ProcessMonitor.
-    """
-    let last_data: U64 = Time.nanos()
+  fun ref dispose(process: ProcessMonitor ref,
+    child_exit_status: ProcessExitStatus)
+  =>
     match \exhaustive\ child_exit_status
     | let e: Exited =>
       _h.log("dispose: child exit code: " + e.exit_code().string())
@@ -847,18 +1024,734 @@ class \nodoc\ _ProcessClient is ProcessNotify
       _h.log("dispose: child terminated by signal: " + s.signal().string())
       _h.fail("didn't expect that.")
     end
-    _h.log("dispose: stdout: " + _d_stdout_chars.string() + " bytes")
-    _h.log("dispose: stderr: '" + _d_stderr + "'")
-    if (_first_data > 0) then
-      _h.log("dispose: received first data after: \t"
-        + (_first_data - _created).string() + " ns")
-    end
-    _h.log("dispose: total data process_time: \t"
-      + (last_data - _first_data).string() + " ns")
-    _h.log("dispose: ProcessNotify lifetime: \t"
-      + (last_data - _created).string() + " ns")
-
     _h.assert_eq[USize](_out, _d_stdout_chars)
     _h.assert_eq[USize](_err.size(), _d_stderr.size())
     _h.assert_eq[String box](_err, _d_stderr)
     _h.complete(true)
+
+// --------------------------------------------------------------------------
+// The redesign's motivating cases, continued
+// --------------------------------------------------------------------------
+
+class \nodoc\ iso _TestGrandchildDeliversBufferedOutput is UnitTest
+  """
+  The child writes output, then backgrounds a long-lived grandchild that
+  inherits stdout, then exits. The child's own output must be delivered before
+  `dispose`, and `dispose` must arrive promptly (well under the grandchild's
+  life), not wait for the grandchild.
+  """
+  fun name(): String => "process/grandchild-delivers-buffered-output"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.complete(true)
+    else
+      let notifier: ProcessNotify iso = _ProcessClient(6, "", 0, h)
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+      let path = FilePath(file_auth, "/bin/sh")
+      let args: Array[String] val =
+        ["sh"; "-c"; "echo hello; sleep 30 & exit 0"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.done_writing()
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+      end
+      h.long_test(10_000_000_000)
+    end
+
+class \nodoc\ iso _TestChildClosesOutputKeepsRunning is UnitTest
+  """
+  The child closes its own stdout and stderr, then keeps running and exits on
+  its own while we still hold its stdin open. Closing output must not tear the
+  monitor down; the exit is reported from the exit event when the child
+  actually exits.
+  """
+  fun name(): String => "process/child-closes-output-keeps-running"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.complete(true)
+    else
+      let notifier =
+        object iso is ProcessNotify
+          fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+            h.fail("failed: " + err.string())
+            h.complete(false)
+
+          fun ref dispose(process: ProcessMonitor ref,
+            status: ProcessExitStatus)
+          =>
+            match status
+            | Exited(5) => h.complete(true)
+            else
+              h.fail("expected Exited(5), got " + status.string())
+              h.complete(false)
+            end
+        end
+
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+      let path = FilePath(file_auth, "/bin/sh")
+      // close stdout+stderr, sleep, exit 5 — all while we hold stdin open.
+      let args: Array[String] val =
+        ["sh"; "-c"; "exec 1>&- 2>&-; sleep 1; exit 5"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        // Deliberately do not call done_writing(): stdin stays open.
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+        h.complete(false)
+      end
+      h.long_test(10_000_000_000)
+    end
+
+class \nodoc\ iso _TestBackpressureAppliedThenReleased is UnitTest
+  """
+  A child that ignores its stdin, written more than a pipe buffer, makes the
+  monitor queue the overflow and apply backpressure. Disposing must release it.
+  The test asserts backpressure was applied first, so a never-applies
+  implementation cannot pass.
+  """
+  fun name(): String => "process/backpressure-applied-then-released"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.complete(true)
+    else
+      let notifier =
+        object iso is ProcessNotify
+          fun ref dispose(process: ProcessMonitor ref,
+            status: ProcessExitStatus)
+          =>
+            None
+        end
+
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+      let path = FilePath(file_auth, "/bin/sleep")
+      let args: Array[String] val = ["sleep"; "5"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      // 256 KB, well over a default pipe buffer, so the write queues and
+      // applies backpressure.
+      let message: Array[U8] val = recover Array[U8].init('x', 262144) end
+
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.write(message)
+        let applied_q = Promise[Bool]
+        pm._test_query_backpressure(applied_q)
+        applied_q.next[None]({(applied)(h, pm) =>
+          h.assert_true(applied,
+            "backpressure should be applied after an over-buffer write")
+          pm.dispose()
+          let released_q = Promise[Bool]
+          pm._test_query_backpressure(released_q)
+          released_q.next[None]({(still)(h) =>
+            if still then
+              h.fail("backpressure still applied after dispose")
+              h.complete(false)
+            else
+              h.complete(true)
+            end
+          })
+        })
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+        h.complete(false)
+      end
+      h.long_test(10_000_000_000)
+    end
+
+// --------------------------------------------------------------------------
+// State-machine invariants via the injectable _Process seam
+// --------------------------------------------------------------------------
+
+class \nodoc\ val _SpyResults
+  let disposes: USize
+  let failures: USize
+  let kills: USize
+  let kill_after_reap: Bool
+  let last_status: (ProcessExitStatus | None)
+  let backpressure_applied: Bool
+
+  new val create(disposes': USize, failures': USize, kills': USize,
+    kill_after_reap': Bool, last_status': (ProcessExitStatus | None),
+    backpressure_applied': Bool)
+  =>
+    disposes = disposes'
+    failures = failures'
+    kills = kills'
+    kill_after_reap = kill_after_reap'
+    last_status = last_status'
+    backpressure_applied = backpressure_applied'
+
+  fun last_is(s: ProcessExitStatus): Bool =>
+    match last_status
+    | let x: ProcessExitStatus => x == s
+    else
+      false
+    end
+
+  fun string(): String iso^ =>
+    recover
+      String
+        .> append("disposes=" + disposes.string())
+        .> append(" failures=" + failures.string())
+        .> append(" kills=" + kills.string())
+        .> append(" kill_after_reap=" + kill_after_reap.string())
+        .> append(" backpressure=" + backpressure_applied.string())
+    end
+
+actor \nodoc\ _SpyRecorder
+  var _kills: USize = 0
+  var _disposes: USize = 0
+  var _failures: USize = 0
+  var _reaped: Bool = false
+  var _kill_after_reap: Bool = false
+  var _last_status: (ProcessExitStatus | None) = None
+
+  be on_kill() =>
+    _kills = _kills + 1
+    if _reaped then _kill_after_reap = true end
+
+  be on_reap() =>
+    _reaped = true
+
+  be on_dispose(s: ProcessExitStatus) =>
+    _disposes = _disposes + 1
+    _last_status = s
+
+  be on_failed() =>
+    _failures = _failures + 1
+
+  be results(backpressure_applied: Bool, p: Promise[_SpyResults]) =>
+    p(_SpyResults(_disposes, _failures, _kills, _kill_after_reap, _last_status,
+      backpressure_applied))
+
+class \nodoc\ _ProcessSpy is _Process
+  """
+  A stand-in for a real child. Records `kill()` to a recorder and returns a
+  chosen result from `wait()`. The first `wait()` (the constructor probe)
+  returns `_StillRunning`; a later `wait()` (a triggered exit) reaps. `lag`
+  extends the `_StillRunning` window past the probe by that many `wait()` calls,
+  standing in for waitpid trailing the OS exit notification. With `fail`, the
+  reap returns `WaitpidError` instead of the status.
+  """
+  let _recorder: _SpyRecorder
+  let _status: ProcessExitStatus
+  let _lag: USize
+  let _fail: Bool
+  var _waits: USize = 0
+
+  new create(recorder: _SpyRecorder, status: ProcessExitStatus,
+    lag: USize = 0, fail: Bool = false)
+  =>
+    _recorder = recorder
+    _status = status
+    _lag = lag
+    _fail = fail
+
+  fun box kill() =>
+    _recorder.on_kill()
+
+  fun ref wait(): _WaitResult =>
+    _waits = _waits + 1
+    if _waits <= (1 + _lag) then
+      _StillRunning
+    elseif _fail then
+      WaitpidError
+    else
+      _recorder.on_reap()
+      _status
+    end
+
+  fun ref arm_exit_event(owner: AsioEventNotify): AsioEventID =>
+    AsioEvent.none()
+
+  fun ref close_exit_source(event: AsioEventID) =>
+    None
+
+class \nodoc\ _SpyNotify is ProcessNotify
+  let _recorder: _SpyRecorder
+
+  new iso create(recorder: _SpyRecorder) =>
+    _recorder = recorder
+
+  fun ref dispose(process: ProcessMonitor ref, s: ProcessExitStatus) =>
+    _recorder.on_dispose(s)
+
+  fun ref failed(process: ProcessMonitor ref, e: ProcessError) =>
+    _recorder.on_failed()
+
+class \nodoc\ _ExpectDisposeClient is ProcessNotify
+  """
+  Completes the test when `dispose` reports the expected status. Used where the
+  reap arrives after a retry that outlives the seam's settle query, so the test
+  must wait on `dispose` itself rather than a one-shot settle.
+  """
+  let _h: TestHelper
+  let _expected: ProcessExitStatus
+
+  new iso create(h: TestHelper, expected: ProcessExitStatus) =>
+    _h = h
+    _expected = expected
+
+  fun ref dispose(process: ProcessMonitor ref, s: ProcessExitStatus) =>
+    if s == _expected then
+      _h.complete(true)
+    else
+      _h.fail("expected dispose(" + _expected.string() + "), got "
+        + s.string())
+      _h.complete(false)
+    end
+
+  fun ref failed(process: ProcessMonitor ref, e: ProcessError) =>
+    _h.fail("expected dispose, got failed(" + e.error_type.string() + ")")
+    _h.complete(false)
+
+class \nodoc\ _ExpectFailedClient is ProcessNotify
+  """
+  Completes the test when `failed` reports the expected error type. Mirrors
+  `_ExpectDisposeClient` for the reap-error path.
+  """
+  let _h: TestHelper
+  let _expected: ProcessErrorType
+
+  new iso create(h: TestHelper, expected: ProcessErrorType) =>
+    _h = h
+    _expected = expected
+
+  fun ref failed(process: ProcessMonitor ref, e: ProcessError) =>
+    if e.error_type is _expected then
+      _h.complete(true)
+    else
+      _h.fail("expected failed(" + _expected.string() + "), got "
+        + e.error_type.string())
+      _h.complete(false)
+    end
+
+  fun ref dispose(process: ProcessMonitor ref, s: ProcessExitStatus) =>
+    _h.fail("expected failed, got dispose(" + s.string() + ")")
+    _h.complete(false)
+
+primitive \nodoc\ _Spy
+  fun monitor(h: TestHelper, recorder: _SpyRecorder,
+    status: ProcessExitStatus): ProcessMonitor
+  =>
+    let bp_auth = ApplyReleaseBackpressureAuth(h.env.root)
+    ProcessMonitor._create(bp_auth, _SpyNotify(recorder),
+      recover iso _ProcessSpy(recorder, status) end,
+      recover iso _Pipe.none() end, recover iso _Pipe.none() end,
+      recover iso _Pipe.none() end, recover iso _Pipe.none() end)
+
+  fun settle_then_check(
+    h: TestHelper,
+    pm: ProcessMonitor,
+    recorder: _SpyRecorder,
+    check: {(_SpyResults): (Bool, String)} val)
+  =>
+    // The query is sent after the driving events, so it resolves once all of
+    // them have been processed by the (single-threaded) monitor actor.
+    let bp = Promise[Bool]
+    pm._test_query_backpressure(bp)
+    bp.next[None]({(applied)(h, recorder, check) =>
+      let rp = Promise[_SpyResults]
+      recorder.results(applied, rp)
+      rp.next[None]({(r)(h, check) =>
+        (let ok, let msg) = check(r)
+        if ok then
+          h.complete(true)
+        else
+          h.fail(msg + " (" + r.string() + ")")
+          h.complete(false)
+        end
+      })
+    })
+
+class \nodoc\ iso _TestExitReportsExactlyOnce is UnitTest
+  """
+  A duplicate exit event after the reap is a no-op: `dispose` fires once.
+  """
+  fun name(): String => "process/exit-reports-exactly-once"
+  fun exclusion_group(): String => "process-monitor-seam"
+  fun apply(h: TestHelper) =>
+    let recorder = _SpyRecorder
+    let pm = _Spy.monitor(h, recorder, Exited(3))
+    pm._test_trigger_exit()
+    pm._test_trigger_exit()
+    _Spy.settle_then_check(h, pm, recorder, {(r: _SpyResults): (Bool, String) =>
+      ((r.disposes == 1) and r.last_is(Exited(3)) and (not r.kill_after_reap)
+        and (not r.backpressure_applied),
+       "expected exactly one dispose of Exited(3), no kill after reap")
+    })
+    h.long_test(5_000_000_000)
+
+class \nodoc\ iso _TestExitSignalRetriesUntilReapable is UnitTest
+  """
+  When the OS signals the child exited but waitpid still reports it running for
+  a few polls, the monitor retries the reap until the status appears and reports
+  the exit. Pins the retry that covers the window where waitpid trails the OS
+  exit notification (the macOS EVFILT_PROC ESRCH race).
+  """
+  fun name(): String => "process/exit-signal-retries-until-reapable"
+  fun exclusion_group(): String => "process-monitor-seam"
+  fun apply(h: TestHelper) =>
+    let recorder = _SpyRecorder
+    let bp_auth = ApplyReleaseBackpressureAuth(h.env.root)
+    // lag = 5: the probe and the first five exit-signal reaps return
+    // `_StillRunning`; the reap converges only by retrying.
+    let pm = ProcessMonitor._create(bp_auth,
+      _ExpectDisposeClient(h, Exited(4)),
+      recover iso _ProcessSpy(recorder, Exited(4), 5) end,
+      recover iso _Pipe.none() end, recover iso _Pipe.none() end,
+      recover iso _Pipe.none() end, recover iso _Pipe.none() end)
+    pm._test_trigger_exit()
+    h.long_test(5_000_000_000)
+
+class \nodoc\ iso _TestRetryWhileDisposing is UnitTest
+  """
+  dispose() runs first, moving the monitor to `_Disposing`; the exit-signal reap
+  then retries entirely within `_Disposing` and reports the exit once via
+  `dispose`. Pins that the retry converges while the monitor is disposing.
+  """
+  fun name(): String => "process/retry-while-disposing"
+  fun exclusion_group(): String => "process-monitor-seam"
+  fun apply(h: TestHelper) =>
+    let recorder = _SpyRecorder
+    let bp_auth = ApplyReleaseBackpressureAuth(h.env.root)
+    let pm = ProcessMonitor._create(bp_auth,
+      _ExpectDisposeClient(h, Exited(0)),
+      recover iso _ProcessSpy(recorder, Exited(0), 3) end,
+      recover iso _Pipe.none() end, recover iso _Pipe.none() end,
+      recover iso _Pipe.none() end, recover iso _Pipe.none() end)
+    pm.dispose()
+    pm._test_trigger_exit()
+    h.long_test(5_000_000_000)
+
+class \nodoc\ iso _TestExitSignalReapErrorReportsFailed is UnitTest
+  """
+  A reap that errors after the exit signal (waitpid fails once the retry finally
+  polls) reports `failed(WaitpidError)`. Pins the reap-error branch on the
+  exit-signal path, which the other seam tests never reach.
+  """
+  fun name(): String => "process/exit-signal-reap-error-reports-failed"
+  fun exclusion_group(): String => "process-monitor-seam"
+  fun apply(h: TestHelper) =>
+    let recorder = _SpyRecorder
+    let bp_auth = ApplyReleaseBackpressureAuth(h.env.root)
+    // lag = 2, fail = true: the probe and two exit-signal reaps return
+    // `_StillRunning`, then the reap returns `WaitpidError`.
+    let pm = ProcessMonitor._create(bp_auth,
+      _ExpectFailedClient(h, WaitpidError),
+      recover iso _ProcessSpy(recorder, Exited(0), 2 where fail = true) end,
+      recover iso _Pipe.none() end, recover iso _Pipe.none() end,
+      recover iso _Pipe.none() end, recover iso _Pipe.none() end)
+    pm._test_trigger_exit()
+    h.long_test(5_000_000_000)
+
+class \nodoc\ iso _TestDisposeThenExit is UnitTest
+  """
+  Client dispose() then the child exits: the child is killed once and the exit
+  status is reported once.
+  """
+  fun name(): String => "process/dispose-then-exit"
+  fun exclusion_group(): String => "process-monitor-seam"
+  fun apply(h: TestHelper) =>
+    let recorder = _SpyRecorder
+    let pm = _Spy.monitor(h, recorder, Exited(0))
+    pm.dispose()
+    pm._test_trigger_exit()
+    _Spy.settle_then_check(h, pm, recorder, {(r: _SpyResults): (Bool, String) =>
+      ((r.disposes == 1) and (r.kills == 1) and (not r.kill_after_reap),
+       "expected one kill, one dispose, no kill after reap")
+    })
+    h.long_test(5_000_000_000)
+
+class \nodoc\ iso _TestDoubleDispose is UnitTest
+  """
+  Two dispose() calls kill the child once and never report an exit that has not
+  happened.
+  """
+  fun name(): String => "process/double-dispose"
+  fun exclusion_group(): String => "process-monitor-seam"
+  fun apply(h: TestHelper) =>
+    let recorder = _SpyRecorder
+    let pm = _Spy.monitor(h, recorder, Exited(0))
+    pm.dispose()
+    pm.dispose()
+    _Spy.settle_then_check(h, pm, recorder, {(r: _SpyResults): (Bool, String) =>
+      ((r.kills == 1) and (r.disposes == 0) and (not r.backpressure_applied),
+       "expected exactly one kill and no dispose")
+    })
+    h.long_test(5_000_000_000)
+
+class \nodoc\ iso _TestNoKillAfterReap is UnitTest
+  """
+  #5765: dispose() after the child has been reaped never signals the reaped pid.
+  """
+  fun name(): String => "process/no-kill-after-reap"
+  fun exclusion_group(): String => "process-monitor-seam"
+  fun apply(h: TestHelper) =>
+    let recorder = _SpyRecorder
+    let pm = _Spy.monitor(h, recorder, Exited(7))
+    pm._test_trigger_exit()
+    pm.dispose()
+    _Spy.settle_then_check(h, pm, recorder, {(r: _SpyResults): (Bool, String) =>
+      ((r.kills == 0) and (not r.kill_after_reap) and (r.disposes == 1)
+        and r.last_is(Exited(7)),
+       "expected no kill after reap and exactly one dispose")
+    })
+    h.long_test(5_000_000_000)
+
+class \nodoc\ iso _TestWriteAfterExitIsDropped is UnitTest
+  """
+  A write() that arrives after the child has been reaped is dropped, not
+  queued: it must not fire a second dispose or strand backpressure.
+  """
+  fun name(): String => "process/write-after-exit-is-dropped"
+  fun exclusion_group(): String => "process-monitor-seam"
+  fun apply(h: TestHelper) =>
+    let recorder = _SpyRecorder
+    let pm = _Spy.monitor(h, recorder, Exited(0))
+    pm._test_trigger_exit()
+    pm.write("late data")
+    pm.done_writing()
+    _Spy.settle_then_check(h, pm, recorder, {(r: _SpyResults): (Bool, String) =>
+      ((r.disposes == 1) and (not r.backpressure_applied),
+       "a write after exit must not add a dispose or strand backpressure")
+    })
+    h.long_test(5_000_000_000)
+
+// --------------------------------------------------------------------------
+// The drain cap and the no-fd-leak invariant (real processes)
+// --------------------------------------------------------------------------
+
+class \nodoc\ iso _TestFloodingGrandchildDoesNotStallTeardown is UnitTest
+  """
+  The child backgrounds a grandchild that floods the inherited stdout without
+  end, then exits. Teardown must complete and `dispose` must arrive: the child
+  exits, its status is reported, and the flooding descendant is left behind (it
+  gets EPIPE once we close our read end). This exercises the reap-edge drain
+  against a live flooder; the `_drain_cap` is the backstop that bounds the
+  drain if the reads never reach EAGAIN.
+  """
+  fun name(): String => "process/flooding-grandchild-does-not-stall-teardown"
+  fun exclusion_group(): String => "process-monitor"
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.complete(true)
+    else
+      let notifier =
+        object iso is ProcessNotify
+          fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+            h.fail("failed: " + err.string())
+            h.complete(false)
+
+          fun ref dispose(process: ProcessMonitor ref,
+            status: ProcessExitStatus)
+          =>
+            match status
+            | Exited(0) => h.complete(true)
+            else
+              h.fail("expected Exited(0), got " + status.string())
+              h.complete(false)
+            end
+        end
+
+      let process_auth = StartProcessAuth(h.env.root)
+      let backpressure_auth = ApplyReleaseBackpressureAuth(h.env.root)
+      let file_auth = FileAuth(h.env.root)
+      let path = FilePath(file_auth, "/bin/sh")
+      // cat /dev/zero floods the inherited stdout without end; the child exits
+      // at once. Once we drain the cap and close our read end, cat gets EPIPE.
+      let args: Array[String] val = ["sh"; "-c"; "cat /dev/zero & exit 0"]
+      let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+      match StartProcess(process_auth, backpressure_auth, consume notifier,
+        path, args, vars)
+      | let pm: ProcessMonitor =>
+        pm.done_writing()
+        h.dispose_when_done(pm)
+      | let err: ProcessError =>
+        h.fail("StartProcess failed: " + err.string())
+        h.complete(false)
+      end
+      h.long_test(10_000_000_000)
+    end
+
+class \nodoc\ iso _TestManyStartsDoNotLeakFds is UnitTest
+  """
+  Start and reap a batch of short-lived children and check that the process's
+  open file descriptor count does not grow. A descriptor leaked per child
+  (#5766) shows up as a count that climbs with the batch size. Linux only: it
+  reads /proc/self/fd. The descriptor-closing logic is shared across posix, so
+  the Linux run exercises it; the kqueue exit source on macOS and the BSDs
+  holds no descriptor to leak.
+  """
+  fun name(): String => "process/many-starts-do-not-leak-fds"
+  fun exclusion_group(): String => "process-monitor"
+
+  fun apply(h: TestHelper) =>
+    ifdef linux then
+      let file_auth = FileAuth(h.env.root)
+      let true_path =
+        try
+          _PathResolver(h.env.vars, file_auth).resolve("true")?.path
+        else
+          h.fail("could not find 'true' on PATH")
+          h.complete(false)
+          return
+        end
+      match _OpenFdCount(file_auth)
+      | let baseline: USize =>
+        _FdLeakDriver(h, 100, true_path, baseline)
+      | None =>
+        h.fail("could not read /proc/self/fd")
+        h.complete(false)
+      end
+    else
+      h.complete(true)
+    end
+    h.long_test(60_000_000_000)
+
+primitive \nodoc\ _OpenFdCount
+  """
+  The number of open file descriptors in this process, read from /proc/self/fd
+  on Linux. None if the directory cannot be read.
+  """
+  fun apply(auth: FileAuth): (USize | None) =>
+    try
+      let dir = Directory(FilePath(auth, "/proc/self/fd"))?
+      let entries = dir.entries()?
+      let n = entries.size()
+      dir.dispose()
+      n
+    else
+      None
+    end
+
+actor \nodoc\ _FdLeakDriver
+  let _h: TestHelper
+  let _total: USize
+  let _true_path: String
+  let _baseline: USize
+  var _n: USize = 0
+
+  new create(h: TestHelper, total: USize, true_path: String, baseline: USize) =>
+    _h = h
+    _total = total
+    _true_path = true_path
+    _baseline = baseline
+    _start_next()
+
+  be _done() =>
+    _n = _n + 1
+    if _n >= _total then
+      match _OpenFdCount(FileAuth(_h.env.root))
+      | let final_count: USize =>
+        // A leaked descriptor per child would add _total to the count. Allow a
+        // small margin for descriptors other packages' tests open while this
+        // one runs in the same test binary.
+        _h.assert_true(final_count <= (_baseline + 30),
+          "open fd count grew from " + _baseline.string() + " to "
+            + final_count.string() + " over " + _total.string() + " starts")
+        _h.complete(true)
+      | None =>
+        _h.fail("could not read /proc/self/fd")
+        _h.complete(false)
+      end
+    else
+      _start_next()
+    end
+
+  be _fail(msg: String) =>
+    _h.fail(msg)
+    _h.complete(false)
+
+  fun ref _start_next() =>
+    let self: _FdLeakDriver = this
+    let notifier =
+      object iso is ProcessNotify
+        fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+          self._fail("a start failed: " + err.string())
+
+        fun ref dispose(process: ProcessMonitor ref,
+          status: ProcessExitStatus)
+        =>
+          self._done()
+      end
+
+    let process_auth = StartProcessAuth(_h.env.root)
+    let backpressure_auth = ApplyReleaseBackpressureAuth(_h.env.root)
+    let file_auth = FileAuth(_h.env.root)
+    let path = FilePath(file_auth, _true_path)
+    let args: Array[String] val = ["true"]
+    let vars: Array[String] val = ["HOME=/"; "PATH=/bin"]
+
+    match StartProcess(process_auth, backpressure_auth, consume notifier, path,
+      args, vars)
+    | let pm: ProcessMonitor =>
+      pm.done_writing()
+    | let err: ProcessError =>
+      _fail("a start failed: " + err.string())
+    end
+
+class \nodoc\ _FailAndExitClient is ProcessNotify
+  """
+  Expects an exec/chdir failure: `failed` must fire with the expected error
+  type, and then `dispose` must report the child's exit. Passes only if both
+  happen, so it cannot be satisfied by `dispose` alone.
+  """
+  let _h: TestHelper
+  let _expected: ProcessErrorType
+  var _failed_fired: Bool = false
+
+  new iso create(h: TestHelper, expected: ProcessErrorType) =>
+    _h = h
+    _expected = expected
+
+  fun ref stdout(process: ProcessMonitor ref, data: Array[U8] iso) =>
+    None
+
+  fun ref stderr(process: ProcessMonitor ref, data: Array[U8] iso) =>
+    None
+
+  fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
+    if err.error_type is _expected then
+      _failed_fired = true
+    else
+      _h.fail("expected " + _expected.string() + ", got "
+        + err.error_type.string())
+      _h.complete(false)
+    end
+
+  fun ref dispose(process: ProcessMonitor ref,
+    child_exit_status: ProcessExitStatus)
+  =>
+    if not _failed_fired then
+      _h.fail("dispose fired without a preceding failed")
+      _h.complete(false)
+      return
+    end
+    match child_exit_status
+    | Exited(_EXOSERR()) => _h.complete(true)
+    else
+      _h.fail("expected Exited(" + _EXOSERR().string() + "), got "
+        + child_exit_status.string())
+      _h.complete(false)
+    end

--- a/packages/process/process.pony
+++ b/packages/process/process.pony
@@ -2,14 +2,19 @@
 # Process package
 
 The Process package provides support for handling Unix style processes.
-For each external process that you want to handle, you need to create a
-`ProcessMonitor` and a corresponding `ProcessNotify` object. Each
-ProcessMonitor runs as it own actor and upon receiving data will call its
-corresponding `ProcessNotify`'s method.
+For each external process that you want to handle, you provide a
+`ProcessNotify` object and call `StartProcess`, which spawns the process and
+gives you back a `ProcessMonitor` for it, or a `ProcessError` if the process
+could not be started. Each `ProcessMonitor` runs as its own actor and upon
+receiving data will call its corresponding `ProcessNotify`'s method.
+
+The child's exit is detected from a native per-platform event, not from its
+output pipes closing, so a child that leaves another process holding its
+stdout or stderr open is still reported as exited promptly.
 
 ## Example program
 
-The following program will spawn an external program and write to it's
+The following program will spawn an external program and write to its
 STDIN. Output received on STDOUT of the child process is forwarded to the
 ProcessNotify client and printed.
 
@@ -32,11 +37,15 @@ actor Main
     // create a ProcessMonitor and spawn the child process
     let sp_auth = StartProcessAuth(env.root)
     let bp_auth = ApplyReleaseBackpressureAuth(env.root)
-    let pm: ProcessMonitor = ProcessMonitor(sp_auth, bp_auth, consume notifier,
-    path, args, vars)
-    // write to STDIN of the child process
-    pm.write("one, two, three")
-    pm.done_writing() // closing stdin allows cat to terminate
+    // start the child process
+    match StartProcess(sp_auth, bp_auth, consume notifier, path, args, vars)
+    | let pm: ProcessMonitor =>
+      // write to STDIN of the child process
+      pm.write("one, two, three")
+      pm.done_writing() // closing stdin allows cat to terminate
+    | let err: ProcessError =>
+      env.out.print("Could not start the process: " + err.string())
+    end
 
 // define a client that implements the ProcessNotify interface
 class ProcessClient is ProcessNotify
@@ -68,12 +77,14 @@ class ProcessClient is ProcessNotify
 ## Process portability
 
 The ProcessMonitor supports spawning processes on Linux, FreeBSD, OSX and
-Windows.
+Windows. On Linux, detecting a child's exit uses `pidfd_open`, so it requires
+kernel 5.3 or newer; on an older kernel, `StartProcess` returns a
+`ProcessError` of type `UnsupportedKernel`.
 
 ## Shutting down ProcessMonitor and external process
 
-When a process is spawned using ProcessMonitor, and it is not necessary to
-communicate to it any further using `stdin` and `stdout` or `stderr`, calling
+When a process has been started and it is not necessary to communicate to it
+any further using `stdin` and `stdout` or `stderr`, calling
 [done_writing()](process-ProcessMonitor.md#done_writing) will close stdin to
 the child process. Processes expecting input will be notified of an `EOF` on
 their `stdin` and can terminate.
@@ -83,9 +94,8 @@ If a running program needs to be canceled and the
 [dispose](process-ProcessMonitor.md#dispose) will terminate the child process
 and clean up all resources.
 
-Once the child process is detected to be closed, the process exit status is
-retrieved and [ProcessNotify.dispose](process-ProcessNotify.md#dispose) is
-called.
+Once the child process exits, its exit status is retrieved and
+[ProcessNotify.dispose](process-ProcessNotify.md#dispose) is called.
 
 The process exit status can be either an instance of
 [Exited](process-Exited.md) containing the process exit code in case the

--- a/packages/process/process_error.pony
+++ b/packages/process/process_error.pony
@@ -1,4 +1,11 @@
 class val ProcessError
+  """
+  Why a process could not be started, or why monitoring one failed.
+  `StartProcess` returns a `ProcessError` when it cannot start a process, and
+  `ProcessNotify.failed` receives one for errors that arise while a process
+  runs. `error_type` is the category of the error; `message` is optional
+  human-readable detail.
+  """
   let error_type: ProcessErrorType
   let message: (String | None)
 
@@ -25,6 +32,8 @@ class val ProcessError
 
 type ProcessErrorType is
   ( ExecveError
+  | ExecutableNotFound
+  | UnsupportedKernel
   | PipeError
   | ForkError
   | WaitpidError
@@ -34,30 +43,83 @@ type ProcessErrorType is
   | ChdirError
   | UnknownError
   )
+  """
+  The category of a `ProcessError`.
+  """
 
 primitive ExecveError
+  """
+  `execve` failed in the child after the process was started, so the program
+  never ran. Arrives through `ProcessNotify.failed`. For a path that does not
+  name a runnable file in the first place, see `ExecutableNotFound`.
+  """
   fun string(): String iso^ => "ExecveError".clone()
 
+primitive ExecutableNotFound
+  """
+  The path given to start a process does not name an existing file we can try
+  to execute; it is missing or is a directory. Distinct from `ExecveError`,
+  which is `execve` failing in the child after the process was started.
+  """
+  fun string(): String iso^ => "ExecutableNotFound".clone()
+
+primitive UnsupportedKernel
+  """
+  The platform cannot report a child's exit. On Linux this means the kernel is
+  older than 5.3 and lacks `pidfd_open`.
+  """
+  fun string(): String iso^ => "UnsupportedKernel".clone()
+
 primitive PipeError
+  """
+  A pipe to communicate with the child could not be opened. Returned by
+  `StartProcess`.
+  """
   fun string(): String iso^ => "PipeError".clone()
 
 primitive ForkError
+  """
+  The child process could not be created (`fork` on posix, `CreateProcess` on
+  Windows). Returned by `StartProcess`.
+  """
   fun string(): String iso^ => "ForkError".clone()
 
 primitive WaitpidError
+  """
+  The child's exit status could not be read. Arrives through
+  `ProcessNotify.failed` as a terminal error in place of `dispose`.
+  """
   fun string(): String iso^ => "WaitpidError".clone()
 
 primitive WriteError
+  """
+  Writing to the child's STDIN failed. Arrives through `ProcessNotify.failed`.
+  """
   fun string(): String iso^ => "WriteError".clone()
 
-primitive KillError   // Not thrown at this time
+primitive KillError
+  """
+  Currently unused.
+  """
   fun string(): String iso^ => "KillError".clone()
 
 primitive CapError
+  """
+  The path does not have the `FileExec` capability, so we are not permitted to
+  execute it. Returned by `StartProcess`.
+  """
   fun string(): String iso^ => "CapError".clone()
 
 primitive ChdirError
+  """
+  The child could not change to the requested working directory. Arrives
+  through `ProcessNotify.failed`.
+  """
   fun string(): String iso^ => "ChdirError".clone()
 
 primitive UnknownError
+  """
+  The child reported a startup failure we could not classify. Arrives through
+  `ProcessNotify.failed`.
+  """
   fun string(): String iso^ => "UnknownError".clone()

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -1,157 +1,259 @@
 use "backpressure"
 use "collections"
 use "files"
-use "time"
+use "promises"
+use @getpid[I32]() if linux
+
+primitive StartProcess
+  """
+  Fork+exec (posix) or create (windows) a child process and return a live
+  `ProcessMonitor` for it, or a `ProcessError` if the process could not be
+  started. Every fallible step of starting the process happens here, before the
+  monitor exists, so a returned `ProcessMonitor` is always monitoring a running
+  child. Use it in place of a constructor:
+
+  ```pony
+  match StartProcess(sp_auth, bp_auth, consume notifier, path, args, vars)
+  | let pm: ProcessMonitor => // a live child is running
+  | let err: ProcessError  => // never started; err says why
+  end
+  ```
+
+  On a `ProcessError` return, no process was started and none of the notifier's
+  callbacks will fire. On Linux, starting a process requires kernel 5.3 or
+  newer; on an older kernel, `StartProcess` returns an `UnsupportedKernel`
+  error.
+  """
+  fun apply(
+    auth: StartProcessAuth,
+    backpressure_auth: ApplyReleaseBackpressureAuth,
+    notifier: ProcessNotify iso,
+    path: FilePath,
+    args: Array[String] val,
+    vars: Array[String] val,
+    wdir: (FilePath | None) = None)
+  : (ProcessMonitor | ProcessError)
+  =>
+    // We need permission to execute and the file itself needs to be an
+    // executable.
+    if not path.caps(FileExec) then
+      return ProcessError(CapError, path.path
+        + " is not an executable or we do not have execute capability.")
+    end
+
+    let is_file = try FileInfo(path)?.file else false end
+    if not is_file then
+      // Unable to stat the path given, so it may not exist or may be a
+      // directory.
+      return ProcessError(ExecutableNotFound, path.path
+        + " does not exist or is a directory.")
+    end
+
+    // On Linux, exit detection uses a pidfd, which needs kernel >= 5.3. Probe
+    // on our own pid: ENOSYS means the kernel is too old. Any other probe
+    // failure (e.g. out of file descriptors) is left for the child's own
+    // pidfd_open to surface as a start failure.
+    ifdef linux then
+      let probe = @ponyint_pidfd_open(@getpid())
+      if probe < 0 then
+        if @pony_os_errno() == _ENOSYS() then
+          return ProcessError(UnsupportedKernel,
+            "the kernel does not support pidfd_open (needs Linux >= 5.3).")
+        end
+      else
+        @close(probe.u32())
+      end
+    end
+
+    // Create the four pipes as iso so they can cross into the actor. On any
+    // failure, close the ones already opened.
+    let stdin_pipe: _Pipe iso =
+      try recover iso _Pipe.outgoing()? end
+      else
+        return ProcessError(PipeError, "Failed to open pipe for stdin.")
+      end
+    let stdout_pipe: _Pipe iso =
+      try recover iso _Pipe.incoming()? end
+      else
+        stdin_pipe.close()
+        return ProcessError(PipeError, "Failed to open pipe for stdout.")
+      end
+    let stderr_pipe: _Pipe iso =
+      try recover iso _Pipe.incoming()? end
+      else
+        stdin_pipe.close()
+        stdout_pipe.close()
+        return ProcessError(PipeError, "Failed to open pipe for stderr.")
+      end
+    let err_pipe: _Pipe iso =
+      try recover iso _Pipe.incoming()? end
+      else
+        stdin_pipe.close()
+        stdout_pipe.close()
+        stderr_pipe.close()
+        return ProcessError(PipeError, "Failed to open auxiliary error pipe.")
+      end
+
+    // Read the far-end fds off the iso pipes (reading a val field off an iso
+    // neither aliases nor consumes it) so the child creation takes plain fds
+    // and the pipes stay whole to hand to the monitor.
+    let in_far = stdin_pipe.far_fd
+    let out_far = stdout_pipe.far_fd
+    let err2_far = stderr_pipe.far_fd
+    let err_far = err_pipe.far_fd
+
+    // Extract the executable path and working directory as sendable values so
+    // they can be used inside the `recover` that builds the child.
+    let exec_path: String val = path.path.clone()
+    let wdir_str: (String val | None) =
+      match \exhaustive\ wdir
+      | let d: FilePath => d.path.clone()
+      | None => None
+      end
+
+    ifdef posix then
+      let child: _Process iso =
+        try
+          recover iso
+            _ProcessPosix(exec_path, args, vars, wdir_str, err_far, in_far,
+              out_far, err2_far)?
+          end
+        else
+          stdin_pipe.close()
+          stdout_pipe.close()
+          stderr_pipe.close()
+          err_pipe.close()
+          return ProcessError(ForkError)
+        end
+      ProcessMonitor._create(backpressure_auth, consume notifier,
+        consume child, consume stdin_pipe, consume stdout_pipe,
+        consume stderr_pipe, consume err_pipe)
+    elseif windows then
+      let windows_child: _ProcessWindows iso =
+        recover iso
+          _ProcessWindows(exec_path, args, vars, wdir_str, in_far, out_far,
+            err2_far)
+        end
+      // Reading the sendable `process_error` field off the iso neither aliases
+      // nor consumes it.
+      match windows_child.process_error
+      | let pe: ProcessError =>
+        stdin_pipe.close()
+        stdout_pipe.close()
+        stderr_pipe.close()
+        err_pipe.close()
+        return pe
+      end
+      ProcessMonitor._create(backpressure_auth, consume notifier,
+        consume windows_child, consume stdin_pipe, consume stdout_pipe,
+        consume stderr_pipe, consume err_pipe)
+    else
+      compile_error "unsupported platform"
+    end
+
+primitive _Running
+primitive _Disposing
+primitive _Reaped
+type _Lifecycle is (_Running | _Disposing | _Reaped)
+  """
+  The monitor's lifecycle. A monitor exists only around a running child, so
+  there is no "not started" state.
+
+  - `_Running`: child alive, being monitored.
+  - `_Disposing`: the client called `dispose()`; the child was killed and the
+    pipes closed, and we are awaiting the exit event.
+  - `_Reaped`: the child exited and we collected its status (or a reap error);
+    absorbing and inert.
+  """
 
 actor ProcessMonitor is AsioEventNotify
   """
-  Fork+execs / creates a child process and monitors it. Notifies a client about
-  STDOUT / STDERR events.
+  Monitors a running child process: forwards its STDOUT/STDERR to a
+  `ProcessNotify`, writes to its STDIN, and reports its exit status once it
+  exits. Create one with `StartProcess`.
+
+  Exit is detected from a native per-platform event (a pidfd on Linux), not
+  from the child's pipes reaching end-of-file, so a child that leaves a
+  grandchild holding its stdout/stderr open is still reported as exited
+  promptly.
   """
   let _notifier: ProcessNotify
   let _backpressure_auth: ApplyReleaseBackpressureAuth
+  let _child: _Process
 
-  var _stdin: _Pipe = _Pipe.none()
-  var _stdout: _Pipe = _Pipe.none()
-  var _stderr: _Pipe = _Pipe.none()
-  var _err: _Pipe = _Pipe.none()
-  var _child: _Process = _ProcessNone
+  var _stdin: _Pipe
+  var _stdout: _Pipe
+  var _stderr: _Pipe
+  var _err: _Pipe
+  var _exit_event: AsioEventID = AsioEvent.none()
 
   let _max_size: USize = 4096
+  // Per-pipe bound on the reap-edge drain. A fixed constant of at least one
+  // default pipe capacity, so all of a well-behaved child's own output is
+  // delivered, while a descendant flooding the pipe the instant the child dies
+  // cannot stall teardown. Not a function of the pipe's buffer size, which the
+  // child can grow (F_SETPIPE_SZ). This is a security bound.
+  let _drain_cap: USize = 1 << 20
   var _read_buf: Array[U8] iso = recover Array[U8] .> undefined(_max_size) end
   var _read_len: USize = 0
   var _expect: USize = 0
 
+  // Backstop for the exit-signal reap retry. Once the OS signals that the child
+  // exited, the child is a zombie we own, so waitpid will collect it and the
+  // retry converges. The cap only guards a non-convergence that should never
+  // occur — a kernel that signals the exit but never lets waitpid reap — where
+  // we surrender to WaitpidError rather than spin forever.
+  let _reap_retry_cap: U32 = 100_000
+
   embed _pending: List[(ByteSeq, USize)] = _pending.create()
   var _done_writing: Bool = false
+  var _backpressure_applied: Bool = false
 
-  var _closed: Bool = false
-  var _timers: (Timers tag | None) = None
-  let _process_poll_interval: U64
+  var _state: _Lifecycle = _Running
 
-  var _polling_child: Bool = false
-  var _final_wait_result: (_WaitResult | None) = None
-
-  new create(
-    auth: StartProcessAuth,
+  new _create(
     backpressure_auth: ApplyReleaseBackpressureAuth,
     notifier: ProcessNotify iso,
-    filepath: FilePath,
-    args: Array[String] val,
-    vars: Array[String] val,
-    wdir: (FilePath | None) = None,
-    process_poll_interval: U64 = Nanos.from_millis(100))
+    child: _Process iso,
+    stdin: _Pipe iso,
+    stdout: _Pipe iso,
+    stderr: _Pipe iso,
+    err: _Pipe iso)
   =>
     """
-    Create infrastructure to communicate with a forked child process and
-    register the asio events. Fork child process and notify our user about
-    incoming data via the notifier.
+    Build a monitor around an already-running child and its pipes. Called by
+    `StartProcess` (and by the in-package test factory). Not public: a monitor
+    is only ever created around a live child.
     """
     _backpressure_auth = backpressure_auth
     _notifier = consume notifier
-    _process_poll_interval = process_poll_interval
+    _child = consume child
+    _stdin = consume stdin
+    _stdout = consume stdout
+    _stderr = consume stderr
+    _err = consume err
 
-    // We need permission to execute and the
-    // file itself needs to be an executable
-    if not filepath.caps(FileExec) then
-      _notifier.failed(this, ProcessError(CapError, filepath.path
-        + " is not an executable or we do not have execute capability."))
-      return
-    end
+    // Register each pipe's asio event and close its far end.
+    _stdin.begin(this)
+    _stdout.begin(this)
+    _stderr.begin(this)
+    _err.begin(this)
 
-    let ok = try
-      FileInfo(filepath)?.file
-    else
-      false
-    end
-    if not ok then
-      // unable to stat the file path given so it may not exist
-      // or may be a directory.
-      _notifier.failed(this, ProcessError(ExecveError, filepath.path
-        + " does not exist or is a directory."))
-      return
-    end
+    // Arm the native exit event.
+    _exit_event = _child.arm_exit_event(this)
 
-    try
-      _stdin = _Pipe.outgoing()?
-    else
-      _stdin.close()
-      _notifier.failed(this, ProcessError(PipeError,
-        "Failed to open pipe for stdin."))
-      return
-    end
-
-    try
-      _stdout = _Pipe.incoming()?
-    else
-      _stdin.close()
-      _stdout.close()
-      _notifier.failed(this, ProcessError(PipeError,
-        "Failed to open pipe for stdout."))
-      return
-    end
-
-    try
-      _stderr = _Pipe.incoming()?
-    else
-      _stdin.close()
-      _stdout.close()
-      _stderr.close()
-      _notifier.failed(this, ProcessError(PipeError,
-        "Failed to open pipe for stderr."))
-      return
-    end
-
-    try
-      _err = _Pipe.incoming()?
-    else
-      _stdin.close()
-      _stdout.close()
-      _stderr.close()
-      _err.close()
-      _notifier.failed(this, ProcessError(PipeError,
-        "Failed to open auxiliary error pipe."))
-      return
-    end
-
-    try
-      ifdef posix then
-        _child = _ProcessPosix.create(
-          filepath.path, args, vars, wdir, _err, _stdin, _stdout, _stderr)?
-      elseif windows then
-        let windows_child = _ProcessWindows.create(
-          filepath.path, args, vars, wdir, _stdin, _stdout, _stderr)
-        _child = windows_child
-        // notify about errors
-        match windows_child.process_error
-        | let pe: ProcessError =>
-          _notifier.failed(this, pe)
-          return
-        end
-      else
-        compile_error "unsupported platform"
-      end
-      _err.begin(this)
-      _stdin.begin(this)
-      _stdout.begin(this)
-      _stderr.begin(this)
-    else
-      _notifier.failed(this, ProcessError(ForkError))
-      return
-    end
-
-    // Asio is not wired up for Windows, so use a timer for now.
-    ifdef windows then
-      _setup_windows_timers()
-    end
     _notifier.created(this)
 
+    // The child may have exited before we armed the exit event; under
+    // edge-triggered notification that readable edge can be missed, so probe
+    // once now. A duplicate real event later lands in `_Reaped` and is a no-op.
+    _reap_if_exited()
 
   be print(data: ByteSeq) =>
     """
     Print some bytes and append a newline.
     """
-    if not _done_writing then
+    if (_state is _Running) and (not _done_writing) then
       _write_final(data)
       _write_final("\n")
     end
@@ -160,7 +262,7 @@ actor ProcessMonitor is AsioEventNotify
     """
     Write to STDIN of the child process.
     """
-    if not _done_writing then
+    if (_state is _Running) and (not _done_writing) then
       _write_final(data)
     end
 
@@ -168,45 +270,53 @@ actor ProcessMonitor is AsioEventNotify
     """
     Print an iterable collection of ByteSeqs.
     """
-    for bytes in data.values() do
-      _write_final(bytes)
-      _write_final("\n")
+    if _state is _Running then
+      for bytes in data.values() do
+        _write_final(bytes)
+        _write_final("\n")
+      end
     end
 
   be writev(data: ByteSeqIter) =>
     """
     Write an iterable collection of ByteSeqs.
     """
-    for bytes in data.values() do
-      _write_final(bytes)
+    if _state is _Running then
+      for bytes in data.values() do
+        _write_final(bytes)
+      end
     end
 
   be done_writing() =>
     """
-    Set the _done_writing flag to true. If _pending is empty we can close the
-    _stdin pipe.
+    Signal that we are finished writing to STDIN. Once any pending writes have
+    drained, STDIN is closed so a child waiting on EOF can proceed.
     """
-    _done_writing = true
-    Backpressure.release(_backpressure_auth)
-    if _pending.size() == 0 then
-      _stdin.close_near()
+    if _state is _Running then
+      _done_writing = true
+      if _pending.size() == 0 then
+        _close_stdin()
+      end
     end
 
   be dispose() =>
     """
-    Terminate child and close down everything.
+    Terminate the child and stop monitoring. The exit status of the killed
+    child is reported through `ProcessNotify.dispose` once its exit event
+    fires.
     """
-    match _child
-    | let never_started: _ProcessNone =>
-      // We never started a child process so do not do any disposal
-      // If we do, some weirdness can happen with dispose getting called
-      // on the notifier which is not supposed to happen if we never started
-      // a child (or haven't started one yet).
-      return
-    else
-      Backpressure.release(_backpressure_auth)
+    match \exhaustive\ _state
+    | _Running =>
+      _state = _Disposing
       _child.kill()
-      _close()
+      // Close the pipes (releasing any backpressure). The exit event stays
+      // armed so the reap still fires and reports the status.
+      _close_stdin()
+      _stdout.close()
+      _stderr.close()
+      _err.close()
+    | _Disposing => None // already disposing; do not kill again
+    | _Reaped => None    // already reaped; never kill a reaped pid
     end
 
   fun ref expect(qty: USize = 0) =>
@@ -219,10 +329,17 @@ actor ProcessMonitor is AsioEventNotify
 
   be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
     """
-    Handle the incoming Asio event from one of the pipes.
+    Handle an asio event from one of the pipes or from the exit source.
     """
-    if AsioEvent.errored(flags) then
-      _close()
+    if (_exit_event isnt AsioEvent.none()) and (event is _exit_event) then
+      if AsioEvent.disposable(flags) then
+        @pony_asio_event_destroy(_exit_event)
+        _exit_event = AsioEvent.none()
+      elseif AsioEvent.errored(flags) then
+        _on_exit_event_error()
+      else
+        _reap_on_exit_signal(0)
+      end
       return
     end
 
@@ -230,129 +347,192 @@ actor ProcessMonitor is AsioEventNotify
     | _stdin.event =>
       if AsioEvent.writeable(flags) then
         _pending_writes()
+      elseif AsioEvent.errored(flags) then
+        _close_stdin()
       elseif AsioEvent.disposable(flags) then
         _stdin.dispose()
       end
     | _stdout.event =>
       if AsioEvent.readable(flags) then
-        _pending_reads(_stdout)
+        _read_pipe(_stdout)
+      elseif AsioEvent.errored(flags) then
+        _stdout.close()
       elseif AsioEvent.disposable(flags) then
         _stdout.dispose()
       end
     | _stderr.event =>
       if AsioEvent.readable(flags) then
-        _pending_reads(_stderr)
+        _read_pipe(_stderr)
+      elseif AsioEvent.errored(flags) then
+        _stderr.close()
       elseif AsioEvent.disposable(flags) then
         _stderr.dispose()
       end
     | _err.event =>
       if AsioEvent.readable(flags) then
-        _pending_reads(_err)
+        _read_pipe(_err)
+      elseif AsioEvent.errored(flags) then
+        _err.close()
       elseif AsioEvent.disposable(flags) then
         _err.dispose()
       end
     end
-    _try_shutdown()
 
-  be timer_notify() =>
+  fun ref _reap_if_exited() =>
     """
-    Windows IO polling timer has fired
+    Proactive start-up reap: the child may have exited before the exit event was
+    armed. Gated on state so it runs at most once. If the child has not exited,
+    do nothing — the exit signal will arrive and drive the reap through
+    `_reap_on_exit_signal`.
     """
-    _pending_writes() // try writes
-    _pending_reads(_stdout)
-    _pending_reads(_stderr)
-    _try_shutdown()
-
-  fun ref _close() =>
-    """
-    Close all pipes and wait for the child process to exit.
-    """
-    if not _closed then
-      _closed = true
-      _stdin.close()
-      _stdout.close()
-      _stderr.close()
-      _wait_for_child()
+    if _state is _Reaped then
+      return
     end
 
-  be _wait_for_child() =>
-    match _final_wait_result
-    | let wr: _WaitResult =>
-      None
+    match \exhaustive\ _child.wait()
+    | let status: ProcessExitStatus =>
+      _do_reap(status)
+    | WaitpidError =>
+      _do_reap_error()
+    | _StillRunning =>
+      None // child still running; the exit signal will drive the reap
+    end
+
+  fun ref _reap_on_exit_signal(attempt: U32) =>
+    """
+    Reap after the OS signalled that the child exited (a real exit event, or the
+    ESRCH-synthesized one on kqueue). Gated on state so it runs at most once.
+    `waitpid` can briefly still report the child as running, because the OS exit
+    notification arrives ahead of waitpid; on `_StillRunning` retry through a
+    self-message, so the reap never blocks a scheduler thread, bounded by
+    `_reap_retry_cap`.
+    """
+    if _state is _Reaped then
+      return
+    end
+
+    match \exhaustive\ _child.wait()
+    | let status: ProcessExitStatus =>
+      _do_reap(status)
+    | WaitpidError =>
+      _do_reap_error()
+    | _StillRunning =>
+      if attempt < _reap_retry_cap then
+        _reap_again(attempt + 1)
+      else
+        _do_reap_error()
+      end
+    end
+
+  be _reap_again(attempt: U32) =>
+    """
+    One yielding hop of the exit-signal reap retry (see `_reap_on_exit_signal`).
+    """
+    _reap_on_exit_signal(attempt)
+
+  fun ref _do_reap(status: ProcessExitStatus) =>
+    """
+    The reap edge. One behavior turn, no yield. On a natural exit (`_Running`),
+    drain the child's last output before reporting; on a disposed exit
+    (`_Disposing`), the client cancelled, so skip the drain.
+    """
+    let was_running = _state is _Running
+    _state = _Reaped
+    if was_running then
+      _drain()
+    end
+    _close_all()
+    _notifier.dispose(this, status)
+
+  fun ref _do_reap_error() =>
+    """
+    The reap returned an error rather than a status. Report `failed`; there is
+    no exit status to `dispose` with.
+    """
+    _state = _Reaped
+    _close_all()
+    _notifier.failed(this, ProcessError(WaitpidError))
+
+  fun ref _on_exit_event_error() =>
+    """
+    The exit event's subscription errored, so we have lost exit detection. Try
+    a last reap; otherwise report failure and stop, without killing the child —
+    a monitor-side fault must not change the child's fate.
+    """
+    if _state is _Reaped then
+      return
+    end
+
+    match _child.wait()
+    | let status: ProcessExitStatus =>
+      _do_reap(status)
     else
-      match \exhaustive\ _child.wait()
-      | let sr: _StillRunning =>
-        if not _polling_child then
-          _polling_child = true
-          let timers = _ensure_timers()
-          let pm: ProcessMonitor tag = this
-          let tn =
-            object iso is TimerNotify
-              fun ref apply(timer: Timer, count: U64): Bool =>
-                pm._wait_for_child()
-                true
-            end
-          let timer = Timer(consume tn, _process_poll_interval, _process_poll_interval)
-          timers(consume timer)
-        end
-      | let exit_status: ProcessExitStatus =>
-        // process child exit code or termination signal
-        _final_wait_result = exit_status
-        _notifier.dispose(this, exit_status)
-        _dispose_timers()
-      | let wpe: WaitpidError =>
-        _final_wait_result = wpe
-        _notifier.failed(this, ProcessError(WaitpidError))
-        _dispose_timers()
-      end
+      _state = _Reaped
+      _close_all()
+      _notifier.failed(this, ProcessError(WaitpidError))
     end
 
-  fun ref _ensure_timers(): Timers tag =>
-    match \exhaustive\ _timers
-    | None =>
-      let ts = Timers
-      _timers = ts
-      ts
-    | let ts: Timers => ts
-    end
-
-  fun ref _dispose_timers() =>
-    match _timers
-    | let ts: Timers =>
-      ts.dispose()
-      _timers = None
-    end
-
-  fun ref _setup_windows_timers() =>
-    let timers = _ensure_timers()
-    let pm: ProcessMonitor tag = this
-    let tn =
-      object iso is TimerNotify
-        fun ref apply(timer: Timer, count: U64): Bool =>
-          pm.timer_notify()
-          true
-      end
-    let timer = Timer(consume tn, 50_000_000, 10_000_000)
-    timers(consume timer)
-
-  fun ref _try_shutdown() =>
+  fun ref _drain() =>
     """
-    If neither stdout nor stderr are open we close down and exit.
+    Read whatever the child left in its pipes before it exited, so its last
+    output is delivered before `dispose`. Draining `_err` is required: an
+    exec/chdir failure writes one byte there, and we must report it before
+    closing the pipe. Bounded per pipe by `_drain_cap`.
     """
-    if _stdin.is_closed() and
-      _stdout.is_closed() and
-      _stderr.is_closed()
-    then
-       _close()
+    _read_from(_stdout, true)
+    _read_from(_stderr, true)
+    _read_from(_err, true)
+
+  fun ref _close_all() =>
+    """
+    Close all four pipes (both ends) and the exit source. Idempotent.
+    """
+    _close_stdin()
+    _stdout.close()
+    _stderr.close()
+    _err.close()
+    _close_exit_source()
+
+  fun ref _close_stdin() =>
+    """
+    Close STDIN, release any applied backpressure, and drop pending writes.
+    Every running-state stdin close routes through here so backpressure can
+    never be stranded.
+    """
+    _stdin.close()
+    _release_backpressure()
+    _pending.clear()
+
+  fun ref _close_exit_source() =>
+    if _exit_event isnt AsioEvent.none() then
+      _child.close_exit_source(_exit_event)
+      // Leave `_exit_event` set: it is destroyed on its `disposable` callback.
     end
 
-  fun ref _pending_reads(pipe: _Pipe) =>
+  fun ref _apply_backpressure() =>
+    if not _backpressure_applied then
+      _backpressure_applied = true
+      Backpressure.apply(_backpressure_auth)
+    end
+
+  fun ref _release_backpressure() =>
+    if _backpressure_applied then
+      _backpressure_applied = false
+      Backpressure.release(_backpressure_auth)
+    end
+
+  fun ref _read_pipe(pipe: _Pipe) =>
+    _read_from(pipe, false)
+
+  fun ref _read_from(pipe: _Pipe, draining: Bool) =>
     """
-    Read from stdout or stderr while data is available. If we read 4 kb of
-    data, send ourself a resume message and stop reading, to avoid starving
-    other actors.
-    It's safe to use the same buffer for stdout and stderr because of
-    causal messaging. Events get processed one _after_ another.
+    Read from a pipe while data is available. Running (`draining = false`):
+    yield after 4 kb via a self-message to avoid starving other actors.
+    Draining (`draining = true`): no yield, capped at `_drain_cap`, for the
+    reap edge which must stay one atomic behavior turn.
+
+    It is safe to use the same buffer for stdout, stderr, and err because of
+    causal messaging: events are processed one after another.
     """
     if pipe.is_closed() then return end
     var sum: USize = 0
@@ -363,12 +543,12 @@ actor ProcessMonitor is AsioEventNotify
       let next = _read_buf.space()
       match len
       | -1 =>
-        if (errno == _EAGAIN()) then
+        if errno == _EAGAIN() then
           return // nothing to read right now, try again later
         end
         pipe.close()
         return
-      | 0  =>
+      | 0 =>
         pipe.close()
         return
       end
@@ -401,10 +581,16 @@ actor ProcessMonitor is AsioEventNotify
       _read_buf_size()
 
       sum = sum + len.usize()
-      if sum > (1 << 12) then
-        // If we've read 4 kb, yield and read again later.
-        _read_again(pipe.near_fd)
-        return
+      if draining then
+        if sum >= _drain_cap then
+          return
+        end
+      else
+        if sum > (1 << 12) then
+          // If we've read 4 kb, yield and read again later.
+          _read_again(pipe.near_fd)
+          return
+        end
       end
     end
 
@@ -417,20 +603,28 @@ actor ProcessMonitor is AsioEventNotify
 
   be _read_again(near_fd: U32) =>
     """
-    Resume reading on file descriptor.
+    Resume reading on a file descriptor after a yield.
     """
-    match near_fd
-    | _stdout.near_fd => _pending_reads(_stdout)
-    | _stderr.near_fd => _pending_reads(_stderr)
+    if _state is _Running then
+      match near_fd
+      | _stdout.near_fd => _read_pipe(_stdout)
+      | _stderr.near_fd => _read_pipe(_stderr)
+      | _err.near_fd => _read_pipe(_err)
+      end
     end
 
   fun ref _write_final(data: ByteSeq) =>
     """
-    Write as much as possible to the pipe if it is open and there are no
-    pending writes. Save everything unwritten into _pending and apply
-    backpressure.
+    Write as much as possible to STDIN if it is open and there are no pending
+    writes. Queue everything unwritten and apply backpressure. If STDIN is
+    already closed, drop the write rather than queue it — nothing would drain
+    the queue or release the backpressure.
     """
-    if (not _closed) and not _stdin.is_closed() and (_pending.size() == 0) then
+    if _stdin.is_closed() then
+      return
+    end
+
+    if _pending.size() == 0 then
       // Send as much data as possible.
       (let len, let errno) = _stdin.write(data, 0)
 
@@ -438,31 +632,31 @@ actor ProcessMonitor is AsioEventNotify
         if errno == _EAGAIN() then
           // Resource temporarily unavailable, send data later.
           _pending.push((data, 0))
-          Backpressure.apply(_backpressure_auth)
+          _apply_backpressure()
         else
           // Notify caller of error, close fd and done.
           _notifier.failed(this, ProcessError(WriteError))
-          _stdin.close_near()
+          _close_stdin()
         end
       elseif len.usize() < data.size() then
         // Send any remaining data later.
         _pending.push((data, len.usize()))
-        Backpressure.apply(_backpressure_auth)
+        _apply_backpressure()
       end
     else
       // Send later, when the pipe is available for writing.
       _pending.push((data, 0))
-      Backpressure.apply(_backpressure_auth)
+      _apply_backpressure()
     end
 
   fun ref _pending_writes() =>
     """
     Send any pending data. If any data can't be sent, keep it in _pending.
-    Once _pending is non-empty, direct writes will get queued there,
-    and they can only be written here. If the _done_writing flag is set, close
-    the pipe once we've processed pending writes.
+    Once _pending is non-empty, direct writes get queued there, and they can
+    only be written here. If _done_writing is set, close STDIN once the queue
+    drains.
     """
-    while (not _closed) and not _stdin.is_closed() and (_pending.size() > 0) do
+    while (not _stdin.is_closed()) and (_pending.size() > 0) do
       try
         let node = _pending.head()?
         (let data, let offset) = node()?
@@ -477,7 +671,7 @@ actor ProcessMonitor is AsioEventNotify
           else
             // Close pipe and bail out.
             _notifier.failed(this, ProcessError(WriteError))
-            _stdin.close_near()
+            _close_stdin()
             return
           end
         elseif (len.usize() + offset) < data.size() then
@@ -487,11 +681,11 @@ actor ProcessMonitor is AsioEventNotify
         else
           // This pending chunk has been fully sent.
           _pending.shift()?
-          if (_pending.size() == 0) then
-            Backpressure.release(_backpressure_auth)
-            // check if the client has signaled it is done
+          if _pending.size() == 0 then
+            _release_backpressure()
+            // Close STDIN if the client is done writing.
             if _done_writing then
-              _stdin.close_near()
+              _close_stdin()
             end
           end
         end
@@ -501,3 +695,22 @@ actor ProcessMonitor is AsioEventNotify
         return
       end
     end
+
+  // --- test seam (package-private) ---------------------------------------
+  // These exist so a package-private test factory can drive the state machine
+  // with a spy `_Process` and placeholder pipes. They have no public surface.
+
+  be _test_trigger_exit() =>
+    """
+    Simulate the native exit event firing. The spy `_Process.wait()` returns
+    the chosen status, driving the reap through the same gated path the real
+    event uses.
+    """
+    _reap_on_exit_signal(0)
+
+  be _test_query_backpressure(p: Promise[Bool]) =>
+    """
+    Report whether backpressure is currently applied, so a test can assert it
+    was released after a terminal edge.
+    """
+    p(_backpressure_applied)

--- a/packages/process/process_notify.pony
+++ b/packages/process/process_notify.pony
@@ -22,8 +22,11 @@ interface ProcessNotify
 
   fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
     """
-    ProcessMonitor calls this if we run into errors communicating with the
-    forked process.
+    Called for an error while the child runs — a failed write to its STDIN, or
+    an exec/chdir failure the child reported as it started. These are followed
+    by `dispose` once the child exits. `failed` is also called once, with a
+    `WaitpidError`, if the child's exit status cannot be read; that is terminal
+    and replaces `dispose`.
     """
 
   fun ref expect(process: ProcessMonitor ref, qty: USize): USize =>
@@ -36,10 +39,12 @@ interface ProcessNotify
 
   fun ref dispose(process: ProcessMonitor ref, child_exit_status: ProcessExitStatus) =>
     """
-    Called when ProcessMonitor terminates to cleanup ProcessNotify if a child
-    process was in fact started. `dispose` will not be called if a child process
-    was never started. The notify will know that a process was started and to
-    expect a `dispose` call by having received a `created` call.
+    Called with the child's exit status once the child has exited. A monitor
+    only exists around a running child, so `created` is always called first.
+    While the child runs, operational errors may arrive through `failed`; then,
+    when the child exits, `dispose` is called with its status. If the exit
+    status itself cannot be read, a terminal `failed` is called in place of
+    `dispose`. `dispose` is called at most once.
 
     `dispose` includes the exit status of the child process. If the process
     finished, then `child_exit_status` will be an instance of [Exited](process-Exited.md).

--- a/src/libponyrt/asio/asio.h
+++ b/src/libponyrt/asio/asio.h
@@ -41,6 +41,8 @@ enum
   ASIO_TIMER = 1 << 2,
   ASIO_SIGNAL = 1 << 3,
   ASIO_ERROR = 1 << 4,
+  ASIO_PROC = 1 << 5,
+  ASIO_PIPE = 1 << 6,
   ASIO_ONESHOT = 1 << 8,
   ASIO_DESTROYED = (uint32_t)-1
 };

--- a/src/libponyrt/asio/event.c
+++ b/src/libponyrt/asio/event.c
@@ -56,6 +56,8 @@ PONY_API asio_event_t* pony_asio_event_create(pony_actor_t* owner, int fd,
 #ifdef PLATFORM_IS_WINDOWS
   ev->timer = NULL;
   ev->removing = false;
+  ev->proc_wait = NULL;
+  ev->next = NULL;
 #endif
 
   owner->live_asio_events = owner->live_asio_events + 1;

--- a/src/libponyrt/asio/event.h
+++ b/src/libponyrt/asio/event.h
@@ -37,6 +37,16 @@ typedef struct asio_event_t
    * REMOVE-issuing unsubscribe. A future change that moved re-arm off the actor
    * thread would break that and must revisit this marker. */
   bool removing;
+
+  /* A process-exit event (ASIO_PROC) waits on the child's process handle via
+   * RegisterWaitForSingleObject; proc_wait is that registration, kept so the
+   * exit-source teardown can UnregisterWaitEx it. NULL until registered. */
+  HANDLE proc_wait;
+
+  /* Intrusive link for the readiness backend's list of the Windows-managed
+   * events it owns between subscribe and unsubscribe: the process-exit events
+   * and the peeked pipe events. NULL when the event is not on that list. */
+  asio_event_t* next;
 #endif
 } asio_event_t;
 

--- a/src/libponyrt/asio/kqueue.c
+++ b/src/libponyrt/asio/kqueue.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <signal.h>
+#include <errno.h>
 
 #if defined(PLATFORM_IS_DRAGONFLY)
 typedef u_short kevent_flag_t;
@@ -505,6 +506,16 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
             }
             break;
 
+          case EVFILT_PROC:
+            if(ev->flags & ASIO_PROC)
+            {
+              // The watched process exited. Deliver it as a read so the owner
+              // reaps, matching the shape of the Linux pidfd exit event.
+              ev->readable = true;
+              pony_asio_event_send(ev, ASIO_READ, 0);
+            }
+            break;
+
           default: {}
         }
       }
@@ -682,6 +693,7 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
 
   struct kevent event[4];
   int i = 0;
+  int proc_index = -1;
 
   kevent_flag_t flags = ev->flags & ASIO_ONESHOT ? EV_ONESHOT : EV_CLEAR;
   if(ev->flags & ASIO_READ)
@@ -710,10 +722,35 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
     i++;
   }
 
+  if(ev->flags & ASIO_PROC)
+  {
+    // Watch for the process whose pid is ev->fd to exit. One-shot: a process
+    // exits once. This is how the process package detects a child's exit on
+    // kqueue platforms, the counterpart to the pidfd read event on Linux.
+    proc_index = i;
+    EV_SET(&event[i], ev->fd, EVFILT_PROC,
+      EV_ADD | EV_RECEIPT | EV_ONESHOT, NOTE_EXIT, 0, ev);
+    i++;
+  }
+
   struct kevent results[4];
   int rc = kevent(b->kq, event, i, results, i, NULL);
 
-  if((rc == -1) || kevent_receipt_has_error(results, i))
+  if((proc_index >= 0) && (rc > proc_index) &&
+    (results[proc_index].data == ESRCH))
+  {
+    // ESRCH when adding the exit filter means the child is already gone: the
+    // kernel reports no-such-process for a pid that has begun exiting. That is
+    // the exit itself, not a failure to watch for it, so deliver it as the same
+    // read the NOTE_EXIT dispatch delivers and let the owner reap. We read the
+    // PROC receipt by its own change index, not results[0], so the check holds
+    // wherever the PROC change sits in the list. (rc == -1 is a failure of the
+    // kevent call itself and leaves results[] unwritten; rc > proc_index
+    // excludes it, and it still routes to ASIO_ERROR below.)
+    ev->readable = true;
+    pony_asio_event_send(ev, ASIO_READ, 0);
+  }
+  else if((rc == -1) || kevent_receipt_has_error(results, i))
     pony_asio_event_send(ev, ASIO_ERROR, 0);
 
   if(ev->fd == STDIN_FILENO)
@@ -806,6 +843,15 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
   {
     EV_SET(&event[i], (uintptr_t)ev, EVFILT_TIMER,
       EV_DELETE | EV_RECEIPT, 0, 0, ev);
+    i++;
+  }
+
+  if(ev->flags & ASIO_PROC)
+  {
+    // A one-shot EVFILT_PROC is auto-removed once it fires; the EV_DELETE then
+    // returns ENOENT, which EV_RECEIPT captures and we ignore, same as the
+    // other delete paths here.
+    EV_SET(&event[i], ev->fd, EVFILT_PROC, EV_DELETE | EV_RECEIPT, 0, 0, ev);
     i++;
   }
 

--- a/src/libponyrt/asio/sock_notify.c
+++ b/src/libponyrt/asio/sock_notify.c
@@ -16,6 +16,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <winsock2.h>
+#include <io.h>
 
 // The Windows asio backend uses readiness notifications via
 // `ProcessSocketNotifications` (PSN), the documented Winsock socket-state
@@ -97,6 +98,7 @@ typedef struct signal_subscribers_t {
 #define KEY_WAKEUP ((ULONG_PTR)1)  // request queue has work / stop requested
 #define KEY_STDIN  ((ULONG_PTR)2)  // stdin readiness (epoch in bytes)
 #define KEY_SIGNAL ((ULONG_PTR)3)  // a CRT signal fired (sig number in bytes)
+#define KEY_PROC   ((ULONG_PTR)4)  // a child exited; its event is in lpOverlapped
 
 // How long the wait on the port runs before a pipe on stdin is peeked again. It
 // is how late a byte on a pipe can be, and how often this thread wakes while a
@@ -114,6 +116,18 @@ struct asio_backend_t
   // KEY_STDIN packet carries the epoch it was posted in, so the loop drops a
   // packet from an old epoch. Atomic: a pool-thread console callback reads it.
   PONY_ATOMIC(uint32_t) stdin_epoch;
+
+  // The events this backend owns between subscribe and unsubscribe, linked
+  // through ev->next: process-exit events (ASIO_PROC) and peeked pipe events
+  // (ASIO_PIPE). The dispatch loop peeks the pipe events every pass and matches
+  // a KEY_PROC packet against this list before it touches the event. Only the
+  // asio thread reads or writes the list, so it needs no lock.
+  asio_event_t* managed;
+
+  // How many of the managed events are pipe events. While any pipe is listed
+  // the port wait takes the peek timeout, because a pipe carries no readiness
+  // signal to wake the port.
+  size_t pipe_count;
 };
 
 
@@ -124,7 +138,11 @@ enum // Event requests
   ASIO_SET_TIMER = 7,
   ASIO_CANCEL_TIMER = 8,
   ASIO_CANCEL_SIGNAL = 10,
-  ASIO_STDIN_UNSUBSCRIBE = 11
+  ASIO_STDIN_UNSUBSCRIBE = 11,
+  ASIO_PROC_SUBSCRIBE = 12,
+  ASIO_PROC_UNSUBSCRIBE = 13,
+  ASIO_PIPE_SUBSCRIBE = 14,
+  ASIO_PIPE_UNSUBSCRIBE = 15
 };
 
 
@@ -255,6 +273,89 @@ static void disarm_stdin(HANDLE* stdin_wait)
     UnregisterWaitEx(*stdin_wait, INVALID_HANDLE_VALUE);
     *stdin_wait = NULL;
   }
+}
+
+
+// The managed list holds the process-exit and pipe events between subscribe and
+// unsubscribe. All three helpers run only on the asio thread.
+
+static void managed_add(asio_backend_t* b, asio_event_t* ev)
+{
+  ev->next = b->managed;
+  b->managed = ev;
+
+  if(ev->flags & ASIO_PIPE)
+    b->pipe_count++;
+}
+
+// Remove ev from the list. Returns true if it was there. A second unsubscribe
+// for the same event finds it gone, so the wait is unregistered, the handle
+// closed, and the event disposed at most once.
+static bool managed_remove(asio_backend_t* b, asio_event_t* ev)
+{
+  asio_event_t** link = &b->managed;
+
+  while(*link != NULL)
+  {
+    if(*link == ev)
+    {
+      *link = ev->next;
+      ev->next = NULL;
+
+      if(ev->flags & ASIO_PIPE)
+        b->pipe_count--;
+
+      return true;
+    }
+
+    link = &(*link)->next;
+  }
+
+  return false;
+}
+
+// Is ev still a managed event? A KEY_PROC packet can name an event that was
+// unsubscribed and freed after the wait fired, so this compares pointers only
+// and never dereferences ev -- safe to call on a freed pointer.
+static bool managed_contains(asio_backend_t* b, asio_event_t* ev)
+{
+  for(asio_event_t* p = b->managed; p != NULL; p = p->next)
+  {
+    if(p == ev)
+      return true;
+  }
+
+  return false;
+}
+
+
+// Thread-pool callback for a process-exit wait. Like stdin_notify_cb it only
+// posts to the port, touching no event state, so the asio thread stays the only
+// thread that sends events. The exited event rides in lpOverlapped; the dispatch
+// loop matches it against the managed list before it touches the event.
+static void CALLBACK proc_notify_cb(void* arg, BOOLEAN timed_out)
+{
+  (void)timed_out;
+  asio_backend_t* b = ponyint_asio_get_backend();
+
+  if(b != NULL)
+    PostQueuedCompletionStatus(b->port, 0, KEY_PROC, (LPOVERLAPPED)arg);
+}
+
+
+// A pipe carries no readiness signal, so it is peeked. A peek that fails means
+// the pipe has ended, which a read returns as zero bytes; avail > 0 means there
+// is data. Either case means read this pipe now. Mirrors ponyint_stdin_pipe_ready
+// for an actor-owned pipe fd.
+static bool pipe_read_ready(asio_event_t* ev)
+{
+  HANDLE h = (HANDLE)_get_osfhandle(ev->fd);
+  DWORD avail = 0;
+
+  if(!PeekNamedPipe(h, NULL, 0, NULL, &avail, NULL))
+    return true;
+
+  return avail > 0;
 }
 
 
@@ -397,7 +498,8 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
     // waits on the port with no timeout.
     DWORD wait_ms = INFINITE;
 
-    if((stdin_event != NULL) && (stdin_kind == STDIN_PIPE) && !stdin_reading)
+    if(((stdin_event != NULL) && (stdin_kind == STDIN_PIPE) && !stdin_reading)
+      || (b->pipe_count > 0))
       wait_ms = STDIN_POLL_MS;
 
     if(!returned_idle && (wait_ms == INFINITE))
@@ -509,6 +611,26 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
           stdin_reading = true;
           pony_asio_event_send(stdin_event, ASIO_READ, 0);
         }
+
+        continue;
+      }
+      else if(key == KEY_PROC)
+      {
+        // A child exited. Its event rides in lpOverlapped. It may have been
+        // unsubscribed and freed between the wait firing and now, so match it
+        // against the managed list -- a pointer compare that never dereferences
+        // it -- and drop the packet if it is gone. Membership implies the event
+        // is still subscribed and not yet freed, because a managed event is
+        // removed from the list before it is disposed, so the send below never
+        // touches freed memory. The barrier and FIFO ordering (see
+        // ASIO_PROC_UNSUBSCRIBE) make it unlikely that a stale packet even
+        // reaches a reused address; what makes a matched stale packet harmless is
+        // idempotent handling -- a proc event re-runs its gated reap probe, a
+        // pipe event does one more non-blocking read.
+        asio_event_t* ev = (asio_event_t*)entries[i].lpOverlapped;
+
+        if(managed_contains(b, ev))
+          pony_asio_event_send(ev, ASIO_READ, 0);
 
         continue;
       }
@@ -645,6 +767,72 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
 
           ev->flags = ASIO_DISPOSABLE;
           pony_asio_event_send(ev, ASIO_DISPOSABLE, 0);
+          break;
+
+        case ASIO_PROC_SUBSCRIBE:
+        {
+          // Register a one-shot wait on the child's process handle (carried in
+          // ev->nsec). Add ev to the list first, so an unsubscribe that arrives
+          // with or before this subscribe still finds it and closes the handle.
+          managed_add(b, ev);
+
+          if(!RegisterWaitForSingleObject(&ev->proc_wait, (HANDLE)ev->nsec,
+            proc_notify_cb, ev, INFINITE, WT_EXECUTEONLYONCE))
+          {
+            // Could not register. Leave ev on the list so the matching
+            // unsubscribe still closes the handle, and report the failure so the
+            // owner tears down. Mirrors arm_stdin's failure path.
+            ev->proc_wait = NULL;
+            pony_asio_event_send(ev, ASIO_ERROR, 0);
+          }
+          break;
+        }
+
+        case ASIO_PROC_UNSUBSCRIBE:
+        {
+          // At-most-once: a second unsubscribe finds ev already gone.
+          if(!managed_remove(b, ev))
+            break;
+
+          // UnregisterWaitEx with INVALID_HANDLE_VALUE blocks until any running
+          // callback has finished and lets no further callback start. Once it
+          // returns, no callback will run again -- so the handle is safe to
+          // close below -- and any KEY_PROC the callback will ever post is
+          // already on the port. That ordering makes a stale KEY_PROC reaching a
+          // reused address unlikely; a match that does happen is caught at the
+          // KEY_PROC handler by the membership check and the idempotent send. The
+          // callback only posts to the port, so this cannot deadlock the asio
+          // thread.
+          if(ev->proc_wait != NULL)
+          {
+            UnregisterWaitEx(ev->proc_wait, INVALID_HANDLE_VALUE);
+            ev->proc_wait = NULL;
+          }
+
+          // The exit event owns the process handle's close (see
+          // ponyint_win_process_wait and the process package's exit-source
+          // teardown): close it once, now that no wait is registered on it.
+          CloseHandle((HANDLE)ev->nsec);
+
+          ev->flags = ASIO_DISPOSABLE;
+          pony_asio_event_send(ev, ASIO_DISPOSABLE, 0);
+          break;
+        }
+
+        case ASIO_PIPE_SUBSCRIBE:
+          managed_add(b, ev);
+          break;
+
+        case ASIO_PIPE_UNSUBSCRIBE:
+          // At-most-once. The backend owns the pipe fd's close: the peek reads
+          // ev->fd, so closing it on the owner thread could race a peek. Remove
+          // ev from the list first, so no further peek runs, then close.
+          if(managed_remove(b, ev))
+          {
+            _close(ev->fd);
+            ev->flags = ASIO_DISPOSABLE;
+            pony_asio_event_send(ev, ASIO_DISPOSABLE, 0);
+          }
           break;
 
         case ASIO_STDIN_RESUME:
@@ -801,6 +989,28 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
       stdin_reading = true;
       pony_asio_event_send(stdin_event, ASIO_READ, 0);
     }
+
+    // Peek the pipe events. A read pipe with data, or one that has ended, gets
+    // an ASIO_READ; a write pipe gets an ASIO_WRITE retry tick, since a Windows
+    // pipe carries no writeable signal either. The subscriber drains each read
+    // to EAGAIN, so a re-sent ASIO_READ before it drains is an idempotent no-op
+    // -- no per-pipe reading gate is needed, unlike stdin's read-once model.
+    // pony_asio_event_send does not touch the list, so iterating it is safe.
+    for(asio_event_t* ev = b->managed; ev != NULL; ev = ev->next)
+    {
+      if((ev->flags & ASIO_PIPE) == 0)
+        continue;
+
+      if(ev->flags & ASIO_READ)
+      {
+        if(pipe_read_ready(ev))
+          pony_asio_event_send(ev, ASIO_READ, 0);
+      }
+      else if(ev->flags & ASIO_WRITE)
+      {
+        pony_asio_event_send(ev, ASIO_WRITE, 0);
+      }
+    }
   }
 
   disarm_stdin(&stdin_wait);
@@ -815,6 +1025,10 @@ DECLARE_THREAD_FN(ponyint_asio_backend_dispatch)
       memory_order_acquire) == 1)
       signal(i, b->sighandlers[i].saved_action);
   }
+
+  // The managed list needs no teardown sweep here: every managed event
+  // (process-exit and pipe) is noisy, and the runtime does not stop the asio
+  // backend while any noisy event is subscribed, so the list is already empty.
 
   CloseHandle(b->port);
   ponyint_messageq_destroy(&b->q, true);
@@ -954,6 +1168,14 @@ PONY_API void pony_asio_event_subscribe(asio_event_t* ev)
       atomic_store_explicit(&subs->subscribers[slot], NULL,
         memory_order_release);
     }
+  } else if((ev->flags & ASIO_PROC) != 0) {
+    // A process-exit event. Register the wait on the asio thread so the managed
+    // list stays single-threaded. Checked before the fd == 0 branch: a proc
+    // event carries fd == 0, and ASIO_PROC is what tells it from stdin.
+    send_request(ev, ASIO_PROC_SUBSCRIBE);
+  } else if((ev->flags & ASIO_PIPE) != 0) {
+    // A peeked pipe event.
+    send_request(ev, ASIO_PIPE_SUBSCRIBE);
   } else if(ev->fd == 0) {
     // Subscribe to stdin.
     send_request(ev, ASIO_STDIN_NOTIFY);
@@ -1065,6 +1287,10 @@ PONY_API void pony_asio_event_unsubscribe(asio_event_t* ev)
       ev->flags = ASIO_DISPOSABLE;
       pony_asio_event_send(ev, ASIO_DISPOSABLE, 0);
     }
+  } else if((ev->flags & ASIO_PROC) != 0) {
+    send_request(ev, ASIO_PROC_UNSUBSCRIBE);
+  } else if((ev->flags & ASIO_PIPE) != 0) {
+    send_request(ev, ASIO_PIPE_UNSUBSCRIBE);
   } else if(ev->fd == 0) {
     // Unsubscribe from stdin. Route disposal through the request queue, like
     // the timer and signal cancels above (and like epoll and kqueue). The asio

--- a/src/libponyrt/lang/process.c
+++ b/src/libponyrt/lang/process.c
@@ -12,6 +12,33 @@ PONY_API int32_t ponyint_wnohang() {
 }
 #endif
 
+#ifdef PLATFORM_IS_LINUX
+
+#include <errno.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+// Open a pidfd for a process. A pidfd goes readable when the process exits and
+// registers with epoll like any other fd, giving exit detection that does not
+// depend on the child's pipes closing. Returns the fd, or -1 with errno set;
+// errno ENOSYS means the kernel is older than 5.3 and does not have the
+// syscall. We call the syscall directly rather than glibc's pidfd_open wrapper,
+// which only exists in glibc 2.36+; SYS_pidfd_open comes from the kernel
+// headers. If the build-time headers predate the syscall number, we report it
+// as unsupported.
+PONY_API int32_t ponyint_pidfd_open(int32_t pid) {
+#ifdef SYS_pidfd_open
+  return (int32_t)syscall(SYS_pidfd_open, (pid_t)pid, 0u);
+#else
+  // Build-time headers predate SYS_pidfd_open. Report it as unsupported; pid is
+  // unused on this path.
+  (void)pid;
+  errno = ENOSYS;
+  return -1;
+#endif
+}
+#endif
+
 #ifdef PLATFORM_IS_WINDOWS
 
 
@@ -119,44 +146,37 @@ PONY_API size_t ponyint_win_process_create(
 }
 
 /**
- * Wait for a Windows process to complete, and return its exit code.
- * This does block if the process is still running.
+ * Report a Windows child's exit status without blocking. Does not close the
+ * process handle: the asio backend registers a wait on that handle for the
+ * exit event, and the handle is closed once, later, when that wait is
+ * unregistered (see the process package's exit-source teardown). Closing it
+ * here while the wait is registered is undefined behavior.
  *
- * // https://stackoverflow.com/questions/5487249/how-write-posix-waitpid-analog-for-windows
+ * WaitForSingleObject with a zero timeout is the non-blocking poll:
+ * WAIT_OBJECT_0 means the child has exited, so a real exit code of 259 is not
+ * confused with the STILL_ACTIVE that GetExitCodeProcess returns for a running
+ * process; WAIT_TIMEOUT means it is still running.
  *
- * possible return values:
- * 0: all ok, extract the exitcode from exit_code_ptr
- * 1: process didnt finish yet
- * anything else: error waiting or getting the process exit code.
+ * Return values:
+ *   0: exited; read the exit code from exit_code_ptr.
+ *   1: still running.
+ *  -1: error waiting or reading the exit code. A fixed sentinel, never a raw
+ *      Windows error code, so an error can never collide with the 1 that means
+ *      still-running.
  */
 PONY_API int32_t ponyint_win_process_wait(size_t hProcess, int32_t* exit_code_ptr)
 {
-    int32_t retval = 0;
-
-    // just poll
-    DWORD result = WaitForSingleObject((HANDLE)hProcess, 0);
-    switch (result)
+    switch (WaitForSingleObject((HANDLE)hProcess, 0))
     {
         case WAIT_OBJECT_0: // process exited
             if (GetExitCodeProcess((HANDLE)hProcess, (DWORD*)exit_code_ptr) == 0)
-            {
-                retval = GetLastError();
-                if (retval == 0) retval = -1;
-            }
-            break;
-        case WAIT_TIMEOUT: // process is still going
-            return 1; // don't close the handle
-        case WAIT_ABANDONED: // shouldn't happen to a process
-        case WAIT_FAILED:
-            retval = GetLastError();
-            if (retval == 0) retval = -1;
-            break;
-        default:
-            break;
+                return -1;
+            return 0;
+        case WAIT_TIMEOUT: // process is still running
+            return 1;
+        default: // WAIT_ABANDONED (shouldn't happen to a process), WAIT_FAILED
+            return -1;
     }
-
-    CloseHandle((HANDLE)hProcess);
-    return retval;
 }
 
 /**

--- a/src/libponyrt/lang/process.h
+++ b/src/libponyrt/lang/process.h
@@ -22,6 +22,12 @@ PONY_API int32_t ponyint_win_process_kill(size_t hProcess);
 
 PONY_API int32_t ponyint_wnohang();
 
+#ifdef PLATFORM_IS_LINUX
+
+PONY_API int32_t ponyint_pidfd_open(int32_t pid);
+
+#endif
+
 #endif
 
 PONY_EXTERN_C_END

--- a/test/full-program-runner/_tester.pony
+++ b/test/full-program-runner/_tester.pony
@@ -94,10 +94,17 @@ actor _Tester
     _stage = _Building
     let spa = StartProcessAuth(_env.root)
     let bpa = ApplyReleaseBackpressureAuth(_env.root)
-    _build_process = ProcessMonitor(spa, bpa, _BuildProcessNotify(this),
-      ponyc_file_path, consume args, _env.vars,
-      FilePath(FileAuth(_env.root), _definition.path))
-      .>done_writing()
+    _build_process =
+      match StartProcess(spa, bpa, _BuildProcessNotify(this),
+        ponyc_file_path, consume args, _env.vars,
+        FilePath(FileAuth(_env.root), _definition.path))
+      | let pm: ProcessMonitor =>
+        pm.done_writing()
+        pm
+      | let err: ProcessError =>
+        _shutdown_failed("unable to start ponyc: " + err.string())
+        None
+      end
 
   fun _get_build_args(ponyc_file_path: FilePath): Array[String] val =>
     recover val
@@ -194,22 +201,25 @@ actor _Tester
         _stage = _Testing
         let spa = StartProcessAuth(_env.root)
         let bpa = ApplyReleaseBackpressureAuth(_env.root)
-        let process = ProcessMonitor(spa, bpa, _TestProcessNotify(this),
+        match StartProcess(spa, bpa, _TestProcessNotify(this),
           executable_file_path, args, vars,
           FilePath(FileAuth(_env.root), _definition.path))
+        | let process: ProcessMonitor =>
+          _test_process = process
 
-        _test_process = process
-
-        match _definition.stdin
-        | _StdinClose =>
-          process.done_writing()
-        | let w: _StdinWrite =>
-          _write_stdin_and_close(process, w.data)
-        | let d: _StdinDelay =>
-          let timer = Timer(_TesterStdinTimerNotify(this),
-            d.seconds * 1_000_000_000)
-          _stdin_timer = timer
-          _timers(consume timer)
+          match _definition.stdin
+          | _StdinClose =>
+            process.done_writing()
+          | let w: _StdinWrite =>
+            _write_stdin_and_close(process, w.data)
+          | let d: _StdinDelay =>
+            let timer = Timer(_TesterStdinTimerNotify(this),
+              d.seconds * 1_000_000_000)
+            _stdin_timer = timer
+            _timers(consume timer)
+          end
+        | let err: ProcessError =>
+          _shutdown_failed("unable to start test program: " + err.string())
         end
       else
         _notify.print(_definition.name,


### PR DESCRIPTION
Detect a child's exit from a native OS event instead of waiting for its output
pipes to close. Construction becomes a `StartProcess` factory that returns a
live `ProcessMonitor` or a `ProcessError`. This is the redesign worked out in
discussion #5769.

`ProcessMonitor` used "stdout and stderr both reached end-of-file" as the
signal that the child had exited. But a pipe reaches end-of-file only when
every process holding its write end has closed it, and the child is not always
the last one holding it: a grandchild that inherited stdout or stderr, or the
parent still holding the child's stdin, keeps the pipe open after the child is
gone. So `ProcessMonitor` reported the exit late, or not at all. That one wrong
assumption caused both #5764 and #5748.

Now the child's exit arrives as an OS event — a pidfd on Linux, `EVFILT_PROC`
on kqueue, and a waitable process handle on Windows — and that event is the
only signal that the child has exited. A pipe reaching end-of-file is now just
a reason to stop reading that pipe. Two related bugs go with the change: the
kill-after-reap guard is now structural (#5765), and a start that fails no
longer leaks its pipes (#5766).

Closes #5764, #5748, #5765, #5766, #5819. Design: #5769.

## What changed for callers

Starting a process now returns a result. Where you wrote:

```pony
let pm = ProcessMonitor(sp_auth, bp_auth, consume notifier, path, args, vars)
```

you now write:

```pony
match StartProcess(sp_auth, bp_auth, consume notifier, path, args, vars)
| let pm: ProcessMonitor => // a live child is running
| let err: ProcessError  => // never started; err says why
end
```

Failures that used to arrive asynchronously through `ProcessNotify.failed` — no
execute permission, a missing executable, and now a Linux kernel too old for
`pidfd_open` — are returned synchronously by `StartProcess`, and no monitor is
created for them. The `ExecveError` that meant two things (a missing file, and
`execve` failing in the child) is split: the missing-file precondition is now
`ExecutableNotFound`.
