### PR TITLE
Update the benchmark README for the CMake build

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,7 +1,28 @@
 Benchmarks for pony runtime
 
-Under this directory are benchmarks for the pony runtime that
-use the Google Benchmark Library. Run via `make benchmark` target.
+Under this directory are benchmarks for the pony runtime and for libponyc
+that use the Google Benchmark Library.
 
-For details Google Benchmark Library readme at: ../lib/gbenchmark/README.md
-Google Benchmark examples can be found at: ../lib/gbenchmark/test/
+The benchmarks build as part of a normal ponyc build. BUILD.md has the
+platform setup and the full steps; the build itself is:
+
+```bash
+cmake --preset release
+cmake --build --preset release
+```
+
+That produces one executable per subdirectory here, next to ponyc in
+`build/release`:
+
+- `libponyrt.benchmarks`
+- `libponyc.benchmarks`
+
+Run either one directly. `--help` lists the Google Benchmark options,
+among them `--benchmark_filter` to select cases by name and
+`--benchmark_repetitions` to repeat them.
+
+`cmake --install` does not install the benchmark binaries.
+
+`lib/CMakeLists.txt` sets the Google Benchmark version in
+`PONYC_GBENCHMARK_URL`. Google Benchmark documents its options and its
+API at https://github.com/google/benchmark.


### PR DESCRIPTION
Update the benchmark README for the CMake build

The README told readers to run the benchmarks via a `make benchmark`
target and pointed at `lib/gbenchmark` for the library's documentation
and examples. Neither exists: the Makefile went away when the build
moved to CMake in #5633, and Google Benchmark is fetched by
ExternalProject_Add from a release tarball rather than vendored as a
submodule, so `lib/gbenchmark` is never on disk.

Describe what the tree does now: the benchmarks build with the rest of
ponyc, the two executables land in `build/release`, and the library's
documentation lives upstream.
