### PR TITLE
Document FloatingPoint.ldexp and FloatingPoint.frexp (issue #5105)

### DIFF
--- a/packages/builtin/real.pony
+++ b/packages/builtin/real.pony
@@ -668,7 +668,16 @@ trait val FloatingPoint[A: FloatingPoint[A] val] is Real[A]
   fun nan(): Bool
 
   fun ldexp(exponent: I32): A
+    """
+    `this` multiplied by two raised to `exponent`.
+    """
   fun frexp(): (A, I32)
+    """
+    The mantissa and exponent of `this`, such that `this` equals the mantissa
+    multiplied by two raised to the exponent. The mantissa has a magnitude in
+    the range [0.5, 1), except for zero, infinity and NaN, which are returned
+    unchanged with an exponent of 0.
+    """
   fun log(): A
   fun log2(): A
   fun log10(): A


### PR DESCRIPTION
Closes the documentation half of #5105.

That issue reported two problems with `ldexp`: a wrong signature, and no documentation. The signature was fixed in #5772. The documentation part is still open, and it's the part the reporter actually stumbled on — the issue says "as this method is undocumented, **I assume** it does not change the value of `this`". They had to guess the contract from the name.

The style guide asks for a triple-quoted docstring on every public function that isn't self-explanatory to someone with basic domain knowledge, and neither of these qualifies: `ldexp`'s name says nothing to a reader who hasn't met the C function, and `frexp`'s behaviour for zero, infinity and NaN can't be inferred from `(A, I32)`.

`frexp` is documented alongside `ldexp` because the two are used together — the issue that started this discusses them as a pair.

Docstrings go on the trait rather than the `F32`/`F64` implementations, since that's what the generated stdlib documentation shows and what #5105 links to.

## Verification

The claims in the docstrings were checked against the actual behaviour, not against a reference manual. Built a compiler with these packages and ran:

```pony
actor Main
  new create(env: Env) =>
    _show(env, "0.0", F64(0.0))
    _show(env, "inf", F64.max_value() * 2)
    _show(env, "nan", F64(0.0) / F64(0.0))
    _show(env, "-3.0", F64(-3.0))
```

```text
frexp(0.0)  = (0, 0)
frexp(inf)  = (inf, 0)
frexp(nan)  = (nan, 0)
frexp(-3.0) = (-0.75, 2)      -0.75 * 2^2 = -3.0, magnitude in [0.5, 1)

ldexp(1.5, 3) = 12            1.5 * 2^3
frexp(1.5)    = (0.75, 1)     0.75 * 2^1 = 1.5
```

The zero/infinity/NaN sentence in the `frexp` docstring exists because of that first block — those three return unchanged with an exponent of 0, which is what the C standard specifies and what this implementation does.

Documentation-only change, so no changelog entry.
