### PR TITLE
Pin the ISA baseline of the tier 3 cross jobs' host builds

### DIFF
--- a/.ci-scripts/cross-test.sh
+++ b/.ci-scripts/cross-test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Cross-compilation test for the tier-3 cross jobs. Invoked from
-# .github/workflows/ponyc-tier3.yml. Runs on the x86-64 host with a
-# host ponyc built natively and a cross libponyrt built by cross-libponyrt.sh.
+# .github/workflows/ponyc-tier3.yml. Runs on the x86-64 host with a host ponyc
+# and a cross libponyrt built by cross-libponyrt.sh.
 #
 # It does two things:
 #   1. The host ponyc's own suites run natively -- the gtest suites, full-program
@@ -10,22 +10,35 @@
 #   2. The stdlib is cross-compiled with the host ponyc pointed at the cross
 #      libponyrt (PONYPATH) and run under the emulator, for both configs.
 #
-# Usage: cross-test.sh <config> <cross_ponypath> <cross_args> <cross_runner> <stdlib_excludes>
-#   config          debug | release (selects which host ponyc runs the tests)
-#   cross_ponypath  cross libponyrt dir, relative to build/<config> (e.g. ../rv64gc/debug)
+# Usage: cross-test.sh <preset> <cross_ponypath> <cross_args> <cross_runner> <stdlib_excludes>
+#   preset          the CMake preset the host ponyc was configured with
+#   cross_ponypath  cross libponyrt dir, relative to ponyc's output directory
+#                   (e.g. ../rv64gc/debug)
 #   cross_args      ponyc cross flags: --triple=.. --cpu=.. --link-arch=.. [--sysroot=..] <extra>
 #   cross_runner    the emulator command (e.g. "qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/")
 #   stdlib_excludes stdlib test excludes (e.g. --exclude=net/)
 set -eu
 
-config="$1"
+preset="$1"
 cross_ponypath="$2"
 cross_args="$3"
 cross_runner="$4"
 stdlib_excludes="$5"
 
+# ponyc's output directory is named after the build type, not after the preset.
+# Map rather than strip a suffix: a preset that sets PONY_USES lands in a
+# directory with those options appended (BUILD.md).
+case "$preset" in
+    debug|x86-64-debug) config=debug ;;
+    release|x86-64-release) config=release ;;
+    *)
+        echo "cross-test.sh: unsupported preset '$preset'" >&2
+        exit 1
+        ;;
+esac
+
 # 1. Host-native tests: all of ci-core except the stdlib (cross-built below).
-ctest --preset "$config" -L ci-core -E stdlib
+ctest --preset "$preset" -L ci-core -E stdlib
 
 # 2. Cross-compile the stdlib with the host ponyc + the cross libponyrt, run it
 # under the emulator. Both configs. cross_args,

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -143,12 +143,17 @@ jobs:
           LIBS_MODE: ${{ ((github.event_name == 'workflow_dispatch' && inputs.ref != 'main') && '--branch-cache') || '--require-cache-hit --skip-on-miss' }}
           LIBS_BUILD: ${{ ((github.event_name == 'workflow_dispatch' && inputs.ref != 'main') && '-- cmake -DJOBS=4 -P lib/build-libs.cmake') || '' }}
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py $LIBS_MODE --image "$LIBS_IMAGE" --tag "$LIBS_TAG" $LIBS_BUILD
+      # Build the host ponyc's C and C++ at a fixed ISA baseline, as the x86-64
+      # rpm job above does. The debug and release presets set -march=native
+      # (CMakePresets.json), so the baseline follows whichever CPU GitHub
+      # assigns; ponyc's C compiles with -Werror, so a feature combination clang
+      # warns about is a build failure.
       - name: Build Debug Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: |
-          cmake --preset debug
-          cmake --build --preset debug
-          cmake --build --preset debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
+          cmake --preset x86-64-debug
+          cmake --build --preset x86-64-debug
+          cmake --build --preset x86-64-debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
       - name: Build Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: sh .ci-scripts/cross-libponyrt.sh debug riscv64-linux-gnu-gcc-10 riscv64-linux-gnu-g++-10 rv64gc "-march=rv64gc -mtune=rocket"
@@ -161,28 +166,28 @@ jobs:
       # kernels on x86, arm64 macOS, and the BSD VMs.
       - name: Test with Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-test.sh debug ../rv64gc/debug "--triple=riscv64-unknown-linux-gnu --cpu=generic-rv64 --link-arch=rv64gc --sysroot=/usr/riscv64-linux-gnu --abi=lp64d --features=+m,+a,+f,+d,+c" "qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/" "--exclude=net/"
+        run: sh .ci-scripts/cross-test.sh x86-64-debug ../rv64gc/debug "--triple=riscv64-unknown-linux-gnu --cpu=generic-rv64 --link-arch=rv64gc --sysroot=/usr/riscv64-linux-gnu --abi=lp64d --features=+m,+a,+f,+d,+c" "qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/" "--exclude=net/"
       - name: Build Release Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: |
-          cmake --preset release
-          cmake --build --preset release
+          cmake --preset x86-64-release
+          cmake --build --preset x86-64-release
       - name: Build Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: sh .ci-scripts/cross-libponyrt.sh release riscv64-linux-gnu-gcc-10 riscv64-linux-gnu-g++-10 rv64gc "-march=rv64gc -mtune=rocket"
       # See the debug step above for why net/ tests are excluded under qemu-user.
       - name: Test with Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-test.sh release ../rv64gc/release "--triple=riscv64-unknown-linux-gnu --cpu=generic-rv64 --link-arch=rv64gc --sysroot=/usr/riscv64-linux-gnu --abi=lp64d --features=+m,+a,+f,+d,+c" "qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/" "--exclude=net/"
+        run: sh .ci-scripts/cross-test.sh x86-64-release ../rv64gc/release "--triple=riscv64-unknown-linux-gnu --cpu=generic-rv64 --link-arch=rv64gc --sysroot=/usr/riscv64-linux-gnu --abi=lp64d --features=+m,+a,+f,+d,+c" "qemu-riscv64 -L /usr/riscv64-linux-gnu/lib/" "--exclude=net/"
       - name: Test pony-doc
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: ctest --preset debug -R pony-doc-tests
+        run: ctest --preset x86-64-debug -R pony-doc-tests
       - name: Test pony-lint
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: ctest --preset debug -R pony-lint-tests
+        run: ctest --preset x86-64-debug -R pony-lint-tests
       - name: Test pony-lsp
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: ctest --preset debug -R pony-lsp-tests
+        run: ctest --preset x86-64-debug -R pony-lsp-tests
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
@@ -227,40 +232,41 @@ jobs:
           LIBS_MODE: ${{ ((github.event_name == 'workflow_dispatch' && inputs.ref != 'main') && '--branch-cache') || '--require-cache-hit --skip-on-miss' }}
           LIBS_BUILD: ${{ ((github.event_name == 'workflow_dispatch' && inputs.ref != 'main') && '-- cmake -DJOBS=4 -P lib/build-libs.cmake') || '' }}
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py $LIBS_MODE --image "$LIBS_IMAGE" --tag "$LIBS_TAG" $LIBS_BUILD
+      # The x86-64 presets pin the ISA baseline; see the riscv64 leg above.
       - name: Build Debug Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: |
-          cmake --preset debug
-          cmake --build --preset debug
-          cmake --build --preset debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
+          cmake --preset x86-64-debug
+          cmake --build --preset x86-64-debug
+          cmake --build --preset x86-64-debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
       - name: Build Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: sh .ci-scripts/cross-libponyrt.sh debug arm-linux-gnueabi-gcc arm-linux-gnueabi-g++ armv7-a "-march=armv7-a -mtune=cortex-a9"
       # net/ tests are excluded under qemu-user; see the riscv64 leg above.
       - name: Test with Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-test.sh debug ../armv7-a/debug "--triple=arm-unknown-linux-gnueabi --cpu=cortex-a9 --link-arch=armv7-a --sysroot=/usr/local/arm-linux-gnueabi/libc " "qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" "--exclude=net/"
+        run: sh .ci-scripts/cross-test.sh x86-64-debug ../armv7-a/debug "--triple=arm-unknown-linux-gnueabi --cpu=cortex-a9 --link-arch=armv7-a --sysroot=/usr/local/arm-linux-gnueabi/libc " "qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" "--exclude=net/"
       - name: Build Release Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: |
-          cmake --preset release
-          cmake --build --preset release
+          cmake --preset x86-64-release
+          cmake --build --preset x86-64-release
       - name: Build Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: sh .ci-scripts/cross-libponyrt.sh release arm-linux-gnueabi-gcc arm-linux-gnueabi-g++ armv7-a "-march=armv7-a -mtune=cortex-a9"
       # net/ tests are excluded under qemu-user; see the riscv64 leg above.
       - name: Test with Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-test.sh release ../armv7-a/release "--triple=arm-unknown-linux-gnueabi --cpu=cortex-a9 --link-arch=armv7-a --sysroot=/usr/local/arm-linux-gnueabi/libc " "qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" "--exclude=net/"
+        run: sh .ci-scripts/cross-test.sh x86-64-release ../armv7-a/release "--triple=arm-unknown-linux-gnueabi --cpu=cortex-a9 --link-arch=armv7-a --sysroot=/usr/local/arm-linux-gnueabi/libc " "qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabi/libc" "--exclude=net/"
       - name: Test pony-doc
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: ctest --preset debug -R pony-doc-tests
+        run: ctest --preset x86-64-debug -R pony-doc-tests
       - name: Test pony-lint
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: ctest --preset debug -R pony-lint-tests
+        run: ctest --preset x86-64-debug -R pony-lint-tests
       - name: Test pony-lsp
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: ctest --preset debug -R pony-lsp-tests
+        run: ctest --preset x86-64-debug -R pony-lsp-tests
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
@@ -305,40 +311,41 @@ jobs:
           LIBS_MODE: ${{ ((github.event_name == 'workflow_dispatch' && inputs.ref != 'main') && '--branch-cache') || '--require-cache-hit --skip-on-miss' }}
           LIBS_BUILD: ${{ ((github.event_name == 'workflow_dispatch' && inputs.ref != 'main') && '-- cmake -DJOBS=4 -P lib/build-libs.cmake') || '' }}
         run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py $LIBS_MODE --image "$LIBS_IMAGE" --tag "$LIBS_TAG" $LIBS_BUILD
+      # The x86-64 presets pin the ISA baseline; see the riscv64 leg above.
       - name: Build Debug Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: |
-          cmake --preset debug
-          cmake --build --preset debug
-          cmake --build --preset debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
+          cmake --preset x86-64-debug
+          cmake --build --preset x86-64-debug
+          cmake --build --preset x86-64-debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
       - name: Build Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: sh .ci-scripts/cross-libponyrt.sh debug arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++ armv7-a "-march=armv7-a -mtune=cortex-a9"
       # net/ tests are excluded under qemu-user; see the riscv64 leg above.
       - name: Test with Debug Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-test.sh debug ../armv7-a/debug "--triple=arm-unknown-linux-gnueabihf --cpu=cortex-a9 --link-arch=armv7-a --sysroot=/usr/local/arm-linux-gnueabihf/libc " "qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" "--exclude=net/"
+        run: sh .ci-scripts/cross-test.sh x86-64-debug ../armv7-a/debug "--triple=arm-unknown-linux-gnueabihf --cpu=cortex-a9 --link-arch=armv7-a --sysroot=/usr/local/arm-linux-gnueabihf/libc " "qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" "--exclude=net/"
       - name: Build Release Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: |
-          cmake --preset release
-          cmake --build --preset release
+          cmake --preset x86-64-release
+          cmake --build --preset x86-64-release
       - name: Build Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
         run: sh .ci-scripts/cross-libponyrt.sh release arm-linux-gnueabihf-gcc arm-linux-gnueabihf-g++ armv7-a "-march=armv7-a -mtune=cortex-a9"
       # net/ tests are excluded under qemu-user; see the riscv64 leg above.
       - name: Test with Release Cross-Compiled Runtime
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: sh .ci-scripts/cross-test.sh release ../armv7-a/release "--triple=arm-unknown-linux-gnueabihf --cpu=cortex-a9 --link-arch=armv7-a --sysroot=/usr/local/arm-linux-gnueabihf/libc " "qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" "--exclude=net/"
+        run: sh .ci-scripts/cross-test.sh x86-64-release ../armv7-a/release "--triple=arm-unknown-linux-gnueabihf --cpu=cortex-a9 --link-arch=armv7-a --sysroot=/usr/local/arm-linux-gnueabihf/libc " "qemu-arm-static -cpu cortex-a9 -L /usr/local/arm-linux-gnueabihf/libc" "--exclude=net/"
       - name: Test pony-doc
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: ctest --preset debug -R pony-doc-tests
+        run: ctest --preset x86-64-debug -R pony-doc-tests
       - name: Test pony-lint
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: ctest --preset debug -R pony-lint-tests
+        run: ctest --preset x86-64-debug -R pony-lint-tests
       - name: Test pony-lsp
         if: ${{ hashFiles('.libs-cache-miss') == '' }}
-        run: ctest --preset debug -R pony-lsp-tests
+        run: ctest --preset x86-64-debug -R pony-lsp-tests
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa


### PR DESCRIPTION
The three tier 3 cross jobs build a host ponyc on whichever x86-64 runner
GitHub assigns them, with presets that set `-march=native`, and ponyc's C
compiles with `-Werror`. On a scheduled run the arm job landed on a CPU where
`-march=native` produced `+avx10.1-256`, which clang reports as an invalid
feature combination, and Build Debug Runtime failed. Re-running the workflow
passed, on a different CPU. Which runner a job gets is not something we
control, so the failure recurs at whatever rate GitHub rolls newer Intel parts
into the pool.

The `x86-64-debug`/`x86-64-release` presets set `-march=x86-64`, so the
baseline no longer depends on the runner's CPU. Those presets already existed
and the `x86-64 Linux glibc rpm` job in this same workflow already used them.

`cross-test.sh` took one argument and used it as both a ctest preset name and
the name of ponyc's output directory. Those are no longer the same string, so
it now takes the preset and maps it to the directory. It maps rather than
strips a suffix because a preset that sets `PONY_USES` lands in a directory
with those options appended.

This changes only the three cross jobs. The BSD VM jobs in this file, two of
the `pr.yml` jobs, `test-with-latest-tools.yml`, and the stress tests still
build with `-march=native` and can still fail the same way. I have that
captured to file as a separate issue after this merges.

## Before merging

Tier 3 runs on a schedule and on `workflow_dispatch`, never on a PR, so this
PR's own checks exercise none of the changed code. A dispatch of `ponyc Tier
3` with `ref` set to this branch is the only way to run it.
