### PR TITLE
Fix pony-lsp not working when your editor escapes characters in a file path

### DIFF
--- a/.release-notes/lsp-percent-encode-uris.md
+++ b/.release-notes/lsp-percent-encode-uris.md
@@ -1,0 +1,9 @@
+## Fix pony-lsp not working when your editor escapes characters in a file path
+
+When your editor tells a language server which file you are editing, it escapes any character that is not legal in a URI. A space is sent as `%20`, `é` as `%C3%A9`. VS Code and emacs lsp-mode also escape the colon after a Windows drive letter, sending `C:` as `C%3A`.
+
+pony-lsp did not undo that escaping. It used the escaped text as the file name, so it looked for a file whose name really did contain `%20`, found nothing, and returned an error for every request about that file. If your project path contained a space or a non-ASCII character, pony-lsp did not work on it. That was true on every platform. On Windows with VS Code, pony-lsp did not work on any project at all, because of the escaped colon after the drive letter.
+
+pony-lsp also did not escape the paths it sent back, so a path containing a space produced a location that was not a valid URI.
+
+pony-lsp now undoes the escaping in the URIs your editor sends, and escapes the paths it sends back. There is nothing you need to change.

--- a/tools/pony-lsp/percent_encoding.pony
+++ b/tools/pony-lsp/percent_encoding.pony
@@ -1,0 +1,123 @@
+primitive PercentEncoding
+  """
+  Percent-encoding for the path component of a file URI, as defined by
+  RFC 3986.
+
+  Both functions operate on bytes, so a multi-byte UTF-8 sequence encodes to
+  one escape per byte.
+  """
+
+  fun encode(s: String): String =>
+    """
+    Percent-encode every byte that may not appear literally in a URI path.
+
+    Hex digits are uppercase, which RFC 3986 section 2.1 specifies for URI
+    producers. The `/` separator is left alone, so a whole path can be passed
+    in one call.
+    """
+    var clean = true
+    for b in s.values() do
+      if not _literal(b) then
+        clean = false
+        break
+      end
+    end
+    if clean then
+      return s
+    end
+
+    let out = recover String(s.size()) end
+    for b in s.values() do
+      if _literal(b) then
+        out.push(b)
+      else
+        out.push('%')
+        out.push(_hex_digit(b >> 4))
+        out.push(_hex_digit(b and 0xF))
+      end
+    end
+    consume out
+
+  fun decode(s: String): String =>
+    """
+    Replace every `%` followed by two hex digits with the byte it denotes.
+    Hex digits of either case are accepted.
+
+    A `%` that is not followed by two hex digits is kept as it is. Clients
+    decode that way too, and a language server has nowhere to report a
+    malformed URI: the only thing left is to try the path, which fails if no
+    such file exists.
+    """
+    if not s.contains("%") then
+      return s
+    end
+
+    let out = recover String(s.size()) end
+    var i = USize(0)
+    try
+      while i < s.size() do
+        let b = s(i)?
+        if b != '%' then
+          out.push(b)
+          i = i + 1
+        else
+          match
+            if (i + 2) < s.size() then
+              (_hex_value(s(i + 1)?), _hex_value(s(i + 2)?))
+            else
+              (None, None)
+            end
+          | (let hi: U8, let lo: U8) =>
+            out.push((hi << 4) or lo)
+            i = i + 3
+          else
+            out.push('%')
+            i = i + 1
+          end
+        end
+      end
+    else
+      // Every index read above is guarded by a size check.
+      _Unreachable()
+    end
+    consume out
+
+  fun _literal(b: U8): Bool =>
+    """
+    True if `b` may appear literally in a URI path: RFC 3986 `pchar`, plus the
+    `/` that separates segments.
+    """
+    if
+      ((b >= 'A') and (b <= 'Z')) or
+      ((b >= 'a') and (b <= 'z')) or
+      ((b >= '0') and (b <= '9'))
+    then
+      true
+    else
+      match b
+      // unreserved
+      | '-' | '.' | '_' | '~'
+      // sub-delims
+      | '!' | '$' | '&' | '\'' | '(' | ')' | '*' | '+' | ',' | ';' | '='
+      // the rest of pchar
+      | ':' | '@'
+      // segment separator
+      | '/' => true
+      else
+        false
+      end
+    end
+
+  fun _hex_digit(v: U8): U8 =>
+    if v < 10 then '0' + v else 'A' + (v - 10) end
+
+  fun _hex_value(b: U8): (U8 | None) =>
+    if (b >= '0') and (b <= '9') then
+      b - '0'
+    elseif (b >= 'A') and (b <= 'F') then
+      (b - 'A') + 10
+    elseif (b >= 'a') and (b <= 'f') then
+      (b - 'a') + 10
+    else
+      None
+    end

--- a/tools/pony-lsp/test/_encoded_uri_integration_tests.pony
+++ b/tools/pony-lsp/test/_encoded_uri_integration_tests.pony
@@ -1,0 +1,109 @@
+use ".."
+use "files"
+use "json"
+use "pony_test"
+
+primitive \nodoc\ _EncodedURIIntegrationTests is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_EncodedURIRoutesToWorkspaceTest)
+
+primitive \nodoc\ _ClientSpelling
+  """
+  Spells a path the way an LSP client does, without going through `Uris`.
+
+  A test that built its URIs with `Uris.from_path` would still pass if
+  encoding and decoding were broken in matching ways, because the two would
+  cancel out. Spelling the URI here keeps the client's side independent of the
+  code under test.
+
+  The Windows spelling is VS Code's: forward slashes, and an escaped colon
+  after the drive letter.
+  """
+  fun uri(path: String): String =>
+    let s = path.clone()
+    ifdef windows then
+      s.replace("\\", "/")
+      s.replace(":", "%3A")
+    end
+    s.replace(" ", "%20")
+    let prefix = ifdef windows then "file:///" else "file://" end
+    prefix + consume s
+
+class \nodoc\ iso _EncodedURIRoutesToWorkspaceTest is UnitTest
+  """
+  A document URI carrying a percent-escape has to reach its workspace.
+
+  A client names the document with an escape. If the escape survives to_path,
+  the router matches the escaped text against no workspace path, and the
+  request comes back as an error.
+  """
+  fun name(): String => "uris/integration/encoded_uri_routes_to_workspace"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+
+    let workspace_dir =
+      Path.join(Path.dir(__loc.file()), "workspace with space")
+    let workspace_uri = _ClientSpelling.uri(workspace_dir)
+    let document_uri =
+      _ClientSpelling.uri(Path.join(workspace_dir, "main.pony"))
+
+    // A fixture path with no space would leave nothing for to_path to decode.
+    h.assert_true(
+      workspace_uri.contains("%20"),
+      "expected an escaped workspace URI, got " + workspace_uri)
+    ifdef windows then
+      h.assert_true(
+        workspace_uri.contains("%3A"),
+        "expected an escaped drive colon, got " + workspace_uri)
+    end
+    // _ClientSpelling escapes a space and a drive colon and nothing else, so a
+    // checkout path holding a '%' would spell a URI for a different directory.
+    h.assert_false(
+      workspace_dir.contains("%"),
+      "checkout path needs escaping this test does not do: " + workspace_dir)
+
+    let harness =
+      TestHarness.create(
+        h,
+        TestCompiler(h),
+        object iso is MessageHandler
+          var _seen: USize = 0
+
+          fun ref handle_response(
+            h: TestHelper,
+            res: ResponseMessage val,
+            server: BaseProtocol)
+          =>
+            _seen = _seen + 1
+            if _seen == 1 then
+              // The initialize response.
+              server(LspMsg.initialized())
+              server(
+                RequestMessage(
+                  I64(300),
+                  Methods.text_document().document_symbol(),
+                  JsonObject.update(
+                    "textDocument",
+                    JsonObject.update("uri", document_uri)))
+                .into_bytes())
+            elseif _seen == 2 then
+              match \exhaustive\ res.err
+              | let e: ResponseError val =>
+                h.fail("no workspace matched the document URI: " + e.message)
+              | None =>
+                None
+              end
+              h.complete(true)
+            end
+        end,
+        {(h: TestHelper, harness: TestHarness ref): Bool => true }
+        where
+          after_sends = USize.max_value(),
+          after_logs = USize.max_value()
+      )
+    harness.send_to_server(
+      LspMsg.initialize(workspace_dir where uri = workspace_uri))

--- a/tools/pony-lsp/test/_percent_encoding_tests.pony
+++ b/tools/pony-lsp/test/_percent_encoding_tests.pony
@@ -1,0 +1,154 @@
+use "pony_check"
+use "pony_test"
+use ".."
+
+primitive \nodoc\ _PercentEncodingTests is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_PercentEncodingEncodeTest)
+    test(_PercentEncodingEncodeLiteralTest)
+    test(_PercentEncodingEncodeBoundaryTest)
+    test(_PercentEncodingEncodeHexCaseTest)
+    test(_PercentEncodingDecodeTest)
+    test(_PercentEncodingDecodeHexCaseTest)
+    test(_PercentEncodingDecodeMalformedTest)
+    test(_PercentEncodingRoundTripTest)
+    test(_PercentEncodingRoundTripPropertyTest)
+
+class \nodoc\ iso _PercentEncodingEncodeTest is UnitTest
+  fun name(): String => "percent_encoding/encode"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("a%20b", PercentEncoding.encode("a b"))
+    // A literal percent must encode, or a decoding reader would read the
+    // bytes after it as an escape.
+    h.assert_eq[String]("100%25", PercentEncoding.encode("100%"))
+    // '#' and '?' would otherwise start a fragment or a query.
+    h.assert_eq[String]("c%231", PercentEncoding.encode("c#1"))
+    h.assert_eq[String]("c%3F1", PercentEncoding.encode("c?1"))
+    h.assert_eq[String]("%5Bx%5D", PercentEncoding.encode("[x]"))
+    // One escape per byte of a multi-byte UTF-8 sequence.
+    h.assert_eq[String]("caf%C3%A9", PercentEncoding.encode("café"))
+    h.assert_eq[String]("", PercentEncoding.encode(""))
+
+class \nodoc\ iso _PercentEncodingEncodeLiteralTest is UnitTest
+  """
+  RFC 3986 pchar, plus the '/' separator, survives encoding unchanged.
+  """
+  fun name(): String => "percent_encoding/encode/literal"
+
+  fun apply(h: TestHelper) =>
+    let unreserved = "azAZ09-._~"
+    h.assert_eq[String](unreserved, PercentEncoding.encode(unreserved))
+    let sub_delims = "!$&'()*+,;="
+    h.assert_eq[String](sub_delims, PercentEncoding.encode(sub_delims))
+    h.assert_eq[String](":@", PercentEncoding.encode(":@"))
+    h.assert_eq[String]("/a/b/c", PercentEncoding.encode("/a/b/c"))
+
+class \nodoc\ iso _PercentEncodingEncodeBoundaryTest is UnitTest
+  """
+  The bytes just outside each literal range encode.
+
+  A round trip cannot pin these: drop a byte from the literal set and encode
+  emits an escape that decode turns straight back, so the pair still agrees.
+  """
+  fun name(): String => "percent_encoding/encode/boundary"
+
+  fun apply(h: TestHelper) =>
+    // '`' is 'a' - 1 and '{' is 'z' + 1
+    h.assert_eq[String]("%60%7B", PercentEncoding.encode("`{"))
+    // '@' is 'A' - 1 and '[' is 'Z' + 1; '@' is pchar, '[' is not
+    h.assert_eq[String]("@%5B", PercentEncoding.encode("@["))
+    // '/' is '0' - 1 and ':' is '9' + 1; both are pchar
+    h.assert_eq[String]("/:", PercentEncoding.encode("/:"))
+
+class \nodoc\ iso _PercentEncodingEncodeHexCaseTest is UnitTest
+  """
+  RFC 3986 section 2.1 specifies uppercase hex digits for URI producers.
+  """
+  fun name(): String => "percent_encoding/encode/hex_case"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("%5B", PercentEncoding.encode("["))
+    h.assert_eq[String]("%7C", PercentEncoding.encode("|"))
+    h.assert_eq[String]("%C3%A9", PercentEncoding.encode("é"))
+
+class \nodoc\ iso _PercentEncodingDecodeTest is UnitTest
+  fun name(): String => "percent_encoding/decode"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("a b", PercentEncoding.decode("a%20b"))
+    h.assert_eq[String]("100%", PercentEncoding.decode("100%25"))
+    h.assert_eq[String]("c#1", PercentEncoding.decode("c%231"))
+    h.assert_eq[String]("café", PercentEncoding.decode("caf%C3%A9"))
+    h.assert_eq[String]("/a/b", PercentEncoding.decode("%2Fa%2Fb"))
+    h.assert_eq[String]("", PercentEncoding.decode(""))
+    h.assert_eq[String]("nothing", PercentEncoding.decode("nothing"))
+
+class \nodoc\ iso _PercentEncodingDecodeHexCaseTest is UnitTest
+  """
+  Neovim emits lowercase hex digits, so both cases have to decode.
+  """
+  fun name(): String => "percent_encoding/decode/hex_case"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("café", PercentEncoding.decode("caf%c3%a9"))
+    h.assert_eq[String]("[x]", PercentEncoding.decode("%5bx%5d"))
+    h.assert_eq[String]("<>", PercentEncoding.decode("%3c%3E"))
+    // 'f' is the top of the lowercase range, and 'e' its neighbour.
+    h.assert_eq[String]("ÿ", PercentEncoding.decode("%c3%bf"))
+    h.assert_eq[String]("î", PercentEncoding.decode("%c3%ae"))
+
+class \nodoc\ iso _PercentEncodingDecodeMalformedTest is UnitTest
+  """
+  A '%' that does not introduce two hex digits stands for itself.
+  """
+  fun name(): String => "percent_encoding/decode/malformed"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("%ZZ", PercentEncoding.decode("%ZZ"))
+    h.assert_eq[String]("%", PercentEncoding.decode("%"))
+    h.assert_eq[String]("a%", PercentEncoding.decode("a%"))
+    h.assert_eq[String]("%A", PercentEncoding.decode("%A"))
+    h.assert_eq[String]("%2", PercentEncoding.decode("%2"))
+    h.assert_eq[String]("%G0", PercentEncoding.decode("%G0"))
+    // The first '%' is literal; the second introduces a real escape.
+    h.assert_eq[String]("% ", PercentEncoding.decode("%%20"))
+
+class \nodoc\ iso _PercentEncodingRoundTripTest is UnitTest
+  fun name(): String => "percent_encoding/round_trip"
+
+  fun apply(h: TestHelper) =>
+    let cases =
+      [ "a b"; "100%"; "50%20off"; "café"; "c#1"; "/a/b"; ""
+        "!$&'()*+,;=:@"; "%%%"; "a\nb" ]
+    for s in cases.values() do
+      h.assert_eq[String](
+        s,
+        PercentEncoding.decode(PercentEncoding.encode(s)),
+        "round trip of " + s)
+    end
+
+class \nodoc\ iso _PercentEncodingRoundTripPropertyTest is UnitTest
+  """
+  decode undoes encode for any string of bytes.
+
+  The codec takes bytes rather than a path, so this needs no constraints on
+  what it generates. It reaches the high half of the byte range, which the
+  worked examples reach only through the two bytes of "é".
+  """
+  fun name(): String => "percent_encoding/round_trip/property"
+
+  fun apply(h: TestHelper) ? =>
+    PonyCheck.for_all[String](
+      recover val
+        Generators.byte_string(Generators.u8(1, 255), 0, 30)
+      end,
+      h)(
+      {(s: String, ph: PropertyHelper) =>
+        ph.assert_eq[String](
+          s,
+          PercentEncoding.decode(PercentEncoding.encode(s)))
+      })?

--- a/tools/pony-lsp/test/_uris_tests.pony
+++ b/tools/pony-lsp/test/_uris_tests.pony
@@ -1,3 +1,4 @@
+use "pony_check"
 use "pony_test"
 use ".."
 
@@ -8,8 +9,12 @@ primitive _URITests is TestList
   fun tag tests(test: PonyTest) =>
     test(_URIToPathTest)
     test(_URIToPathNoSchemeTest)
+    test(_URIToPathDecodeTest)
     test(_URIFromPathTest)
+    test(_URIFromPathEncodeTest)
     test(_URIFromPathAlreadyURITest)
+    test(_URIRoundTripTest)
+    test(_URIRoundTripPropertyTest)
 
 class \nodoc\ iso _URIToPathTest is UnitTest
   fun name(): String => "uris/to_path"
@@ -31,8 +36,8 @@ class \nodoc\ iso _URIToPathTest is UnitTest
 
 class \nodoc\ iso _URIToPathNoSchemeTest is UnitTest
   """
-  When no "://" separator is present, split_by returns the whole string
-  as a single element and to_path returns it unchanged.
+  A string with no "://" is returned unchanged. Unchanged means undecoded: a
+  path is bytes, so a '%' in one is part of a filename.
   """
   fun name(): String => "uris/to_path/no_scheme"
 
@@ -41,10 +46,60 @@ class \nodoc\ iso _URIToPathNoSchemeTest is UnitTest
       h.assert_eq[String](
         "C:\\foo\\bar.pony",
         Uris.to_path("C:\\foo\\bar.pony"))
+      h.assert_eq[String](
+        "C:\\foo\\50%20off.pony",
+        Uris.to_path("C:\\foo\\50%20off.pony"))
     else
       h.assert_eq[String](
         "/foo/bar.pony",
         Uris.to_path("/foo/bar.pony"))
+      h.assert_eq[String](
+        "/foo/50%20off.pony",
+        Uris.to_path("/foo/50%20off.pony"))
+    end
+
+class \nodoc\ iso _URIToPathDecodeTest is UnitTest
+  """
+  Clients percent-encode the URIs they send. VS Code and emacs lsp-mode also
+  encode the drive colon, so decoding has to run before the drive-letter check.
+  """
+  fun name(): String => "uris/to_path/decode"
+
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.assert_eq[String](
+        "c:\\Users\\sean\\x.pony",
+        Uris.to_path("file:///c%3A/Users/sean/x.pony"))
+      h.assert_eq[String](
+        "C:\\project\\readme.md",
+        Uris.to_path("file:///C%3A/project/readme.md"))
+      // Neovim emits lowercase hex.
+      h.assert_eq[String](
+        "c:\\Users\\sean\\x.pony",
+        Uris.to_path("file:///c%3a/Users/sean/x.pony"))
+      h.assert_eq[String](
+        "C:\\my project\\x.pony",
+        Uris.to_path("file:///C:/my%20project/x.pony"))
+    else
+      h.assert_eq[String](
+        "/home/sean/my project/x.pony",
+        Uris.to_path("file:///home/sean/my%20project/x.pony"))
+      h.assert_eq[String](
+        "/home/sean/café/x.pony",
+        Uris.to_path("file:///home/sean/caf%C3%A9/x.pony"))
+      // Neovim emits lowercase hex.
+      h.assert_eq[String](
+        "/home/sean/café/x.pony",
+        Uris.to_path("file:///home/sean/caf%c3%a9/x.pony"))
+      h.assert_eq[String](
+        "/a/100%.pony",
+        Uris.to_path("file:///a/100%25.pony"))
+      h.assert_eq[String](
+        "/a/c#1.pony",
+        Uris.to_path("file:///a/c%231.pony"))
+      h.assert_eq[String](
+        "/a/%ZZ.pony",
+        Uris.to_path("file:///a/%ZZ.pony"))
     end
 
 class \nodoc\ iso _URIFromPathTest is UnitTest
@@ -61,10 +116,111 @@ class \nodoc\ iso _URIFromPathTest is UnitTest
         Uris.from_path("/foo/bar.pony"))
     end
 
+class \nodoc\ iso _URIFromPathEncodeTest is UnitTest
+  """
+  A raw space is not a legal URI at all, and a raw '#' would be read back as
+  the start of a fragment, naming a different file.
+  """
+  fun name(): String => "uris/from_path/encode"
+
+  fun apply(h: TestHelper) =>
+    ifdef windows then
+      h.assert_eq[String](
+        "file:///C:/my%20project/x.pony",
+        Uris.from_path("C:\\my project\\x.pony"))
+      h.assert_eq[String](
+        "file:///C:/a/100%25.pony",
+        Uris.from_path("C:\\a\\100%.pony"))
+    else
+      h.assert_eq[String](
+        "file:///home/sean/my%20project/x.pony",
+        Uris.from_path("/home/sean/my project/x.pony"))
+      h.assert_eq[String](
+        "file:///home/sean/caf%C3%A9/x.pony",
+        Uris.from_path("/home/sean/café/x.pony"))
+      h.assert_eq[String](
+        "file:///a/100%25.pony",
+        Uris.from_path("/a/100%.pony"))
+      h.assert_eq[String](
+        "file:///a/c%231.pony",
+        Uris.from_path("/a/c#1.pony"))
+      // pchar stays literal, so these keep the spelling clients already send.
+      h.assert_eq[String](
+        "file:///a/b,c+d.pony",
+        Uris.from_path("/a/b,c+d.pony"))
+    end
+
 class \nodoc\ iso _URIFromPathAlreadyURITest is UnitTest
+  """
+  A string that is already a URI passes through, escapes and all, rather than
+  having its '%' encoded a second time.
+  """
   fun name(): String => "uris/from_path/already_uri"
 
   fun apply(h: TestHelper) =>
     h.assert_eq[String](
       "file:///foo/bar.pony",
       Uris.from_path("file:///foo/bar.pony"))
+    h.assert_eq[String](
+      "file:///a%20b.pony",
+      Uris.from_path("file:///a%20b.pony"))
+
+class \nodoc\ iso _URIRoundTripTest is UnitTest
+  """
+  Diagnostic.from_error turns a compiler path into a URI with from_path and
+  WorkspaceManager turns it back with to_path, so the pair has to be lossless.
+  A file named "50%20off.pony" comes back as "50 off.pony" if the encode side
+  does not escape '%'.
+  """
+  fun name(): String => "uris/round_trip"
+
+  fun apply(h: TestHelper) =>
+    let cases =
+      ifdef windows then
+        [ "C:\\a\\my project\\x.pony"; "C:\\a\\100%.pony"
+          "C:\\a\\50%20off.pony"; "C:\\a\\café.pony"; "C:\\a\\c#1.pony" ]
+      else
+        [ "/a/my project/x.pony"; "/a/100%.pony"; "/a/50%20off.pony"
+          "/a/café.pony"; "/a/c#1.pony"; "/a/b,c+d.pony" ]
+      end
+    for path in cases.values() do
+      h.assert_eq[String](
+        path,
+        Uris.to_path(Uris.from_path(path)),
+        "round trip of " + path)
+    end
+
+class \nodoc\ iso _URIRoundTripPropertyTest is UnitTest
+  """
+  to_path undoes from_path for any single-segment absolute path.
+
+  '/' is removed from the generated segment on both platforms: on Windows it
+  comes back as a separator, and on either platform a segment holding "://"
+  makes from_path treat the path as a URI already. '\' is removed only on
+  Windows, where it is a separator; on Linux it is an ordinary filename byte
+  and encodes to %5C. Windows needs the drive letter, since from_path only
+  produces a round-trippable URI for a drive-letter path.
+  """
+  fun name(): String => "uris/round_trip/property"
+
+  fun apply(h: TestHelper) ? =>
+    PonyCheck.for_all[String](
+      recover val
+        Generators.ascii(where min = 0, max = 30, range = ASCIIPrintable)
+      end,
+      h)(
+      {(segment: String, ph: PropertyHelper) =>
+        let cleaned = segment.clone()
+        cleaned.remove("/")
+        ifdef windows then
+          cleaned.remove("\\")
+        end
+        let safe: String val = consume cleaned
+        let path: String val =
+          ifdef windows then
+            "C:\\tmp\\" + safe
+          else
+            "/tmp/" + safe
+          end
+        ph.assert_eq[String](path, Uris.to_path(Uris.from_path(path)))
+      })?

--- a/tools/pony-lsp/test/_workspace_tests.pony
+++ b/tools/pony-lsp/test/_workspace_tests.pony
@@ -25,7 +25,7 @@ class \nodoc\ iso _RouterFindTest is UnitTest
     let channel = FakeChannel
     let scanner = WorkspaceScanner.create(channel)
     let workspaces = scanner.scan(file_auth, this_dir_path)
-    h.assert_eq[USize](3, workspaces.size())
+    h.assert_eq[USize](4, workspaces.size())
 
     // Verify all expected workspaces were found
     // (order is not guaranteed because path.walk
@@ -39,6 +39,7 @@ class \nodoc\ iso _RouterFindTest is UnitTest
         folder.path
         folder.join("error_workspace")?.path
         folder.join("workspace")?.path
+        folder.join("workspace with space")?.path
       ]
     h.assert_array_eq_unordered[String](expected, actual)
 

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -24,6 +24,8 @@ actor Main is TestList
     _WorkspaceTests.make().tests(test)
     _InlayHintSourceTests.make().tests(test)
     _URITests.make().tests(test)
+    _PercentEncodingTests.make().tests(test)
+    _EncodedURIIntegrationTests.make().tests(test)
     _SymbolKindsTests.make().tests(test)
     _HoverFormatterTests.make().tests(test)
     _DiagnosticTests.make().tests(test)

--- a/tools/pony-lsp/test/message_handler.pony
+++ b/tools/pony-lsp/test/message_handler.pony
@@ -228,10 +228,17 @@ primitive LspMsg
     dir: String,
     did_change_configuration_dynamic_registration:
       Bool = true,
-    supports_configuration: Bool = true
+    supports_configuration: Bool = true,
+    uri: (String | None) = None
   ): Array[U8] iso^ =>
     let safe_dir = _json_escape(dir)
-    let dir_uri = Uris.from_path(dir)
+    let dir_uri =
+      _json_escape(
+        match uri
+        | let u: String => u
+        else
+          Uris.from_path(dir)
+        end)
     this.apply("""
     {
       "jsonrpc": "2.0",

--- a/tools/pony-lsp/test/workspace with space/corral.json
+++ b/tools/pony-lsp/test/workspace with space/corral.json
@@ -1,0 +1,12 @@
+{
+  "packages": [],
+  "deps": [],
+  "info": {
+    "description": "A pony-lsp test workspace whose path needs percent-encoding",
+    "homepage": "",
+    "license": "",
+    "documentation_url": "",
+    "version": "0.1.0",
+    "name": "lsp-test-space"
+  }
+}

--- a/tools/pony-lsp/test/workspace with space/main.pony
+++ b/tools/pony-lsp/test/workspace with space/main.pony
@@ -1,0 +1,3 @@
+actor Main
+  new create(env: Env) =>
+    None

--- a/tools/pony-lsp/test/workspace with space/workspace with space.pony
+++ b/tools/pony-lsp/test/workspace with space/workspace with space.pony
@@ -1,0 +1,4 @@
+"""
+Workspace fixture whose directory name contains a space, so that a client's
+URI for it carries a percent-escape.
+"""

--- a/tools/pony-lsp/uris.pony
+++ b/tools/pony-lsp/uris.pony
@@ -9,19 +9,29 @@ primitive Uris
   fun to_path(uri: String): String =>
     """
     Convert an LSP document URI to a local filesystem path by stripping the
-    scheme. On Windows, also strips the leading `/` before a drive letter
-    (e.g., `/D:/path` becomes `D:/path`) and normalises forward slashes to
-    the native separator.
+    scheme and percent-decoding what is left. On Windows, also strips the
+    leading `/` before a drive letter (e.g., `/D:/path` becomes `D:/path`) and
+    normalises forward slashes to the native separator.
+
+    A string with no `://` is taken to be a path already and is returned
+    without decoding: a `%` in a path is part of the filename.
     """
     let result = uri.split_by("://", 2)
     let path =
-      try
-        result(result.size() - 1)?
+      if result.size() > 1 then
+        try
+          PercentEncoding.decode(result(1)?)
+        else
+          // split_by returned more than one part, so index 1 exists.
+          _Unreachable()
+          uri
+        end
       else
         uri
       end
     ifdef windows then
-      // file:///D:/path -> /D:/path after stripping scheme; remove leading /
+      // file:///D:/path and file:///D%3A/path both reach here as /D:/path,
+      // the scheme stripped and the path decoded; remove the leading /
       let trimmed =
         try
           if (path.size() >= 3) and (path(0)? == '/') and (path(2)? == ':') then
@@ -41,9 +51,12 @@ primitive Uris
 
   fun from_path(path: String): String =>
     """
-    Convert a local filesystem path to an LSP file URI. On Windows, normalises
-    backslashes to forward slashes and uses the `file:///` prefix required for
-    drive-letter paths.
+    Convert a local filesystem path to an LSP file URI, percent-encoding the
+    path. On Windows, normalises backslashes to forward slashes and uses the
+    `file:///` prefix required for drive-letter paths.
+
+    A string that is already a URI is returned as it is, so that its escapes
+    are not encoded a second time.
     """
     if path.contains("://") then
       path
@@ -51,8 +64,8 @@ primitive Uris
       ifdef windows then
         let s = path.clone()
         s.replace("\\", "/")
-        "file:///" + consume s
+        "file:///" + PercentEncoding.encode(consume s)
       else
-        "file://" + path
+        "file://" + PercentEncoding.encode(path)
       end
     end


### PR DESCRIPTION
`Uris.to_path` never percent-decoded and `Uris.from_path` never percent-encoded. Running the real code on Linux, `to_path("file:///home/sean/my%20project/x.pony")` returns `/home/sean/my%20project/x.pony`, a file that does not exist, and `from_path("/home/sean/my project/x.pony")` returns `file:///home/sean/my project/x.pony`, which has a raw space in it and is not a legal URI. This is not Windows-only. Any client sending a path with a space or a non-ASCII character was already broken on every platform. The Windows drive colon is just the case you cannot miss.

A new `PercentEncoding` primitive supplies `encode` and `decode`. It is public, matching the existing `InlayHintSource` precedent in the same tool: a pure helper, unit-tested directly from the test package. `to_path` decodes after stripping the scheme and before the drive-letter check. That ordering is the fix for the Windows case: the check reads index 2 for a colon, and with `%3A` sitting there, index 2 is `%`. `from_path` encodes after the separator swap, before prepending the scheme.

Both functions had to change together. `Diagnostic.from_error` turns a compiler-reported path into a URI with `from_path`, and `WorkspaceManager` turns it straight back with `to_path`, so that round trip has to be lossless. If `to_path` decoded while `from_path` left `%` alone, a file genuinely named `50%20off.pony` would resolve to `50 off.pony`, a different file. `%` to `%25` is required, not optional.

The encode set is RFC 3986 `pchar` plus `/`, and that was a real choice. I ran the four clients' actual encoders to get their raw sets, and they split 2-2: vscode-uri and emacs lsp-mode leave only unreserved characters raw; Neovim and Helix leave all of `pchar` raw. The drive colon follows from that split, because `:` is a `pchar`: vscode-uri and emacs lsp-mode escape it as `%3A`, and Neovim and Helix send it literal. No set matches all four, because under RFC 3986 §2.2, `file:///a,b` and `file:///a%2Cb` are formally different URIs, though both are valid and name the same file. I picked `pchar` because it is the smaller change, not because it is more correct: it escapes exactly what RFC 3986 does not allow raw and nothing else, so every character that works today keeps working and only the currently-broken ones change.

Decoding is lenient: a `%` not followed by two hex digits stands for itself. All four clients decode that way, but the deciding reason is that there is no recipient for the error. LSP has nowhere for a server to report a malformed URI on a notification, so the only thing left is to try the path and use what the filesystem returns. `to_path` decodes only when a scheme is present. It also accepts a bare path, pinned by an existing test, and decoding one would turn a real file named `50%20off.pony` into `50 off.pony`.

`_uris_tests.pony` had no `%` in it anywhere before this. There are now unit tests for both directions, a PonyCheck round-trip property, and an end-to-end integration test with a workspace directory whose name contains a space. The integration test's URIs are written the way a client sends them rather than built by calling `Uris.from_path`; built with `from_path`, an encode side and a decode side broken in matching ways cancel out and the test passes anyway. With the fix reverted, that test fails with `No workspace found for '{"method":"textDocument/documentSymbol"...}'`, the same error reported in ponylang/vscode-extension#29. I broke the code in each dimension of the change and confirmed that every new test fails under at least one of those breaks. I have not run the integration test's Windows spelling on this machine: its Windows behavior is reasoned from the code, and the `Tools: Windows` CI job, which runs this suite on every PR, is what exercises it.

Drive-letter casing is not addressed here, and that is the open question I want reviewed rather than a call I have made. The issue's suggested-fix paragraph says handling it "belongs in the fix." What it would be is normalizing the drive letter's case in `to_path`. It would cover the `WorkspaceRouter.workspaces` map, because both sides of that map do flow through `to_path`: the lookup at `workspace_router.pony:18`, and the key, `folder.canonical()?.path`, whose folder traces back to `scan(auth, Uris.to_path(uri), name)` at `language_server.pony:449`. It would not cover `WorkspaceManager._packages`, keyed at `workspace_manager.pony:164` from `package.path`, which comes from the compiler and never passes through `to_path`. Normalizing in `to_path` changes only one side of that comparison, so it could break a pair that matches today. `state.pony:102` already carries `// TODO: ensure both module and package-state paths are normalised`, and `FilePath.canonical()` is not a normalization point: on Windows it reaches `GetFullPathName`, which passes the drive letter through verbatim. Whether it goes in this PR anyway is what I want a reviewer to decide.

I also did not echo the client's URI back byte-for-byte. That is the right end state for outgoing URIs (store the exact string from `didOpen` and reuse it, generating a URI only for files the client never opened), and it would make the encode-set choice above moot for nearly all traffic. It is an architectural change across 8 call sites plus `DocumentState`, and fixing this bug does not need it.

Closes #5774
