### PR TITLE
Fix FilePath.from allowing paths outside the base directory

### DIFF
--- a/.release-notes/fix-filepath-from-containment.md
+++ b/.release-notes/fix-filepath-from-containment.md
@@ -1,9 +1,9 @@
 ## Fix FilePath.from allowing paths outside the base directory
 
-`FilePath.from` and `FilePath.join` are meant to keep the resulting path within the directory that the base `FilePath` grants access to. Two kinds of relative path slipped past that check and produced a `FilePath`, carrying the base's capabilities, that pointed outside the directory.
+`FilePath.from` and `FilePath.join` are meant to keep the resulting path within the directory that the base `FilePath` grants access to. Two kinds of relative path were accepted despite pointing outside it, producing a `FilePath` that carried the base's capabilities.
 
-The first was a sibling whose name began with the base directory's name. Given a `FilePath` for `/srv/app`, `base.join("../app-backup/secret")` was accepted and named a file under `/srv/app-backup`, outside `/srv/app`. The second was a path containing an embedded NUL byte, which the check read in full while the operating system stopped at the NUL, so the two disagreed about which file was named. Because every `Directory` operation on a relative path routes through the same check, both escapes were reachable through `Directory` as well.
+The first was a sibling whose name began with the base directory's name. Given a `FilePath` for `/srv/app`, `base.join("../app-backup/secret")` was accepted and named a file under `/srv/app-backup`, outside `/srv/app`. The second was a path containing an embedded NUL byte: it was accepted, and the operating system, which stops reading a path at the first NUL, then acted on a shorter path naming a different file. `Directory` operations that take a relative path were affected in the same way.
 
-Both are now rejected with an error. A path is accepted only when it is the base path itself or lies beneath it at a directory boundary, and a path containing a NUL byte is refused.
+Both are now rejected with an error. A path is accepted only when it is the base path itself or a path below it, and never when it contains a NUL byte.
 
 Containment is still checked on the path text and does not resolve symlinks, so a symlink within the directory can still lead outside it.

--- a/.release-notes/fix-filepath-from-containment.md
+++ b/.release-notes/fix-filepath-from-containment.md
@@ -1,0 +1,9 @@
+## Fix FilePath.from allowing paths outside the base directory
+
+`FilePath.from` and `FilePath.join` are meant to keep the resulting path within the directory that the base `FilePath` grants access to. Two kinds of relative path slipped past that check and produced a `FilePath`, carrying the base's capabilities, that pointed outside the directory.
+
+The first was a sibling whose name began with the base directory's name. Given a `FilePath` for `/srv/app`, `base.join("../app-backup/secret")` was accepted and named a file under `/srv/app-backup`, outside `/srv/app`. The second was a path containing an embedded NUL byte, which the check read in full while the operating system stopped at the NUL, so the two disagreed about which file was named. Because every `Directory` operation on a relative path routes through the same check, both escapes were reachable through `Directory` as well.
+
+Both are now rejected with an error. A path is accepted only when it is the base path itself or lies beneath it at a directory boundary, and a path containing a NUL byte is refused.
+
+Containment is still checked on the path text and does not resolve symlinks, so a symlink within the directory can still lead outside it.

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -244,17 +244,21 @@ class \nodoc\ iso _TestFilePathFromContainment is UnitTest
 class \nodoc\ iso _TestFilePathFromNul is UnitTest
   """
   _TestFilePathFromNul checks that `FilePath.from` rejects a path containing an
-  embedded NUL byte. Without this the lexical containment check sees the whole
-  string while the OS, reading a C string, stops at the NUL and acts on a
-  shorter, different path.
+  embedded NUL byte. A Pony string may hold a NUL; the OS, reading a C string,
+  stops at it and acts on a shorter, different path.
   """
   fun name(): String => "files/FilePath.from-nul"
   fun apply(h: TestHelper) =>
     let base = FilePath(FileAuth(h.env.root), "/tmp/pony_sandbox")
-    let evil: String val = recover val
-      (String .> append("..")) .> push(0) .> append("/etc")
-    end
-    h.assert_error({()? => FilePath.from(base, evil)? })
+    h.assert_error(
+      {()? => FilePath.from(base, "..\x00/etc")? },
+      "a NUL byte surviving into the joined path must be rejected")
+    // `Path.clean` deletes the component before a `..`, taking the NUL with it,
+    // so the joined path is NUL-free and within the base. `Directory` passes
+    // this argument to the OS unchanged, where it names `../secret` instead.
+    h.assert_error(
+      {()? => FilePath.from(base, "../secret\x00/../pony_sandbox/child")? },
+      "a NUL byte that cleaning removes must still be rejected")
 
 class \nodoc\ iso _TestFilePathFromError is UnitTest
   """

--- a/packages/files/_test.pony
+++ b/packages/files/_test.pony
@@ -34,7 +34,9 @@ actor \nodoc\ Main is TestList
     test(_TestFileOpenWrite)
     test(_TestFilePathFileAuth)
     test(_TestFilePathFrom)
+    test(_TestFilePathFromContainment)
     test(_TestFilePathFromError)
+    test(_TestFilePathFromNul)
     test(_TestFileQueue)
     test(_TestFileQueuev)
     test(_TestFileReadMore)
@@ -222,6 +224,37 @@ class \nodoc\ iso _TestFilePathFrom is UnitTest
     let path = "tmp.filepath"
     let filepath = FilePath(FileAuth(h.env.root), path)
     h.assert_no_error({()? => FilePath.from(filepath, path)? })
+
+class \nodoc\ iso _TestFilePathFromContainment is UnitTest
+  """
+  _TestFilePathFromContainment checks that `FilePath.from` rejects a sibling
+  whose name merely begins with the base path's name, while still allowing a
+  genuine child. The containment check must fall on a path separator, not on a
+  raw byte prefix.
+  """
+  fun name(): String => "files/FilePath.from-containment"
+  fun apply(h: TestHelper) =>
+    let base = FilePath(FileAuth(h.env.root), "/tmp/pony_sandbox")
+    // A genuine child is within the hierarchy.
+    h.assert_no_error({()? => FilePath.from(base, "child")? })
+    // A sibling that extends the base name is not, even though its absolute
+    // path has the base path as a byte prefix.
+    h.assert_error({()? => FilePath.from(base, "../pony_sandbox_evil")? })
+
+class \nodoc\ iso _TestFilePathFromNul is UnitTest
+  """
+  _TestFilePathFromNul checks that `FilePath.from` rejects a path containing an
+  embedded NUL byte. Without this the lexical containment check sees the whole
+  string while the OS, reading a C string, stops at the NUL and acts on a
+  shorter, different path.
+  """
+  fun name(): String => "files/FilePath.from-nul"
+  fun apply(h: TestHelper) =>
+    let base = FilePath(FileAuth(h.env.root), "/tmp/pony_sandbox")
+    let evil: String val = recover val
+      (String .> append("..")) .> push(0) .> append("/etc")
+    end
+    h.assert_error({()? => FilePath.from(base, evil)? })
 
 class \nodoc\ iso _TestFilePathFromError is UnitTest
   """

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -76,8 +76,14 @@ class val FilePath
     """
     Create a new path from an existing `FilePath`.
 
-    path' is relative to the existing `FilePath`,
-    and the existing `FilePath` must be a prefix of the resulting path.
+    `path'` is relative to the existing `FilePath`. It is joined onto that path
+    and cleaned, and the result must be the existing path or lie within it. A
+    sibling whose name merely begins with the existing path's name is not within
+    it and raises an error, as does a `path'` that escapes upward with `..` or
+    contains a NUL byte.
+
+    Containment is textual: it does not resolve symlinks, so a symlink within
+    the existing path may still lead outside it.
 
     The resulting `FilePath` will have capabilities that are the intersection of
     the supplied capabilities and the capabilities of the existing `FilePath`.
@@ -90,7 +96,19 @@ class val FilePath
     let tmp_path = Path.join(base.path, path')
     caps.intersect(base.caps)
 
-    if not tmp_path.at(base.path, 0) then
+    // `tmp_path` must be `base.path` or lie beneath it. A byte-prefix match is
+    // not enough — a sibling like `.../sandbox_evil` shares the prefix
+    // `.../sandbox` without being within it — so the match must fall on a
+    // separator (or span the whole of a root `base.path` that ends in one). A
+    // NUL byte is rejected: the OS would stop at it and act on a shorter path
+    // than the one checked here.
+    let contained =
+      tmp_path.at(base.path, 0) and
+        ((tmp_path.size() == base.path.size()) or
+          (try Path.is_sep(base.path(base.path.size() - 1)?) else false end) or
+          (try Path.is_sep(tmp_path(base.path.size())?) else false end))
+
+    if tmp_path.contains("\x00") or not contained then
       error
     end
     path = tmp_path

--- a/packages/files/file_path.pony
+++ b/packages/files/file_path.pony
@@ -77,10 +77,12 @@ class val FilePath
     Create a new path from an existing `FilePath`.
 
     `path'` is relative to the existing `FilePath`. It is joined onto that path
-    and cleaned, and the result must be the existing path or lie within it. A
-    sibling whose name merely begins with the existing path's name is not within
-    it and raises an error, as does a `path'` that escapes upward with `..` or
-    contains a NUL byte.
+    and the result cleaned; that result must be the existing path itself or a
+    path within it, and any other result is an error.
+
+    A sibling whose name begins with the existing path's name is not within it:
+    from a base of `/srv/app`, a `path'` of `../app-backup/secret` is an error.
+    A `path'` containing a NUL byte is an error.
 
     Containment is textual: it does not resolve symlinks, so a symlink within
     the existing path may still lead outside it.
@@ -97,18 +99,23 @@ class val FilePath
     caps.intersect(base.caps)
 
     // `tmp_path` must be `base.path` or lie beneath it. A byte-prefix match is
-    // not enough — a sibling like `.../sandbox_evil` shares the prefix
-    // `.../sandbox` without being within it — so the match must fall on a
-    // separator (or span the whole of a root `base.path` that ends in one). A
-    // NUL byte is rejected: the OS would stop at it and act on a shorter path
-    // than the one checked here.
+    // not enough: a sibling like `.../sandbox_evil` has `.../sandbox` as a
+    // prefix without being within it, so the match must end at a separator or
+    // at the end of a base path that already ends in one.
+    //
+    // Both strings are checked for a NUL byte. `Directory` hands `path'`
+    // straight to the *at syscalls, which stop at the first NUL, and
+    // `Path.clean` drops a NUL-bearing component when a later `..` backtracks
+    // over it, so a NUL in `path'` need not survive into `tmp_path`.
     let contained =
       tmp_path.at(base.path, 0) and
         ((tmp_path.size() == base.path.size()) or
           (try Path.is_sep(base.path(base.path.size() - 1)?) else false end) or
           (try Path.is_sep(tmp_path(base.path.size())?) else false end))
 
-    if tmp_path.contains("\x00") or not contained then
+    if
+      path'.contains("\x00") or tmp_path.contains("\x00") or not contained
+    then
       error
     end
     path = tmp_path
@@ -124,8 +131,8 @@ class val FilePath
 
     If `FileAuth` is provided, the resulting `FilePath` will
     be relative to the program's working directory. Otherwise, it will be
-    relative to the existing `FilePath`, and the existing `FilePath` must be a
-    prefix of the resulting path.
+    relative to the existing `FilePath`, and must be that path or a path within
+    it, on the same terms as `FilePath.from`.
 
     The resulting `FilePath` will have capabilities that are the intersection
     of the supplied capabilities and the capabilities on the base.


### PR DESCRIPTION
FilePath.from's containment check compared the joined path against the base as a raw byte prefix, so a sibling whose name extended the base's name (e.g. base /srv/app accepting ../app-backup/secret) passed as if it were within the base. It also accepted a path containing an embedded NUL, which the check read in full while the OS, reading a C string, stopped at the NUL and acted on a shorter, different path. Both produced a FilePath carrying the base's capabilities but pointing outside the granted directory, and both were reachable through every Directory operation on a relative path, since those route through FilePath.from.

The check now requires the match to be the whole base path or to fall on a path separator, and rejects any path containing a NUL byte. Containment remains textual and does not resolve symlinks.