### PR TITLE
Fix OpenBSD build broken by spaces in test-fixture paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -680,10 +680,12 @@ else()
         add_subdirectory(src/ponyc-shim)
     endif()
 
+    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/PonyGlob.cmake)
+
     # Stamp file so tools rebuild when shared library sources change.
     # Adding new shared libraries under tools/lib/ only requires updating
     # the glob here rather than every tool's CMakeLists.txt.
-    file(GLOB_RECURSE TOOLS_LIB_SOURCES CONFIGURE_DEPENDS "tools/lib/*.pony")
+    pony_prereq_glob(TOOLS_LIB_SOURCES "tools/lib/*.pony")
     set(TOOLS_LIB_STAMP ${CMAKE_BINARY_DIR}/tools_lib.stamp)
     add_custom_command(OUTPUT ${TOOLS_LIB_STAMP}
       COMMAND ${CMAKE_COMMAND} -E touch ${TOOLS_LIB_STAMP}

--- a/cmake/PonyBinary.cmake
+++ b/cmake/PonyBinary.cmake
@@ -12,6 +12,10 @@
 #
 # Rebuilds when any watched .pony source changes, when the shared tool libraries
 # change (TOOLS_LIB_STAMP), or when ponyc itself is rebuilt.
+
+# Provides pony_prereq_glob.
+include(${CMAKE_CURRENT_LIST_DIR}/PonyGlob.cmake)
+
 function(add_pony_binary _target)
     cmake_parse_arguments(_pb "ALL" "NAME;SOURCE" "PATHS;WATCH" ${ARGN})
 
@@ -27,7 +31,7 @@ function(add_pony_binary _target)
 
     set(_watch_srcs "")
     foreach(_w IN LISTS _pb_WATCH)
-        file(GLOB_RECURSE _found CONFIGURE_DEPENDS "${_w}/*.pony")
+        pony_prereq_glob(_found "${_w}/*.pony")
         list(APPEND _watch_srcs ${_found})
     endforeach()
 

--- a/cmake/PonyGlob.cmake
+++ b/cmake/PonyGlob.cmake
@@ -1,0 +1,21 @@
+include_guard(GLOBAL)
+
+# Recursively glob files for use as make prerequisites, dropping any whose path
+# holds a character that has no portable spelling in a Makefile prerequisite.
+#
+# CMake writes such characters in a form GNU make accepts but OpenBSD's base
+# make can't parse: a space or '#' comes out backslash-escaped, ':' and other
+# make-special characters come out raw. A path holding one can't be a
+# prerequisite at all.
+#
+# Dropping one changes nothing that gets built: these paths only trigger
+# rebuilds, and what ponyc compiles comes from the source directory, not from
+# this list -- so a dropped path just stops retriggering a rebuild when it
+# changes. The paths this drops are test fixtures whose names carry such
+# characters to exercise path handling. Do not use this to gather compile
+# sources -- a dropped source would silently vanish from the build.
+function(pony_prereq_glob out_var)
+    file(GLOB_RECURSE _found CONFIGURE_DEPENDS ${ARGN})
+    list(FILTER _found EXCLUDE REGEX "[^A-Za-z0-9/._-]")
+    set(${out_var} "${_found}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
OpenBSD's build broke because CMake writes globbed .pony paths into the
generated Makefile as prerequisites, and OpenBSD's base make can't parse
the backslash-escaped space CMake emits for a path containing one. The
recursive glob that tracks the tools' sources for rebuilds picked up the
pony-lsp test fixtures whose directory names contain spaces, so those
paths became prerequisites. GNU make reads the escaped space fine;
OpenBSD's base make is what breaks.

A new cmake/PonyGlob.cmake helper globs .pony files and drops any whose
path holds a character with no portable Makefile spelling. The two globs
whose results become make prerequisites -- the tools' source glob and the
shared-library stamp -- use it. The dropped paths are test fixtures read
at runtime, never compiled, so dropping them from rebuild-tracking loses
nothing.
