### PR TITLE
Retry the DragonFly CI VM setup until ssh comes up

### DIFF
--- a/.ci-scripts/bsd/dfly_configure_vm.py
+++ b/.ci-scripts/bsd/dfly_configure_vm.py
@@ -2,11 +2,13 @@
 """Drive the DragonFly BSD VM's VGA console over the QEMU monitor.
 
 DragonFly raw images boot to a passwordless root login with no cloud-init, so the
-setup commands (login, network, sshd, ssh key, build disk) are typed in with QEMU
-monitor `sendkey`. Runs on the GitHub Actions host after the VM boots; reads the
-public key to install from the PUB_KEY environment variable and the QEMU monitor
-socket path from DFLY_MONITOR_SOCK (defaulting to dfly-monitor.sock in the
-current directory). Called by dragonfly-provision.bash.
+commands that bring SSH up (login, network, sshd, ssh key) are typed in with QEMU
+monitor `sendkey`. Each run first clears any half-typed line, then logs in fresh,
+so a re-run after a failed attempt starts from a clean prompt instead of adding to
+a line an earlier run left unfinished. Reads the public key to install from the
+PUB_KEY environment variable and the QEMU monitor socket path from DFLY_MONITOR_SOCK
+(defaulting to dfly-monitor.sock in the current directory). Called by
+dragonfly-provision.bash.
 """
 import os
 import socket
@@ -61,6 +63,13 @@ def main():
     time.sleep(0.5)
     sock.recv(4096)
 
+    # Clear any half-typed line left by a dropped keystroke on an earlier run: an
+    # unterminated quote leaves the shell at a continuation prompt, and without
+    # this the next run's keystrokes are swallowed by the open string. ctrl-c
+    # cancels the pending line so this run starts at a fresh prompt.
+    send_hmp(sock, 'sendkey ctrl-c')
+    time.sleep(0.5)
+
     # Press enter and login as root (no password)
     send_line(sock, '')
     time.sleep(2)
@@ -90,12 +99,6 @@ def main():
     time.sleep(10)
     send_line(sock, '/usr/sbin/sshd')
     time.sleep(3)
-
-    # Format and mount build disk
-    send_line(sock, 'newfs /dev/vbd1')
-    time.sleep(10)
-    send_line(sock, 'mkdir -p /build && mount /dev/vbd1 /build')
-    time.sleep(2)
 
     sock.close()
 

--- a/.ci-scripts/bsd/dfly_configure_vm_test.py
+++ b/.ci-scripts/bsd/dfly_configure_vm_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Tests for dfly_configure_vm: KEYMAP de-escaping, send_line key mapping, and
-the monitor-socket path selection.
+"""Tests for dfly_configure_vm: KEYMAP de-escaping, send_line key mapping, the
+monitor-socket path selection, and the console reset.
 
 The KEYMAP checks guard the heredoc-to-standalone-.py extraction: the entries for
 backslash, backtick and dollar were shell-escaped in the original embedded
@@ -8,7 +8,9 @@ heredoc, so a botched de-escape would silently corrupt them. The monitor-socket
 checks guard the contract with dragonfly-provision.bash, which creates the socket
 under VM_ARTIFACTS (outside the checkout, so it isn't rsynced into the guest) and
 passes its path via DFLY_MONITOR_SOCK; hardcoding the path back would break
-DragonFly provisioning. No VM required.
+DragonFly provisioning. The console-reset check guards that main() sends ctrl-c
+before any login keystroke, so a re-run after a dropped keystroke starts at a fresh
+prompt rather than adding to a half-typed line. No VM required.
 """
 import os
 import sys
@@ -82,6 +84,57 @@ def monitor_path_for(env):
     return ConnectSock.connected_path
 
 
+class RecordingSock:
+    """A socket stand-in that records every command main() sends."""
+
+    def __init__(self):
+        self.sent = []
+
+    def connect(self, _):
+        pass
+
+    def sendall(self, data):
+        self.sent.append(data.decode().strip())
+
+    def settimeout(self, _):
+        pass
+
+    def recv(self, _):
+        return b''
+
+    def close(self):
+        pass
+
+
+def capture_main(env):
+    """Run main() with a recording socket and send_line captured; return
+    (sendkeys, typed_lines) -- the ordered sendkey args and the text of each line
+    main() types into the console."""
+    saved_env = dict(os.environ)
+    saved_socket = d.socket.socket
+    saved_send_line = d.send_line
+    rec = RecordingSock()
+    typed = []
+
+    def capturing_send_line(sock, text):
+        typed.append(text)
+        saved_send_line(sock, text)
+
+    os.environ.clear()
+    os.environ.update(env)
+    d.socket.socket = lambda *_a, **_k: rec
+    d.send_line = capturing_send_line
+    try:
+        d.main()
+    finally:
+        d.send_line = saved_send_line
+        d.socket.socket = saved_socket
+        os.environ.clear()
+        os.environ.update(saved_env)
+    sendkeys = [c.removeprefix('sendkey ') for c in rec.sent if c.startswith('sendkey ')]
+    return sendkeys, typed
+
+
 def main():
     failures = []
 
@@ -119,10 +172,22 @@ def main():
         monitor_path_for({"PUB_KEY": "k"}) == "dfly-monitor.sock",
     )
 
+    # main() clears the console before it logs in, so a re-run after a dropped
+    # keystroke starts at a fresh prompt; newfs/mount are no longer typed (the
+    # provision script mounts the build disk over ssh once ssh is up); and the
+    # bring-up still starts sshd.
+    sendkeys, typed = capture_main({"PUB_KEY": "k"})
+    check("console is reset (ctrl-c) before any login keystroke", sendkeys[0] == "ctrl-c")
+    check(
+        "newfs/mount are not typed into the console",
+        not any("newfs" in line or "mount" in line for line in typed),
+    )
+    check("bring-up starts sshd", any("/usr/sbin/sshd" in line for line in typed))
+
     if failures:
         print(f"dfly_configure_vm_test: FAIL ({len(failures)}): {', '.join(failures)}")
         return 1
-    print("dfly_configure_vm_test: ok (12 checks)")
+    print("dfly_configure_vm_test: ok (15 checks)")
     return 0
 
 

--- a/.ci-scripts/bsd/dragonfly-provision.bash
+++ b/.ci-scripts/bsd/dragonfly-provision.bash
@@ -75,31 +75,65 @@ qemu-system-x86_64 \
   -daemonize
 echo "::endgroup::"
 
-echo "::group::Configure VM"
+echo "::group::Configure and wait for VM"
 # Declare then export PUB_KEY separately (SC2155) so dfly_configure_vm.py can
 # read the VM ssh public key from the environment.
 PUB_KEY="$(cat vm_key.pub)"
 export PUB_KEY
 
-# Wait for the VM to boot
-sleep 90
-
-# DragonFly BSD raw images boot to a login prompt with root having no password
-# and no cloud-init support; dfly_configure_vm.py types the setup commands into
-# the VGA console via the QEMU monitor, reading the key from PUB_KEY and the
-# monitor socket path (created by qemu above, under VM_ARTIFACTS) from
-# DFLY_MONITOR_SOCK.
-DFLY_MONITOR_SOCK="$VM_ARTIFACTS/dfly-monitor.sock" \
-  python3 .ci-scripts/bsd/dfly_configure_vm.py
-echo "::endgroup::"
-
-echo "::group::Wait for VM"
-timeout 300 bash -c '
-  while ! ssh -o StrictHostKeyChecking=no -o ConnectTimeout=2 -i vm_key -p 2222 root@localhost true 2>/dev/null; do
+# dfly_configure_vm.py types the ssh-bring-up commands (login, network, sshd, ssh
+# key) into the VGA console over the QEMU monitor on fixed timers, with no
+# feedback. When a slow host pushes boot past those timers, the keystrokes land
+# before the login prompt is up and sshd never starts. So type the sequence, poll
+# ssh, and retype if it did not take: a later attempt, after boot has finished,
+# lands correctly. The script clears the console at the start of each run, so a
+# retype starts fresh.
+poll_ssh() { # 0 if ssh answers within $1 seconds, else 1
+  local deadline=$(( SECONDS + $1 ))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=2 -i vm_key -p 2222 \
+        root@localhost true 2>/dev/null; then
+      return 0
+    fi
     sleep 2
   done
-'
-echo "SSH available"
+  return 1
+}
+
+max_attempts=4
+sleep 90 # wait for boot to reach the login prompt before the first attempt
+
+configured=false
+for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
+  echo "Configure attempt ${attempt}/${max_attempts}: typing setup into the console"
+  DFLY_MONITOR_SOCK="$VM_ARTIFACTS/dfly-monitor.sock" \
+    python3 .ci-scripts/bsd/dfly_configure_vm.py
+  if poll_ssh 30; then
+    configured=true
+    echo "SSH available after ${attempt} attempt(s)"
+    break
+  fi
+  echo "SSH not up after attempt ${attempt}"
+done
+
+if [ "$configured" != true ]; then
+  echo "::error::DragonFly VM never became ssh-reachable after ${max_attempts} configure attempts"
+  echo "::endgroup::"
+  exit 1
+fi
+echo "::endgroup::"
+
+echo "::group::Mount build disk"
+# The root partition is too small for the build, so it uses the second disk
+# (vbd1). newfs runs here over ssh, once, rather than being blind-typed into the
+# console on each configure attempt, where a retype could newfs an already-mounted
+# disk.
+ssh -o StrictHostKeyChecking=no -i vm_key -p 2222 root@localhost /bin/sh <<'EOF'
+set -e
+newfs /dev/vbd1
+mkdir -p /build
+mount /dev/vbd1 /build
+EOF
 echo "::endgroup::"
 
 echo "::group::Install build dependencies"

--- a/.ci-scripts/libs-cache/README.md
+++ b/.ci-scripts/libs-cache/README.md
@@ -207,8 +207,10 @@ main), or the main-cache build and push (the warmer).
 
 Both sets of scripts are file-based, so Super-Linter's shellcheck covers them,
 which it could not do for the embedded `run:` blocks they replaced.
-`dfly_configure_vm_test.py` guards the `KEYMAP` de-escaping and the
-`DFLY_MONITOR_SOCK` monitor-socket path contract with `dragonfly-provision.bash`.
+`dfly_configure_vm_test.py` guards the `KEYMAP` de-escaping, the
+`DFLY_MONITOR_SOCK` monitor-socket path contract with `dragonfly-provision.bash`,
+and the console reset that lets a re-typed configure attempt start from a clean
+prompt.
 
 The two callers differ only in how they invoke the script.
 


### PR DESCRIPTION
The DragonFly tier-3 CI VM occasionally never came up: its setup is typed
into the VGA console on fixed timers with no feedback, and when a slow host
pushed boot past those timers the setup was lost, sshd never started, and
the ssh wait timed out after five minutes. It failed only when boot ran
long, so it flaked rather than failing every time.

The provision script now types the setup, polls ssh, and retypes until ssh
answers, so a later attempt gets through once boot has finished. newfs and
mount run once over ssh instead of in the typed sequence, so a retype can't
reformat a mounted disk, which also matches the FreeBSD and OpenBSD scripts
that already mount over ssh. Each attempt clears the console first, so a
dropped keystroke doesn't leave a half-typed line for the next one. A unit
test checks the console reset and that newfs/mount stay out of the typed
sequence.
