### PR TITLE
Treat empty PR file listing as run-everything

### DIFF
--- a/.ci-scripts/pr_changed_suites.py
+++ b/.ci-scripts/pr_changed_suites.py
@@ -36,9 +36,10 @@ filter, or the workflow never starts and that suite silently never runs.
 Editing `pr.yml` itself re-triggers every suite: each suite's original filter
 re-included its own workflow file, and now there is one shared file.
 
-A `pulls/<n>/files` listing caps at 3000 files; a larger PR comes back truncated,
-so a full listing of exactly the cap (or more) is treated as "run everything"
-rather than risk skipping a suite whose only changed file fell past the cap.
+An empty listing and a truncated listing both run every suite. An empty listing
+means the API failed (an outage, a transient error), not that nothing changed. A
+truncated listing (3000 files, the API cap) means changed files were dropped. In
+both cases, skipping suites risks a false green.
 
 Stdlib only; no pip install on any CI runner.
 """
@@ -96,7 +97,11 @@ def render(result):
 
 def main():
     paths = [line.strip() for line in sys.stdin if line.strip()]
-    if len(paths) >= FILES_API_CAP:                 # truncated listing -> run all
+    if not paths:                                    # empty listing -> run all
+        print("warning: no changed files on stdin; "
+              "running all suites.", file=sys.stderr)
+        result = {n: True for n, _ in SUITES}
+    elif len(paths) >= FILES_API_CAP:                # truncated listing -> run all
         print(f"warning: changed-file list hit the API cap ({FILES_API_CAP}); "
               "running all suites.", file=sys.stderr)
         result = {n: True for n, _ in SUITES}

--- a/.ci-scripts/pr_changed_suites_test.py
+++ b/.ci-scripts/pr_changed_suites_test.py
@@ -136,8 +136,16 @@ def run_main(stdin_text):
 def test_main_integration():
     out, _ = run_main("src/libponyc/README.md\n")
     check("main gotcha", out, "ponyc=false\npony_compiler=true\ntools=false\n")
-    out, _ = run_main("\n  \n")  # blank lines are stripped -> empty changeset
-    check("main empty", out, "ponyc=false\npony_compiler=false\ntools=false\n")
+
+
+def test_main_empty_runs_all():
+    # An empty listing (API failure, blank lines only) is never "nothing
+    # changed" -- run every suite rather than report a false green.
+    for label, stdin in [("empty", ""), ("blanks", "\n  \n")]:
+        out, err = run_main(stdin)
+        check(f"empty-{label} runs all", out,
+              "ponyc=true\npony_compiler=true\ntools=true\n")
+        check(f"empty-{label} warns", "no changed files" in err, True)
 
 
 def test_main_truncation_runs_all():
@@ -157,7 +165,7 @@ def test_main_truncation_runs_all():
 TESTS = [test_single_path_table, test_or_aggregation, test_empty_changeset,
          test_ponyc_subset_of_tools, test_render_format,
          test_truncation_constant, test_main_integration,
-         test_main_truncation_runs_all]
+         test_main_empty_runs_all, test_main_truncation_runs_all]
 
 
 def main():

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Classify changed files
         id: classify
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename' | python3 .ci-scripts/pr_changed_suites.py >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
When `gh api` fails (GitHub REST API outage), `pr_changed_suites.py` gets empty stdin, classifies all suites as false, and the PR shows green with nothing built. This happened to PR #5777 during a 2026-07-16 outage.

An empty listing never means nothing changed. Treat it the same way the script already treats a truncated listing (3000+ files): run every suite and warn on stderr.

Also set `shell: bash` on the classify step so a non-zero `gh api` exit surfaces as a job failure via pipefail, rather than being silently swallowed by the pipeline.

Closes #5778
