### PR TITLE
Fix slow stdin reads from redirected files on Windows

### DIFF
--- a/.release-notes/fix-windows-stdin-file-perf.md
+++ b/.release-notes/fix-windows-stdin-file-perf.md
@@ -1,0 +1,3 @@
+## Fix slow stdin reads from redirected files on Windows
+
+On Windows, reading a file redirected into stdin (`program < file.txt`) was about nine times slower than necessary. The runtime now uses the same approach Linux and macOS use for redirected files, eliminating the overhead.

--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -138,8 +138,8 @@ actor Stdin is AsioEventNotify
 
   fun ref _read(): Bool =>
     """
-    Read a chunk of data from stdin. Read a maximum of _chunk_size bytes, send
-    ourself a resume message and stop reading to avoid starving other actors.
+    Read chunks of data from stdin until ~4KB has been delivered, then return
+    true so the caller can yield to other actors before continuing.
     """
     try
       let notify = _notify as InputNotify
@@ -167,8 +167,10 @@ actor Stdin is AsioEventNotify
         notify(consume data)
 
         ifdef windows then
-          // Not allowed to call pony_os_stdin_read again yet, exit loop.
-          return true
+          if _use_event then
+            // The asio backend must re-arm before the next read.
+            return true
+          end
         end
 
         sum = sum + len

--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -471,8 +471,13 @@ PONY_API bool pony_os_stdin_setup()
     if(GetConsoleMode(handle, &mode))
       SetConsoleMode(handle, mode & ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT));
   }
+
+  // A file (or NUL) returns data at once from ReadFile — there is nothing to
+  // wait for — so read it in a loop. A pipe or a console needs the event.
+  if(ponyint_stdin_kind() == STDIN_OTHER)
+    stdin_event_based = false;
 #else
-  // on *nix only not use events when stdin is a redirected file
+  // Skip events when stdin is a redirected file.
   fd_type_t stdin_type = fd_type(STDIN_FILENO);
   if((stdin_type == FD_TYPE_TTY) && is_stdout_tty)
     stdin_tty();
@@ -562,7 +567,10 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
     }
   }
 
-  if(len != 0)  // Start listening to stdin notifications again
+  // Resume stdin notifications only when the asio backend is managing events
+  // for stdin. In loop mode (STDIN_OTHER — a file or NUL) there is no event
+  // to resume.
+  if(len != 0 && ponyint_stdin_kind() != STDIN_OTHER)
     ponyint_sock_notify_resume_stdin();
 
   return len;


### PR DESCRIPTION
On Windows, `pony_os_stdin_setup` returned `true` for every stdin kind, so the Stdin actor always used event-based reading. For a redirected file, that sent every chunk through the asio thread and back even though `ReadFile` returns the data immediately. On top of that, the `ifdef windows` block in `Stdin._read` returned after a single chunk even in loop mode, preventing the batching that POSIX already does. At the default 32-byte chunk size, the overhead made file reads about nine times slower than necessary.

Three changes:

- `pony_os_stdin_setup` returns `false` for `STDIN_OTHER` (files, NUL) so Stdin reads in a loop, matching the POSIX path.
- `pony_os_stdin_read` skips the resume call when there is no event to resume.
- `Stdin._read` gates the Windows early-return on `_use_event` so loop-based reads batch up to 4KB per behavior invocation, matching POSIX.

Closes #5744
