### PR TITLE
Fix stale escape-sequence timeout corrupting later input in ANSITerm

### DIFF
--- a/packages/term/_test.pony
+++ b/packages/term/_test.pony
@@ -30,6 +30,7 @@ actor \nodoc\ Main is TestList
     test(_TestANSITermPrivateParam)
     test(_TestANSITermControlAbort)
     test(_TestANSITermTimeoutFlush)
+    test(_TestANSITermStaleTimeout)
     test(_TestANSITermRealTimerFlush)
     test(_TestANSITermDispose)
     test(_TestANSITermPromptForward)
@@ -512,9 +513,36 @@ class \nodoc\ iso _TestANSITermTimeoutFlush is UnitTest
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
     term.apply(_Bytes("\x1B"))
-    term._timeout()
+    term._timeout(1)
     term.apply(_Bytes("\x1B["))
-    term._timeout()
+    term._timeout(2)
+    term.prompt("")
+
+class \nodoc\ iso _TestANSITermStaleTimeout is UnitTest
+  """
+  A timeout armed for one escape sequence must not flush a later sequence's
+  buffer. Sequence 1 completes normally (up-arrow). Sequence 2 starts with a
+  lone ESC. A stale timeout tagged with sequence 1's generation fires while
+  sequence 2 is in progress; it is ignored because the generation doesn't
+  match, and the remaining bytes complete a second up-arrow. Without the
+  generation check the stale timeout's callback would flush the ESC as plain
+  input and the `[A` bytes would be delivered as literal characters instead.
+  """
+  fun name(): String => "term/ANSITerm.stale-timeout"
+
+  fun ref apply(h: TestHelper) =>
+    let expected = recover val ["up 000"; "up 000"] end
+    let timers = Timers
+    let term = ANSITerm(
+      SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+    h.dispose_when_done(term)
+    h.dispose_when_done(timers)
+    h.long_test(2_000_000_000)
+    term.apply(_Bytes("\x1B"))
+    term.apply(_Bytes("[A"))
+    term.apply(_Bytes("\x1B"))
+    term._timeout(1)
+    term.apply(_Bytes("[A"))
     term.prompt("")
 
 class \nodoc\ iso _TestANSITermRealTimerFlush is UnitTest

--- a/packages/term/ansi_term.pony
+++ b/packages/term/ansi_term.pony
@@ -56,6 +56,7 @@ actor ANSITerm
   var _esc_mod: U8 = 0
   var _esc_private: Bool = false
   embed _esc_buf: Array[U8] = Array[U8]
+  var _esc_gen: USize = 0
   var _closed: Bool = false
   let _auth: SignalAuth
   var _winch: (SignalHandler | None) = None
@@ -165,12 +166,16 @@ actor ANSITerm
         try _timers.cancel(_timer as Timer tag) end
       end
 
+      _esc_gen = _esc_gen + 1
+      let esc_gen = _esc_gen
+
       let t = recover
         object is TimerNotify
           let term: ANSITerm = this
+          let gen: USize = esc_gen
 
           fun ref apply(timer: Timer, count: U64): Bool =>
-            term._timeout()
+            term._timeout(gen)
             false
         end
       end
@@ -222,13 +227,20 @@ actor ANSITerm
       _closed = true
     end
 
-  be _timeout() =>
+  be _timeout(gen: USize) =>
     """
     Our timer since receiving an ESC has expired. Send the buffered data as if
-    it was not an escape sequence. Guarded like the other notifier-forwarding
-    behaviors so a timer that fires after dispose delivers nothing.
+    it was not an escape sequence. Each timer captures the generation that was
+    current when it was armed; a timeout whose generation doesn't match the
+    current one is stale (new data arrived and re-armed the timer) and is
+    ignored. Guarded like the other notifier-forwarding behaviors so a timer
+    that fires after dispose delivers nothing.
     """
     if _closed then
+      return
+    end
+
+    if gen != _esc_gen then
       return
     end
 


### PR DESCRIPTION
When an escape sequence arrives split across reads, ANSITerm arms a 25ms timer to flush the partial sequence as plain input. If the sequence completes and a new one starts before the timer message reaches the actor's mailbox, the stale timeout flushes the new sequence's buffer instead of the old one's. `_timers.cancel()` can't recall a message already queued to the actor.

Each timer now captures a generation counter that `_timeout` checks against the current value; a mismatch means new data arrived and re-armed the timer, so the stale callback is dropped.

Closes ponylang/ponyc#5692
