### PR TITLE
Fix quadratic type checking of large array literals

### DIFF
--- a/.release-notes/array-literal-compile-time.md
+++ b/.release-notes/array-literal-compile-time.md
@@ -1,0 +1,3 @@
+## Speed up type checking of large array literals
+
+Type checking an array literal was quadratic in the number of elements, which made the type-check pass very slow for large literals -- a few thousand elements took many seconds. It is now linear in the number of elements: a 2000-element literal that spent about 93 seconds in the type checker now spends under half a second. Runtime behavior is unchanged.

--- a/src/libponyc/expr/array.c
+++ b/src/libponyc/expr/array.c
@@ -1,14 +1,9 @@
 #include "array.h"
-#include "call.h"
-#include "control.h"
 #include "literal.h"
-#include "postfix.h"
-#include "reference.h"
 #include "../ast/astbuild.h"
 #include "../pkg/package.h"
 #include "../pass/names.h"
 #include "../pass/expr.h"
-#include "../pass/refer.h"
 #include "../type/alias.h"
 #include "../type/assemble.h"
 #include "../type/reify.h"
@@ -547,61 +542,77 @@ bool expr_array(pass_opt_t* opt, ast_t** astp)
     ast_free_unattached(aliasable_type);
   }
 
-  BUILD(ref, ast, NODE(TK_REFERENCE, ID("Array")));
-
-  BUILD(qualify, ast,
-    NODE(TK_QUALIFY,
-      TREE(ref)
-      NODE(TK_TYPEARGS, TREE(type))));
-
-  BUILD(dot, ast, NODE(TK_DOT, TREE(qualify) ID("create")));
-
-  ast_t* size_arg = ast_from_int(ast, size);
-  BUILD(size_arg_seq, ast, NODE(TK_SEQ, TREE(size_arg)));
-  ast_settype(size_arg, type_builtin(opt, ast, "USize"));
-  ast_settype(size_arg_seq, type_builtin(opt, ast, "USize"));
-
-  BUILD(call, ast,
+  // Desugar the literal to a flat sequence that fills the array through a temp
+  // local:
+  //   (let $array = Array[T].create(N); $array.push(e1); ...; $array)
+  // rather than the left-nested `Array[T].create(N).>push(e1).>push(e2)...`
+  // chain this used to build. The chain deepened by one level per element, and
+  // re-attaching the growing expression each iteration made building it O(N^2):
+  // TREE() duplicates an already-parented node and ast_replace() frees one, so
+  // both touched the whole accumulated tree every time. The flat form touches
+  // only fixed-size nodes per element, so the build is O(N). The sequence is
+  // left unprocessed and run through ast_passes_subtree, which sets up the temp
+  // local and resolves its references through the normal front-end passes
+  // (sugar through expr).
+  BUILD(array_create, ast,
     NODE(TK_CALL,
-      TREE(dot)
-      NODE(TK_POSITIONALARGS, TREE(size_arg_seq))
+      NODE(TK_DOT,
+        NODE(TK_QUALIFY,
+          NODE(TK_REFERENCE, ID("Array"))
+          NODE(TK_TYPEARGS, TREE(type)))
+        ID("create"))
+      NODE(TK_POSITIONALARGS, NODE(TK_SEQ, INT(size)))
       NONE
       NONE));
 
-  if(!refer_reference(opt, &ref) ||
-    !refer_qualify(opt, qualify) ||
-    !expr_typeref(opt, &qualify) ||
-    !expr_dot(opt, &dot) ||
-    !expr_call(opt, &call)
-    )
-    return false;
-
-  ast_swap(ast, call);
-  *astp = call;
-
-  elements = ast_childidx(ast, 1);
-
-  for(ast_t* ele = ast_child(elements); ele != NULL; ele = ast_sibling(ele))
+  if(size == 0)
   {
-    BUILD(append_chain, ast, NODE(TK_CHAIN, TREE(*astp) ID("push")));
-    BUILD(ele_seq, ast, NODE(TK_SEQ, TREE(ele)));
+    // No elements to push: leave the array as a bare constructor call. An
+    // embedded field must be assigned a constructor. is_expr_constructor
+    // (expr/operator.c) looks through a sequence to its last expression, so the
+    // size>0 form above is rejected for an embed field not because it is a
+    // sequence but because it ends in the temp-local reference; keeping the bare
+    // create for an empty literal is what lets `embed field = []` stay valid.
+    ast_replace(astp, array_create);
+  }
+  else
+  {
+    const char* tmp_name = package_hygienic_id(&opt->check, opt);
 
-    BUILD(append, ast,
-      NODE(TK_CALL,
-        TREE(append_chain)
-        NODE(TK_POSITIONALARGS, TREE(ele_seq))
-        NONE
-        NONE));
+    // No AST_SCOPE on the sequence: an expression-position sequence is a
+    // rawseq, exactly as Pony represents a parenthesised `(let x = ...; x)`.
+    // The temp local is defined in the enclosing scope; its hygienic name
+    // rules out any collision. A scope here would make the node a scoped seq,
+    // which the tree-check `expr` group rejects in expression position.
+    BUILD(seq, ast,
+      NODE(TK_SEQ,
+        NODE(TK_ASSIGN,
+          NODE(TK_LET, NICE_ID(tmp_name, "array literal") NONE)
+          TREE(array_create))));
 
-    ast_replace(astp, append);
+    // Track the last sibling so each push is appended in O(1) instead of
+    // walking to the end of the sequence's child list.
+    ast_t* last = ast_child(seq); // the TK_ASSIGN
+    for(ast_t* ele = ast_pop(elements); ele != NULL; ele = ast_pop(elements))
+    {
+      BUILD(push, ast,
+        NODE(TK_CALL,
+          NODE(TK_DOT, NODE(TK_REFERENCE, ID(tmp_name)) ID("push"))
+          NODE(TK_POSITIONALARGS, NODE(TK_SEQ, TREE(ele)))
+          NONE
+          NONE));
+      last = ast_add_sibling(last, push);
+    }
 
-    if(!expr_chain(opt, &append_chain) ||
-      !expr_seq(opt, ele_seq) ||
-      !expr_call(opt, &append)
-      )
-      return false;
+    BUILD(array_ref, ast, NODE(TK_REFERENCE, ID(tmp_name)));
+    ast_add_sibling(last, array_ref);
+
+    ast_replace(astp, seq);
   }
 
-  ast_free_unattached(ast);
-  return true;
+  // Run the front-end passes over the spliced-in nodes. The already-processed
+  // elements carry the expr pass flag, so each pass skips them; only the new
+  // structural nodes (the let, references, push calls and sequence) are
+  // processed.
+  return ast_passes_subtree(astp, opt, PASS_EXPR);
 }

--- a/test/libponyc/array.cc
+++ b/test/libponyc/array.cc
@@ -217,3 +217,75 @@ TEST_F(ArrayTest, EmptyArrayLiteralMustBeInferable)
     "must specify the element type or it must be inferable",
     "must specify the element type or it must be inferable");
 }
+
+
+TEST_F(ArrayTest, EmbedFieldFromEmptyArrayLiteral)
+{
+  // An empty array literal desugars to a bare Array.create() constructor call,
+  // which an embedded field requires. (A non-empty literal desugars to a
+  // sequence ending in a reference, not a constructor -- see the negative case
+  // below.)
+  const char* src =
+    "class Foo\n"
+    "  embed _a: Array[U32] = []\n"
+    "  fun ref push(x: U32) => _a.push(x)";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(ArrayTest, EmbedFieldFromNonEmptyArrayLiteralFails)
+{
+  // A non-empty array literal desugars to a sequence whose last expression is
+  // the temp-local reference, not a constructor, so it can't initialise an
+  // embedded field. (The empty case above stays a bare constructor and does.)
+  const char* src =
+    "class Foo\n"
+    "  embed _a: Array[U32] = [1]";
+
+  TEST_ERRORS_1(src, "an embedded field must be assigned using a constructor");
+}
+
+
+TEST_F(ArrayTest, NonEmptyTupleArrayLiteral)
+{
+  // A multi-element literal desugars to a temp local filled by push() calls;
+  // check a representative literal (including tuple elements) type checks.
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply(): Array[(U32, U32)] val =>\n"
+    "    [(0x41, 0x5A); (0xC0, 0xD6); (0x100, 0x100)]";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(ArrayTest, NestedArrayLiteral)
+{
+  // A literal whose elements are themselves array literals recurses through the
+  // desugar (a sequence with a temp local, nested inside another).
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply(): Array[Array[U8]] =>\n"
+    "    [[as U8: 1; 2]; [as U8: 3; 4]]";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(ArrayTest, NonEmptyArrayLiteralCompilesThroughReach)
+{
+  // The desugared sequence is an expression-position rawseq, not a scoped seq.
+  // The full-tree well-formedness check only runs once compilation proceeds
+  // into reach, so a literal has to be compiled at least that far to exercise
+  // it -- the "expr"-pass cases above stop short of it.
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: Array[U32] = [1; 2; 3]\n"
+    "    env.out.print(a.size().string())";
+
+  set_builtin(nullptr);
+
+  DO(test_compile(src, "ir"));
+}


### PR DESCRIPTION
Type checking an array literal was quadratic in the number of elements. The literal `[a; b; c]` desugared to a left-nested chain, Array[T].create(3).>push(a).>push(b).>push(c), growing the expression one level per element and re-attaching the whole thing each step. Because ast_add and ast_replace duplicate and free an already-parented node, every element touched the entire accumulated tree, so the expr pass cost was on the order of N squared -- a few thousand elements took many seconds.

Desugar to a flat sequence over a temporary local instead -- (let $array = Array[T].create(3); $array.push(a); $array.push(b); $array) -- where every per-element step is a fixed size. Elements are moved out with ast_pop and pushes are appended through a tracked last sibling, so the expr pass is now linear in the element count. The sequence is run through ast_passes_subtree so the temp local and its references resolve through the normal front-end pipeline.

An empty literal is left as a bare Array.create() so that an embedded field assigned an empty literal (embed f = []) stays valid: the non-empty desugar's sequence ends in the temp-local reference, not a constructor. Runtime behavior is unchanged.

This addresses only the type-check cost. Two other, pre-existing quadratic costs for very large literals are unaffected: the sugar pass for `;`-separated elements, and the LLVM optimizer on a function with many pushes.