### PR TITLE
Fix pony-lsp not working when your editor sends your project's location as a URI

### DIFF
--- a/.release-notes/lsp-root-uri-workspace-detection.md
+++ b/.release-notes/lsp-root-uri-workspace-detection.md
@@ -1,0 +1,11 @@
+## Fix pony-lsp not working when your editor sends your project's location as a URI
+
+When your editor starts a language server, it tells the server where your project is. Some editors send a list of folders. Others send a single location instead, either as a plain path like `/home/you/myproject` or as a URI like `file:///home/you/myproject`.
+
+pony-lsp read that single location as a plain path in both cases. When an editor sent a URI, pony-lsp searched for a directory whose name really did start with `file://`, found nothing, and registered no project at all. Every request about your code returned an error, so hover, go to definition, find references, and rename all did nothing.
+
+vim-lsp sends a URI in its default configuration, so pony-lsp did not work there on a stock setup. Kate sends one when you have configured a project root. If your editor sends a folder list with your project in it, as VS Code does, pony-lsp already worked.
+
+pony-lsp now accepts a project location in either form. There is nothing you need to change.
+
+One case is not covered by this fix: an editor that sends an empty folder list alongside a project location still finds no project. Kate does this when you have not configured a project root.

--- a/tools/pony-lsp/language_server.pony
+++ b/tools/pony-lsp/language_server.pony
@@ -423,7 +423,7 @@ actor LanguageServer is (Notifier & RequestSender)
           this._channel.log(
             "Scanning workspace " + workspace_str)
           let pony_workspaces =
-            scanner.scan(this._file_auth, workspace_str)
+            scanner.scan(this._file_auth, Uris.to_path(workspace_str))
           for pony_workspace in pony_workspaces.values() do
             let mgr =
               WorkspaceManager.create(

--- a/tools/pony-lsp/test/_client_spelling.pony
+++ b/tools/pony-lsp/test/_client_spelling.pony
@@ -1,0 +1,21 @@
+primitive \nodoc\ _ClientSpelling
+  """
+  Spells a path the way an LSP client does, without going through `Uris`.
+
+  A test that built its URIs with `Uris.from_path` would still pass if
+  encoding and decoding were broken in matching ways, because the two would
+  cancel out. Spelling the URI here keeps the client's side independent of the
+  code under test.
+
+  The Windows spelling is VS Code's: forward slashes, and an escaped colon
+  after the drive letter.
+  """
+  fun uri(path: String): String =>
+    let s = path.clone()
+    ifdef windows then
+      s.replace("\\", "/")
+      s.replace(":", "%3A")
+    end
+    s.replace(" ", "%20")
+    let prefix = ifdef windows then "file:///" else "file://" end
+    prefix + consume s

--- a/tools/pony-lsp/test/_encoded_uri_integration_tests.pony
+++ b/tools/pony-lsp/test/_encoded_uri_integration_tests.pony
@@ -10,28 +10,6 @@ primitive \nodoc\ _EncodedURIIntegrationTests is TestList
   fun tag tests(test: PonyTest) =>
     test(_EncodedURIRoutesToWorkspaceTest)
 
-primitive \nodoc\ _ClientSpelling
-  """
-  Spells a path the way an LSP client does, without going through `Uris`.
-
-  A test that built its URIs with `Uris.from_path` would still pass if
-  encoding and decoding were broken in matching ways, because the two would
-  cancel out. Spelling the URI here keeps the client's side independent of the
-  code under test.
-
-  The Windows spelling is VS Code's: forward slashes, and an escaped colon
-  after the drive letter.
-  """
-  fun uri(path: String): String =>
-    let s = path.clone()
-    ifdef windows then
-      s.replace("\\", "/")
-      s.replace(":", "%3A")
-    end
-    s.replace(" ", "%20")
-    let prefix = ifdef windows then "file:///" else "file://" end
-    prefix + consume s
-
 class \nodoc\ iso _EncodedURIRoutesToWorkspaceTest is UnitTest
   """
   A document URI carrying a percent-escape has to reach its workspace.

--- a/tools/pony-lsp/test/_root_uri_integration_tests.pony
+++ b/tools/pony-lsp/test/_root_uri_integration_tests.pony
@@ -1,0 +1,167 @@
+use ".."
+use "files"
+use "json"
+use "pony_test"
+
+primitive \nodoc\ _RootURIIntegrationTests is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_RootURIRoutesToWorkspaceTest)
+    test(_RootPathRoutesToWorkspaceTest)
+
+class \nodoc\ iso _RootURIRoutesToWorkspaceTest is UnitTest
+  """
+  A client that names the workspace with rootUri and sends no workspaceFolders
+  has to reach its workspace.
+
+  The initialize params carry the workspace location under one of three keys.
+  Only workspaceFolders holds an array; rootUri and rootPath are both strings,
+  and rootUri is a URI. A URI reaching the scanner without conversion names no
+  directory, so no workspace registers and every document request comes back
+  as an error.
+  """
+  fun name(): String => "uris/integration/root_uri_routes_to_workspace"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let workspace_uri = _ClientSpelling.uri(workspace_dir)
+    let document_uri =
+      _ClientSpelling.uri(Path.join(workspace_dir, "main.pony"))
+
+    // A URI with no scheme would leave nothing for to_path to strip.
+    h.assert_true(
+      workspace_uri.contains("://"),
+      "expected a URI with a scheme, got " + workspace_uri)
+    // _ClientSpelling escapes a space and a drive colon and nothing else, so a
+    // checkout path holding a '%' would spell a URI for a different directory.
+    h.assert_false(
+      workspace_dir.contains("%"),
+      "checkout path needs escaping this test does not do: " + workspace_dir)
+
+    let harness =
+      TestHarness.create(
+        h,
+        TestCompiler(h),
+        object iso is MessageHandler
+          var _seen: USize = 0
+
+          fun ref handle_response(
+            h: TestHelper,
+            res: ResponseMessage val,
+            server: BaseProtocol)
+          =>
+            _seen = _seen + 1
+            if _seen == 1 then
+              // The initialize response.
+              server(LspMsg.initialized())
+              server(
+                RequestMessage(
+                  I64(400),
+                  Methods.text_document().document_symbol(),
+                  JsonObject.update(
+                    "textDocument",
+                    JsonObject.update("uri", document_uri)))
+                .into_bytes())
+            elseif _seen == 2 then
+              match \exhaustive\ res.err
+              | let e: ResponseError val =>
+                h.fail("no workspace matched the document URI: " + e.message)
+              | None =>
+                None
+              end
+              h.complete(true)
+            end
+        end,
+        {(h: TestHelper, harness: TestHarness ref): Bool => true }
+        where
+          after_sends = USize.max_value(),
+          after_logs = USize.max_value()
+      )
+    // vim-lsp's default configuration: rootUri and rootPath, no
+    // workspaceFolders. The extraction prefers rootUri over rootPath, so the
+    // URI is what reaches the scanner.
+    harness.send_to_server(
+      LspMsg.initialize(
+        workspace_dir
+        where
+          uri = workspace_uri,
+          send_workspace_folders = false))
+
+class \nodoc\ iso _RootPathRoutesToWorkspaceTest is UnitTest
+  """
+  A client that names the workspace with rootPath alone has to reach its
+  workspace.
+
+  rootPath is a path, not a URI, and it reaches the scanner through the same
+  conversion as rootUri. This test fails if that conversion stops passing a
+  plain path through.
+  """
+  fun name(): String => "uris/integration/root_path_routes_to_workspace"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(10_000_000_000)
+
+    let workspace_dir = Path.join(Path.dir(__loc.file()), "workspace")
+    let document_uri =
+      _ClientSpelling.uri(Path.join(workspace_dir, "main.pony"))
+
+    // A workspace path holding a scheme separator would not survive the
+    // conversion this test covers.
+    h.assert_false(
+      workspace_dir.contains("://"),
+      "checkout path contains a scheme separator: " + workspace_dir)
+    // _ClientSpelling escapes a space and a drive colon and nothing else, so a
+    // checkout path holding a '%' would spell a URI for a different directory.
+    h.assert_false(
+      workspace_dir.contains("%"),
+      "checkout path needs escaping this test does not do: " + workspace_dir)
+
+    let harness =
+      TestHarness.create(
+        h,
+        TestCompiler(h),
+        object iso is MessageHandler
+          var _seen: USize = 0
+
+          fun ref handle_response(
+            h: TestHelper,
+            res: ResponseMessage val,
+            server: BaseProtocol)
+          =>
+            _seen = _seen + 1
+            if _seen == 1 then
+              // The initialize response.
+              server(LspMsg.initialized())
+              server(
+                RequestMessage(
+                  I64(401),
+                  Methods.text_document().document_symbol(),
+                  JsonObject.update(
+                    "textDocument",
+                    JsonObject.update("uri", document_uri)))
+                .into_bytes())
+            elseif _seen == 2 then
+              match \exhaustive\ res.err
+              | let e: ResponseError val =>
+                h.fail("no workspace matched the document URI: " + e.message)
+              | None =>
+                None
+              end
+              h.complete(true)
+            end
+        end,
+        {(h: TestHelper, harness: TestHarness ref): Bool => true }
+        where
+          after_sends = USize.max_value(),
+          after_logs = USize.max_value()
+      )
+    harness.send_to_server(
+      LspMsg.initialize(
+        workspace_dir
+        where
+          send_workspace_folders = false,
+          send_root_uri = false))

--- a/tools/pony-lsp/test/_uris_tests.pony
+++ b/tools/pony-lsp/test/_uris_tests.pony
@@ -36,8 +36,9 @@ class \nodoc\ iso _URIToPathTest is UnitTest
 
 class \nodoc\ iso _URIToPathNoSchemeTest is UnitTest
   """
-  A string with no "://" is returned unchanged. Unchanged means undecoded: a
-  path is bytes, so a '%' in one is part of a filename.
+  A string with no "://" is returned without decoding: a path is bytes, so a
+  '%' in one is part of a filename. On Windows it is still normalised to
+  native separators.
   """
   fun name(): String => "uris/to_path/no_scheme"
 
@@ -46,6 +47,10 @@ class \nodoc\ iso _URIToPathNoSchemeTest is UnitTest
       h.assert_eq[String](
         "C:\\foo\\bar.pony",
         Uris.to_path("C:\\foo\\bar.pony"))
+      // A rootPath can arrive with forward slashes.
+      h.assert_eq[String](
+        "C:\\foo\\bar.pony",
+        Uris.to_path("C:/foo/bar.pony"))
       h.assert_eq[String](
         "C:\\foo\\50%20off.pony",
         Uris.to_path("C:\\foo\\50%20off.pony"))

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -26,6 +26,7 @@ actor Main is TestList
     _URITests.make().tests(test)
     _PercentEncodingTests.make().tests(test)
     _EncodedURIIntegrationTests.make().tests(test)
+    _RootURIIntegrationTests.make().tests(test)
     _SymbolKindsTests.make().tests(test)
     _HoverFormatterTests.make().tests(test)
     _DiagnosticTests.make().tests(test)

--- a/tools/pony-lsp/test/message_handler.pony
+++ b/tools/pony-lsp/test/message_handler.pony
@@ -229,8 +229,21 @@ primitive LspMsg
     did_change_configuration_dynamic_registration:
       Bool = true,
     supports_configuration: Bool = true,
-    uri: (String | None) = None
+    uri: (String | None) = None,
+    send_workspace_folders: Bool = true,
+    send_root_uri: Bool = true
   ): Array[U8] iso^ =>
+    """
+    An LSP initialize request naming `dir` as the workspace.
+
+    By default the params carry the workspace location under all three keys
+    the spec allows — `rootPath`, `rootUri`, and a `workspaceFolders` array —
+    which is the shape VS Code sends. `send_workspace_folders = false` drops
+    the array and the matching client capability, for a client that does not
+    support workspace folders. `send_root_uri = false` drops `rootUri`. `uri`
+    replaces the spelling of the URI, for a test that needs the escaping a
+    particular client applies.
+    """
     let safe_dir = _json_escape(dir)
     let dir_uri =
       _json_escape(
@@ -239,6 +252,29 @@ primitive LspMsg
         else
           Uris.from_path(dir)
         end)
+    let root_uri_field =
+      if send_root_uri then
+        """
+          "rootUri": """" + dir_uri + """
+",
+"""
+      else
+        ""
+      end
+    let workspace_folders_field =
+      if send_workspace_folders then
+        "," + """
+          "workspaceFolders": [
+              {
+                  "uri": """" + dir_uri + """
+",
+                  "name": "workspace"
+              }
+          ]
+"""
+      else
+        ""
+      end
     this.apply("""
     {
       "jsonrpc": "2.0",
@@ -253,8 +289,7 @@ primitive LspMsg
           "locale": "en",
           "rootPath": """" + safe_dir + """
 ",
-          "rootUri": """" + dir_uri + """
-",
+""" + root_uri_field + """
           "capabilities": {
               "workspace": {
                   "applyEdit": true,
@@ -300,7 +335,9 @@ primitive LspMsg
       did_change_configuration_dynamic_registration
         .string() + """
                   },
-                  "workspaceFolders": true,
+                  "workspaceFolders": """ +
+      send_workspace_folders.string() + """
+,
                   "foldingRange": {"refreshSupport": true},
                   "semanticTokens": {"refreshSupport": true},
                   "fileOperations": {
@@ -567,14 +604,8 @@ primitive LspMsg
                   }
               }
           },
-          "trace": "verbose",
-          "workspaceFolders": [
-              {
-                  "uri": """" + dir_uri + """
-",
-                  "name": "workspace"
-              }
-          ]
+          "trace": "verbose"
+""" + workspace_folders_field + """
       }
     }
     """)


### PR DESCRIPTION
The initialize params name the workspace under one of three keys, and two of them are strings: `rootUri` holds a URI, `rootPath` holds a path. The extraction queries all three at once with a JsonPath union and then branches on JSON type, so the string arm cannot tell which key it came from and treats every string as a path. A `rootUri` reached `WorkspaceScanner.scan` unconverted, named a directory that does not exist, and registered no workspace, so every document request afterwards came back "No workspace found". The array arm three lines down already converted; the string arm never did.

`Uris.to_path` takes either form — it strips a scheme when there is one and does not decode a string without one — so the single call is correct for both keys. That property is what #5777 documented and pinned; before it, this one-liner would have stripped the scheme without decoding and still failed on any path with a space.

No integration test could reach the string arm. `LspMsg.initialize` always emitted a `params.workspaceFolders` array, and the union resolves selectors in expression order, so the array always won and every test took the array arm. That is why a bug this total sat green. The new `send_workspace_folders` and `send_root_uri` knobs are what let a test send the shape vim-lsp sends by default.

Two tests, and they are not the same kind. `root_uri_routes_to_workspace` reproduces the bug — reverting the fix fails it. `root_path_routes_to_workspace` is a divergence guard: the fix newly routes `rootPath` through `to_path`, so `rootPath` clients are the population this change could regress. It passes with the fix reverted by construction, so its counterfactual is breaking the assertion and confirming it fires, which I did.

`rootPath` now passing through `Uris.to_path` is the one behavior change for clients that work today. On POSIX the result is identical. On Windows it is not: the separator normalization and drive-letter strip in `uris.pony` run on scheme-less input too, so `C:/foo` comes back `C:\foo`. Windows accepts either separator and the length is unchanged, so this is believed harmless, but it is a real change and I have not run the Windows arm — that rests on reading `uris.pony` and on the `Tools: Windows` CI job.

### What this does not fix

Kate is the editor in the report, and this only fixes some Kate setups. Reading Kate's source (`addons/lspclient`): `lspclientservermanager.cpp:790` defaults `useWorkspace` to true when no project root is configured, `:793-795` then falls `rootpath` back to `QDir::homePath()`, `:928-931` assigns an **empty** folder list, and `lspclientserver.cpp:1870-71` emits the key for an empty-but-present list. So Kate has two shapes:

- **Root configured** — no `workspaceFolders`, a `rootUri`. This is the reporter's case ("solved the issue in my case") and this PR fixes it.
- **No root configured** (Kate's default) — `workspaceFolders: []` plus `rootUri`. Takes the array arm with zero folders, registers nothing, and is **still broken**.

That second one is a different defect: `query(...)(0)` takes the first key *present*, not the first *usable*, and the match has no `else`. `workspaceFolders: null`, `rootUri: null`, and `workspaceFolders: []` each register zero workspaces while a usable location sits in the same message — all three are spec-legal, and I confirmed each by probe. I have filed it as #5784 rather than folding it in, because the obvious fall-through is not safe: in Kate's default path `rootUri` is `$HOME`, so falling through would recursively walk the user's home directory hunting for `corral.json`. That needs its own design discussion.

`Closes #5324` is still right — that issue is titled and diagnosed as the `rootUri`/`rootPath` confusion, and that is fixed — but Kate is not wholly fixed, and this says so rather than letting the close imply otherwise.

### The design finding underneath

Collapsing "try three differently-typed sources in priority order" into one JsonPath union plus a type match throws away both which key was found and the fallback the comment at `language_server.pony:410` claims. That shortcut is what permits both defects: erasing presence-vs-usability gives the null/empty bug, and erasing which-key-matched is why the string arm has to guess. Raising it rather than fixing it here.

The reporter also asked for the code to "differentiate between path strings and URIs" by key. I did not: `to_path` already differentiates by inspecting the value, and that is the contract roughly thirty other call sites in the tool rely on — forking this one site to distrust it would be inconsistency, not explicitness. If the null/empty defect gets fixed with a real fallback chain, the key becomes available for free and that decision is worth re-taking.

Closes #5324

