### PR TITLE
Compile the generative stress engine in per-PR CI

### DIFF
--- a/.ci-scripts/pr_changed_suites.py
+++ b/.ci-scripts/pr_changed_suites.py
@@ -10,12 +10,16 @@ each suite to stdout in `$GITHUB_OUTPUT` (`name=value`) format.
 The rules are the three suites' original `paths:` blocks, transcribed as plain
 prefix/suffix/exact tests -- no glob engine -- plus two deliberate departures
 from those blocks. First, `test/rt-stress/` and `test/rt-systematic/` are
-excluded from every suite. They hold test workloads the PR suites build nothing
-of -- their Pony is compiled and run only by scheduled workflows (`stress-test-*`
-and `ponyc-weekly-checks.yml`). The stress harness's Python orchestration is
-linted by `lint-python.yml` and tested by `test-rt-stress.yml` when it changes;
+excluded from every suite -- with one exception: the generative stress engine's
+`.pony` source (`test/rt-stress/generative/**/*.pony`) triggers the `ponyc`
+suite so a compile check catches syntax errors, type errors, and stdlib API
+drift at PR time. The remaining test workloads' Pony
+is compiled and run only by scheduled workflows (`stress-test-*` and
+`ponyc-weekly-checks.yml`). The stress harness's Python orchestration is linted
+by `lint-python.yml` and tested by `test-rt-stress.yml` when it changes;
 `test/rt-systematic/` carries no Python (its orchestrator lives under
-`.ci-scripts/`). So a PR touching only these needs none of these suites.
+`.ci-scripts/`). So a PR touching only the excluded subset needs none of these
+suites.
 
 Second, the shared CMake build system -- the top-level `CMakeLists.txt`,
 `CMakePresets.json`, and `cmake/` -- triggers `pony_compiler`. That suite builds
@@ -50,6 +54,9 @@ WORKFLOW_FILE = '.github/workflows/pr.yml'
 
 
 def excluded(path):
+    if (path.startswith('test/rt-stress/generative/')
+            and path.endswith('.pony')):
+        return False
     return (path.endswith('.md') or path.endswith('.yml')
             or path.startswith('.dockerfiles/')
             or path.startswith('.ci-dockerfiles/')

--- a/.ci-scripts/pr_changed_suites_test.py
+++ b/.ci-scripts/pr_changed_suites_test.py
@@ -49,10 +49,10 @@ SINGLE_PATH_TABLE = [
     ('lib/CMakePresets.json', (True, False, True)),
     ('cmakefoo/build.cmake', (True, False, True)),
     ('cmake/notes.md', (False, False, False)),
-    # scheduled-only test workloads trigger no suite: nothing under
-    # test/rt-stress/ or test/rt-systematic/ feeds test-ci-core or the tools
-    # build, so the whole directory is excluded -- a .py orchestration file and
-    # a .pony workload alike classify to nothing.
+    # The generative stress engine's .pony source triggers the ponyc suite
+    # (not excluded like the rest of test/rt-stress/). Python, other workloads'
+    # Pony, and rt-systematic stay excluded.
+    ('test/rt-stress/generative/main.pony', (True, False, True)),
     ('test/rt-stress/generative/orchestrate_normal_test.py', (False, False,
                                                               False)),
     ('test/rt-stress/generative/stress_common.py', (False, False, False)),

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,8 +7,10 @@ on:
     # for any file that triggers any suite in `.ci-scripts/pr_changed_suites.py`;
     # otherwise that PR never starts the workflow and the suite silently never
     # runs. `ponyc` is a subset of `tools`, so the union is `tools` plus
-    # `pony_compiler` plus this workflow file. The re-includes below add back the
-    # pony_compiler paths (which have no doc/yaml exclusion) and this file.
+    # `pony_compiler` plus this workflow file. The re-includes below add back
+    # the pony_compiler paths (which have no doc/yaml exclusion), this file,
+    # and the generative stress engine's Pony source (compiled in the ponyc
+    # suite to catch breaks at PR time).
     paths:
       - '**'
       - '!**/*.md'
@@ -17,13 +19,15 @@ on:
       - '!.ci-dockerfiles/**'
       - '!.gitignore'
       - '!.markdownlintignore'
-      # Test workloads these suites build nothing of: their Pony runs only in
-      # scheduled workflows (stress-test-*, ponyc-weekly-checks). The stress
-      # harness's Python is linted by lint-python.yml and tested by
-      # test-rt-stress.yml; rt-systematic has no Python. Excluded here AND in
-      # pr_changed_suites.py.
+      # Test workloads whose Pony runs only in scheduled workflows
+      # (stress-test-*, ponyc-weekly-checks). The stress harness's Python is
+      # linted by lint-python.yml and tested by test-rt-stress.yml;
+      # rt-systematic has no Python. Excluded here AND in
+      # pr_changed_suites.py, except the generative engine's .pony source
+      # (re-included below; compiled in the ponyc suite).
       - '!test/rt-stress/**'
       - '!test/rt-systematic/**'
+      - 'test/rt-stress/generative/**/*.pony'
       - 'src/libponyc/**'
       - 'tools/lib/ponylang/pony_compiler/**'
       - '.github/workflows/pr.yml'
@@ -162,6 +166,8 @@ jobs:
           PONY_TEST_DEBUGGER="$(.ci-scripts/test-debugger.sh lldb)"
           export PONY_TEST_DEBUGGER
           ctest --preset x86-64-debug -L ci-core
+      - name: Compile generative stress engine
+        run: PONYPATH=packages build/debug/ponyc -d --pic -b generative -o build/debug test/rt-stress/generative/
       - name: Build Release Runtime
         run: |
           cmake --preset x86-64-release


### PR DESCRIPTION
The generative stress engine is only compiled by scheduled cron workflows. A break in its source passes PR CI clean and surfaces at the next daily run, which can be a day or more later.

This adds a compile-only step to the existing ponyc Linux debug job. The compile runs on every ponyc-suite run, not just when engine files change, so it also catches compiler/stdlib/runtime changes that break the engine. It reuses the debug-built ponyc from the same job, so the cost is a few seconds.

Three pieces: the workflow-level paths filter re-includes `test/rt-stress/generative/**/*.pony`; `pr_changed_suites.py` no longer excludes those files (so an engine-only change triggers the ponyc suite); and the ponyc Linux job gets a compile step after the debug test.

The compile runs only on Linux. The engine is pure Pony -- type errors are platform-independent, and the scheduled stress tests already cover all three platforms.

Closes #5650
