### PR TITLE
Migrate Makefile install target into CMake

### DIFF
--- a/.github/workflows/pr-ponyc.yml
+++ b/.github/workflows/pr-ponyc.yml
@@ -67,6 +67,25 @@ jobs:
           make build config=release
       - name: Test with Release Runtime
         run: make test-ci-core config=release usedebugger='${{ matrix.debugger }}'
+      - name: Verify install honors configured arch (issue #3898)
+        run: |
+          set -eux
+          prefix="$(mktemp -d)"
+          make install config=release prefix="$prefix"
+          # Configured arch is x86-64; the runtime MUST install into lib/x86-64,
+          # not lib/native. A lib/native here is the exact #3898 regression.
+          ls -R "$prefix"/lib/pony/*/lib
+          test -f "$prefix"/lib/pony/*/lib/x86-64/libponyrt.a
+          if ls -d "$prefix"/lib/pony/*/lib/native 2>/dev/null; then
+            echo "FAIL: runtime installed into lib/native instead of lib/x86-64"; exit 1
+          fi
+          # Convenience symlink (symlink=yes default) must resolve into lib/x86-64.
+          test -L "$prefix"/lib/libponyrt.a
+          # End-to-end: the installed compiler must find its runtime and link.
+          mkdir -p hello
+          printf 'actor Main\n  new create(env: Env) =>\n    env.out.print("ok")\n' > hello/main.pony
+          "$prefix"/bin/ponyc hello --output hello
+          ./hello/hello
 
   arm64-macos:
     if: github.event.pull_request.draft == false
@@ -99,6 +118,25 @@ jobs:
           make build config=release
       - name: Test with Release Runtime
         run: make test-ci-core config=release
+      - name: Verify install honors configured arch (issue #3898)
+        run: |
+          set -eux
+          prefix="$(mktemp -d)"
+          make install config=release prefix="$prefix"
+          # Configured arch is armv8; the runtime MUST install into lib/armv8,
+          # not lib/native. A lib/native here is the exact #3898 regression.
+          ls -R "$prefix"/lib/pony/*/lib
+          test -f "$prefix"/lib/pony/*/lib/armv8/libponyrt.a
+          if ls -d "$prefix"/lib/pony/*/lib/native 2>/dev/null; then
+            echo "FAIL: runtime installed into lib/native instead of lib/armv8"; exit 1
+          fi
+          # Convenience symlink (symlink=yes default) must resolve into lib/armv8.
+          test -L "$prefix"/lib/libponyrt.a
+          # End-to-end: the installed compiler must find its runtime and link.
+          mkdir -p hello
+          printf 'actor Main\n  new create(env: Env) =>\n    env.out.print("ok")\n' > hello/main.pony
+          "$prefix"/bin/ponyc hello --output hello
+          ./hello/hello
 
   x86_64-windows:
     if: github.event.pull_request.draft == false

--- a/.release-notes/fix-install-honors-configured-arch.md
+++ b/.release-notes/fix-install-honors-configured-arch.md
@@ -1,0 +1,17 @@
+## Make `make install` honor the architecture chosen at `make configure`
+
+Previously, the Unix Makefile's `install` target built its destination from
+make's `arch` variable, which defaults to `native` on every invocation. The
+build, however, was configured against the `PONY_ARCH` cached by CMake at
+`make configure` time. Running `make configure arch=<non-default>`, `make
+build`, then `make install` (without re-passing `arch=`) installed the runtime
+libraries into `lib/native/` while the compiler — which looks for its runtime
+at `lib/<arch>` using the architecture it was compiled with — searched
+elsewhere, producing an installation that could not find its own libraries.
+
+The `install` target now delegates to `cmake --install`, and the install rules
+place the runtime into `lib/${PONY_ARCH}` (a flat `lib/` on Windows, matching
+the compiler's platform-specific lookup). `PONY_ARCH`, set once at configure
+time, is the single source of truth for both the compiled-in lookup path and
+the install destination, so the install location can no longer drift from what
+the build configured.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,16 +519,38 @@ else()
     add_subdirectory(tools/pony-lint)
     add_subdirectory(tools/pony-doc)
 
+    # The ponyc compiler binary. Test and benchmark binaries are deliberately
+    # NOT installed — they are build artifacts, not part of a user install.
     install(TARGETS
         ponyc
-        libponyc.tests
-        libponyc.benchmarks
-        libponyrt.benchmarks
-        libponyrt.tests
         DESTINATION bin)
+
+    # Static libraries that are real CMake targets; CMake resolves their archive
+    # paths regardless of where they are emitted.
     install(TARGETS
+        libponyc
         libponyrt
         DESTINATION lib)
+
+    # Static libs and crt objects produced by custom build steps into the output
+    # directory. OPTIONAL because which ones exist is platform/config dependent:
+    # libponyrt-pic.a (Linux), libponyc-standalone.a, the crt objects (Linux),
+    # and libdtrace_probes.a (FreeBSD + DTrace).
+    install(FILES
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/libponyc-standalone.a
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/libponyrt-pic.a
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/libdtrace_probes.a
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtbeginS.o
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtendS.o
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtbeginT.o
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtend.o
+        DESTINATION lib
+        OPTIONAL)
+
+    # Public headers.
+    install(FILES src/libponyrt/pony.h DESTINATION include)
+    install(FILES src/common/pony/detail/atomics.h DESTINATION include/pony/detail)
+
     install(DIRECTORY packages/ DESTINATION packages)
     install(DIRECTORY examples/ DESTINATION examples PATTERN .gitignore EXCLUDE)
     install(PROGRAMS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,16 +525,26 @@ else()
         ponyc
         DESTINATION bin)
 
+    # Where the runtime libraries are installed. The compiler locates its runtime
+    # relative to the ponyc binary via add_exec_dir() in
+    # src/libponyc/pkg/package.c, and that lookup differs by platform:
+    #   * non-Windows: "../lib/<arch>", where <arch> is the compiled-in PONY_ARCH
+    #     (or --link-arch when the user overrides it at compile time). The install
+    #     destination must match PONY_ARCH so the default lookup resolves.
+    #   * Windows: a flat "..\lib" with no arch component.
+    # The destination is gated on platform to stay in sync with both branches.
+    if(WIN32)
+        set(PONY_LIB_DESTINATION lib)
+    else()
+        set(PONY_LIB_DESTINATION lib/${PONY_ARCH})
+    endif()
+
     # Static libraries that are real CMake targets; CMake resolves their archive
-    # paths regardless of where they are emitted. They MUST go in lib/${PONY_ARCH}
-    # because the compiler looks for its runtime at "../lib/<arch>" relative to
-    # the ponyc binary, where <arch> is the compiled-in PONY_ARCH (see
-    # add_exec_dir() in src/libponyc/pkg/package.c). PONY_ARCH is the single
-    # source of truth shared by the compiled binary and this install rule.
+    # paths regardless of where they are emitted.
     install(TARGETS
         libponyc
         libponyrt
-        DESTINATION lib/${PONY_ARCH})
+        DESTINATION ${PONY_LIB_DESTINATION})
 
     # Static libs and crt objects produced by custom build steps into the output
     # directory. OPTIONAL because which ones exist is platform/config dependent:
@@ -548,7 +558,7 @@ else()
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtendS.o
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtbeginT.o
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtend.o
-        DESTINATION lib/${PONY_ARCH}
+        DESTINATION ${PONY_LIB_DESTINATION}
         OPTIONAL)
 
     # Public headers.
@@ -557,13 +567,18 @@ else()
 
     install(DIRECTORY packages/ DESTINATION packages)
     install(DIRECTORY examples/ DESTINATION examples PATTERN .gitignore EXCLUDE)
+    # OPTIONAL mirrors the old Makefile's "if [ -f ... ]" guards: a build that
+    # excludes a tool binary should skip it, not fail the whole install.
     install(PROGRAMS
         $<TARGET_FILE_DIR:ponyc>/pony-lsp${CMAKE_EXECUTABLE_SUFFIX}
-        DESTINATION bin)
+        DESTINATION bin
+        OPTIONAL)
     install(PROGRAMS
         $<TARGET_FILE_DIR:ponyc>/pony-lint${CMAKE_EXECUTABLE_SUFFIX}
-        DESTINATION bin)
+        DESTINATION bin
+        OPTIONAL)
     install(PROGRAMS
         $<TARGET_FILE_DIR:ponyc>/pony-doc${CMAKE_EXECUTABLE_SUFFIX}
-        DESTINATION bin)
+        DESTINATION bin
+        OPTIONAL)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,11 +526,15 @@ else()
         DESTINATION bin)
 
     # Static libraries that are real CMake targets; CMake resolves their archive
-    # paths regardless of where they are emitted.
+    # paths regardless of where they are emitted. They MUST go in lib/${PONY_ARCH}
+    # because the compiler looks for its runtime at "../lib/<arch>" relative to
+    # the ponyc binary, where <arch> is the compiled-in PONY_ARCH (see
+    # add_exec_dir() in src/libponyc/pkg/package.c). PONY_ARCH is the single
+    # source of truth shared by the compiled binary and this install rule.
     install(TARGETS
         libponyc
         libponyrt
-        DESTINATION lib)
+        DESTINATION lib/${PONY_ARCH})
 
     # Static libs and crt objects produced by custom build steps into the output
     # directory. OPTIONAL because which ones exist is platform/config dependent:
@@ -544,7 +548,7 @@ else()
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtendS.o
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtbeginT.o
         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/crtend.o
-        DESTINATION lib
+        DESTINATION lib/${PONY_ARCH}
         OPTIONAL)
 
     # Public headers.

--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ distclean:
 	$(SILENT)([ -d build ] && rm -rf build) || true
 
 install: all
-	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config)
+	$(SILENT)cd '$(buildDir)' && env DESTDIR= CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config)
 ifeq ($(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
@@ -453,12 +453,13 @@ ifeq ($(symlink),yes)
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lint ]; then ln -s -f $(ponydir)/bin/pony-lint $(prefix)/bin/pony-lint; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-doc ]; then ln -s -f $(ponydir)/bin/pony-doc $(prefix)/bin/pony-doc; fi
 	$(SILENT)cmake_arch=`grep '^PONY_ARCH:' '$(buildDir)/CMakeCache.txt' | cut -d= -f2`; \
-	libdir=$(ponydir)/lib/$$cmake_arch; \
-	if [ -f $$libdir/libponyc.a ]; then ln -s -f $$libdir/libponyc.a $(prefix)/lib/libponyc.a; fi; \
-	if [ -f $$libdir/libponyc-standalone.a ]; then ln -s -f $$libdir/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi; \
-	if [ -f $$libdir/libponyrt.a ]; then ln -s -f $$libdir/libponyrt.a $(prefix)/lib/libponyrt.a; fi; \
-	if [ -f $$libdir/libponyrt-pic.a ]; then ln -s -f $$libdir/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi; \
-	if [ -f $$libdir/libdtrace_probes.a ]; then ln -s -f $$libdir/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
+	if [ -z "$$cmake_arch" ]; then echo "install: could not read PONY_ARCH from $(buildDir)/CMakeCache.txt; run 'make configure' first" >&2; exit 1; fi; \
+	libdir="$(ponydir)/lib/$$cmake_arch"; \
+	if [ -f "$$libdir/libponyc.a" ]; then ln -s -f "$$libdir/libponyc.a" "$(prefix)/lib/libponyc.a"; fi; \
+	if [ -f "$$libdir/libponyc-standalone.a" ]; then ln -s -f "$$libdir/libponyc-standalone.a" "$(prefix)/lib/libponyc-standalone.a"; fi; \
+	if [ -f "$$libdir/libponyrt.a" ]; then ln -s -f "$$libdir/libponyrt.a" "$(prefix)/lib/libponyrt.a"; fi; \
+	if [ -f "$$libdir/libponyrt-pic.a" ]; then ln -s -f "$$libdir/libponyrt-pic.a" "$(prefix)/lib/libponyrt-pic.a"; fi; \
+	if [ -f "$$libdir/libdtrace_probes.a" ]; then ln -s -f "$$libdir/libdtrace_probes.a" "$(prefix)/lib/libdtrace_probes.a"; fi
 	$(SILENT)ln -s -f $(ponydir)/include/pony.h $(prefix)/include/pony.h
 	$(SILENT)ln -s -f $(ponydir)/include/pony/detail/atomics.h $(prefix)/include/pony/detail/atomics.h
 endif

--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ distclean:
 	$(SILENT)([ -d build ] && rm -rf build) || true
 
 install: all
-	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config) --strip
+	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config)
 ifeq ($(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
@@ -452,11 +452,13 @@ ifeq ($(symlink),yes)
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lsp ]; then ln -s -f $(ponydir)/bin/pony-lsp $(prefix)/bin/pony-lsp; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lint ]; then ln -s -f $(ponydir)/bin/pony-lint $(prefix)/bin/pony-lint; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-doc ]; then ln -s -f $(ponydir)/bin/pony-doc $(prefix)/bin/pony-doc; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libponyc.a ]; then ln -s -f $(ponydir)/lib/libponyc.a $(prefix)/lib/libponyc.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libponyc-standalone.a ]; then ln -s -f $(ponydir)/lib/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libponyrt.a ]; then ln -s -f $(ponydir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libponyrt-pic.a ]; then ln -s -f $(ponydir)/lib/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/libdtrace_probes.a ]; then ln -s -f $(ponydir)/lib/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
+	$(SILENT)cmake_arch=`grep '^PONY_ARCH:' '$(buildDir)/CMakeCache.txt' | cut -d= -f2`; \
+	libdir=$(ponydir)/lib/$$cmake_arch; \
+	if [ -f $$libdir/libponyc.a ]; then ln -s -f $$libdir/libponyc.a $(prefix)/lib/libponyc.a; fi; \
+	if [ -f $$libdir/libponyc-standalone.a ]; then ln -s -f $$libdir/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi; \
+	if [ -f $$libdir/libponyrt.a ]; then ln -s -f $$libdir/libponyrt.a $(prefix)/lib/libponyrt.a; fi; \
+	if [ -f $$libdir/libponyrt-pic.a ]; then ln -s -f $$libdir/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi; \
+	if [ -f $$libdir/libdtrace_probes.a ]; then ln -s -f $$libdir/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
 	$(SILENT)ln -s -f $(ponydir)/include/pony.h $(prefix)/include/pony.h
 	$(SILENT)ln -s -f $(ponydir)/include/pony/detail/atomics.h $(prefix)/include/pony/detail/atomics.h
 endif

--- a/Makefile
+++ b/Makefile
@@ -442,26 +442,8 @@ clean:
 distclean:
 	$(SILENT)([ -d build ] && rm -rf build) || true
 
-install: build
-	@mkdir -p $(ponydir)/bin
-	@mkdir -p $(ponydir)/lib/$(arch)
-	@mkdir -p $(ponydir)/include/pony/detail
-	$(SILENT)cp $(buildDir)/src/libponyrt/libponyrt.a $(ponydir)/lib/$(arch)
-	$(SILENT)if [ -f $(buildDir)/src/libponyrt/libdtrace_probes.a ]; then cp $(buildDir)/src/libponyrt/libdtrace_probes.a $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/libponyc.a ]; then cp $(outDir)/libponyc.a $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/libponyc-standalone.a ]; then cp $(outDir)/libponyc-standalone.a $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/libponyrt-pic.a ]; then cp $(outDir)/libponyrt-pic.a $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/crtbeginS.o ]; then cp $(outDir)/crtbeginS.o $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/crtendS.o ]; then cp $(outDir)/crtendS.o $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/crtbeginT.o ]; then cp $(outDir)/crtbeginT.o $(ponydir)/lib/$(arch); fi
-	$(SILENT)if [ -f $(outDir)/crtend.o ]; then cp $(outDir)/crtend.o $(ponydir)/lib/$(arch); fi
-	$(SILENT)cp $(outDir)/ponyc $(ponydir)/bin
-	$(SILENT)if [ -f $(outDir)/pony-lsp ]; then cp $(outDir)/pony-lsp $(ponydir)/bin; fi
-	$(SILENT)if [ -f $(outDir)/pony-lint ]; then cp $(outDir)/pony-lint $(ponydir)/bin; fi
-	$(SILENT)if [ -f $(outDir)/pony-doc ]; then cp $(outDir)/pony-doc $(ponydir)/bin; fi
-	$(SILENT)cp src/libponyrt/pony.h $(ponydir)/include
-	$(SILENT)cp src/common/pony/detail/atomics.h $(ponydir)/include/pony/detail
-	$(SILENT)cp -r packages $(ponydir)/
+install: all
+	$(SILENT)cd '$(buildDir)' && env CC="$(CC)" CXX="$(CXX)" cmake --install '$(buildDir)' --prefix $(ponydir) --config $(config) --strip
 ifeq ($(symlink),yes)
 	@mkdir -p $(prefix)/bin
 	@mkdir -p $(prefix)/lib
@@ -470,11 +452,11 @@ ifeq ($(symlink),yes)
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lsp ]; then ln -s -f $(ponydir)/bin/pony-lsp $(prefix)/bin/pony-lsp; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-lint ]; then ln -s -f $(ponydir)/bin/pony-lint $(prefix)/bin/pony-lint; fi
 	$(SILENT)if [ -f $(ponydir)/bin/pony-doc ]; then ln -s -f $(ponydir)/bin/pony-doc $(prefix)/bin/pony-doc; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyc.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyc.a $(prefix)/lib/libponyc.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyc-standalone.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyrt.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyrt.a $(prefix)/lib/libponyrt.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libponyrt-pic.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi
-	$(SILENT)if [ -f $(ponydir)/lib/$(arch)/libdtrace_probes.a ]; then ln -s -f $(ponydir)/lib/$(arch)/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libponyc.a ]; then ln -s -f $(ponydir)/lib/libponyc.a $(prefix)/lib/libponyc.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libponyc-standalone.a ]; then ln -s -f $(ponydir)/lib/libponyc-standalone.a $(prefix)/lib/libponyc-standalone.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libponyrt.a ]; then ln -s -f $(ponydir)/lib/libponyrt.a $(prefix)/lib/libponyrt.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libponyrt-pic.a ]; then ln -s -f $(ponydir)/lib/libponyrt-pic.a $(prefix)/lib/libponyrt-pic.a; fi
+	$(SILENT)if [ -f $(ponydir)/lib/libdtrace_probes.a ]; then ln -s -f $(ponydir)/lib/libdtrace_probes.a $(prefix)/lib/libdtrace_probes.a; fi
 	$(SILENT)ln -s -f $(ponydir)/include/pony.h $(prefix)/include/pony.h
 	$(SILENT)ln -s -f $(ponydir)/include/pony/detail/atomics.h $(prefix)/include/pony/detail/atomics.h
 endif


### PR DESCRIPTION
## What does this PR do?

This change migrates the Unix Makefile install flow into CMake so the install step preserves the architecture selected during configure instead of falling back to the default.

## Why was this PR needed?

The install target previously used Makefile-driven shell logic and re-read the Make value for arch. That caused the installed runtime to drift from the configured architecture and broke installs for non-default arch values. This PR moves installation to CMake so configure/build/install all use the same source of truth.

## What are the relevant issue numbers?

Closes #3898

## Does this PR meet the acceptance criteria?

- [x] Tests added for new/changed behavior
- [x] All tests passing
- [x] Follows project style guide
- [x] No breaking changes introduced
- [x] Documentation updated (if applicable)