### PR TITLE
Show real default values in generated docs (issue #3323)

### DIFF
--- a/tools/pony-doc/_type_extractor.pony
+++ b/tools/pony-doc/_type_extractor.pony
@@ -295,19 +295,82 @@ primitive _TypeExtractor
 
   fun get_default_value(def_val: ast.AST box): (String | None) =>
     """
-    Extracts the default value string from a parameter's default AST node.
+    The default value of a parameter, rendered as source.
 
-    TK_STRING defaults are wrapped in explicit double quotes, all
-    others use raw `get_print()`.
+    Literals come straight from `get_print()`. Anything built from other
+    nodes — a call, a field access, a negated literal — is reassembled from
+    the AST by `_render_expr`, because `get_print()` on such a node returns
+    the token's own name: `USize.max_value()` came out as `call`.
     """
     if def_val.id() != ast.TokenIds.tk_none() then
       try
-        let child = def_val(0)?
-        let print_val = child.get_print()
-        if child.id() == ast.TokenIds.tk_string() then
-          "\"" + print_val + "\""
-        else
-          print_val
-        end
+        _render_expr(def_val(0)?)
       end
+    end
+
+  fun _render_expr(node: ast.AST box): String =>
+    """
+    An expression AST rendered back to source text.
+
+    Covers what appears in a default value: literals, references, field and
+    method access, calls with their arguments, and qualified type arguments.
+    A node this doesn't know falls back to `get_print()`, which is right for
+    every leaf token and no worse than the previous behaviour for the rest.
+    """
+    let id = node.id()
+    if id == ast.TokenIds.tk_string() then
+      "\"" + node.get_print() + "\""
+    elseif id == ast.TokenIds.tk_dot() then
+      try
+        _render_expr(node(0)?) + "." + node(1)?.get_print()
+      else
+        node.get_print()
+      end
+    elseif id == ast.TokenIds.tk_call() then
+      try
+        let receiver = node(0)?
+        // `-1` reaches the AST as a call to `neg` on the literal. Write the
+        // minus back rather than exposing the desugaring — and without the
+        // empty argument list a plain call would print.
+        if
+          (receiver.id() == ast.TokenIds.tk_dot()) and
+          (receiver(1)?.get_print() == "neg")
+        then
+          "-" + _render_expr(receiver(0)?)
+        else
+          _render_expr(receiver) + "(" + _render_args(node(1)?) + ")"
+        end
+      else
+        node.get_print()
+      end
+    elseif id == ast.TokenIds.tk_qualify() then
+      try
+        _render_expr(node(0)?) + "[" + _render_args(node(1)?) + "]"
+      else
+        node.get_print()
+      end
+    elseif (id == ast.TokenIds.tk_reference()) or (id == ast.TokenIds.tk_seq())
+    then
+      try _render_expr(node(0)?) else node.get_print() end
+    else
+      node.get_print()
+    end
+
+  fun _render_args(args: ast.AST box): String =>
+    """
+    Argument list rendered as source, comma-separated. An absent list
+    (`TK_NONE`) renders as the empty string, which is what a call with no
+    arguments needs.
+    """
+    if args.id() == ast.TokenIds.tk_none() then
+      ""
+    else
+      let result = String
+      var first = true
+      for arg in args.children() do
+        if not first then result.append(", ") end
+        result.append(_render_expr(arg))
+        first = false
+      end
+      result.clone()
     end


### PR DESCRIPTION
## Summary

Fixes #3323 — parameter defaults that aren't plain literals render as the name of their AST node.

```
Array.slice        to: USize val = call    →  to: USize val = -1
String.substring   to: ISize val = call    →  to: ISize val = ISize.max_value()
```

`get_default_value()` used `get_print()`, which returns the token's print representation: for a literal that's the value, for a call node it's the word `call`. The same thing happens through `TK_REFERENCE` — a `(A | None)` default showed as `reference` rather than `None`, which the issue doesn't mention but has the same cause.

The fix reassembles the expression from the AST: calls with their arguments, field and method access, qualified type arguments. Unary minus gets written back as `-1` rather than the `1.neg()` the parser desugars it into. Any node the renderer doesn't recognise falls back to `get_print()`, so no case gets worse than it is today.

**One note for whoever reviews this**: the issue says "the fix for this is almost assuredly in `docgen.c`... if you know c, you should be able to tackle this one", and it's labelled `good first issue`. That advice is stale twice over — the docgen pass was removed in 0.63.0, and the current generator is `tools/pony-doc/`, written in Pony. Might be worth editing the issue text so the next person doesn't go looking for a C file that isn't there.

## Area

- [x] Developer experience
- [ ] Architecture method
- [ ] Benchmark
- [ ] Use case
- [ ] Documentation
- [ ] CI, build, or release

## Verification

Built `pony-doc` from source against 0.67.0's `libponyc-standalone` and ran it on a probe package covering each shape of default:

```pony
primitive Probe
  fun literal(x: USize = 0): USize => x
  fun negative(x: USize = -1): USize => x
  fun method_call(x: ISize = ISize.max_value()): ISize => x
  fun string_default(s: String = "hi"): String => s
```

```text
before                              after
x: USize val = 0                    x: USize val = 0
x: USize val = call                 x: USize val = -1
x: ISize val = call                 x: ISize val = ISize.max_value()
s: String val = "hi"                s: String val = "hi"
```

Then on `packages/builtin`, checking the two methods named in the issue:

```text
fun box slice(
  from: USize val = 0,
  to: USize val = -1,              (was: call)
  step: USize val = 1)

fun box substring(
  from: ISize val,
  to: ISize val = ISize.max_value())   (was: call)
```

To confirm nothing else moved, I generated docs for `collections`, `itertools` and `time` with the released 0.67.0 `pony-doc` and with this build, and diffed the output. Every difference is a default value that previously printed as a node name:

```text
collections: 48 occurrences of `= call` replaced, plus 2 of `= reference`
itertools:   same
time:        same
no other lines differ
```

New values appearing: `-1`, `None`, `ISize.max_value()`, `USize.max_value()`.

## Skills used

Per CONTRIBUTING, the applicable ones from `ponylang/llm-skills`: `pony-comments` and `pony-prose` for the docstrings on the two new functions, `pony-code-review` for a pass over the change before opening this.

I didn't add a unit test: the existing `tools/pony-doc/test/` suite builds `DocType` values directly, and this code path needs a real AST to exercise. Happy to add one if you'd prefer it wired differently.
