### PR TITLE
Fix TCP and UDP sockets being closed when the system runs low on socket buffers

### DIFF
--- a/.release-notes/socket-send-buffer-exhaustion.md
+++ b/.release-notes/socket-send-buffer-exhaustion.md
@@ -1,0 +1,3 @@
+## Fix TCP and UDP sockets being closed when the system runs low on socket buffers
+
+Under heavy load the operating system can momentarily run out of buffer space while a socket is sending. Previously the runtime treated this as a fatal error: a `TCPConnection` closed the connection, dropping data that had not yet been delivered, and a `UDPSocket` closed entirely because a single datagram could not be queued. The condition is transient, so it is now handled the way a full send buffer already is — a `TCPConnection` pauses sending and resumes once space is available, and a `UDPSocket` drops the datagram and keeps running. This was most visible on macOS under high connection churn.

--- a/packages/net/udp_socket.pony
+++ b/packages/net/udp_socket.pony
@@ -370,8 +370,8 @@ actor UDPSocket is AsioEventNotify
     if not _closed then
       // `count` (bytes sent on Ok) is discarded: UDP is unreliable, so we
       // don't track partial-send progress. The local is required by the FFI
-      // shape. `_SocketResultRetry` (EWOULDBLOCK/EAGAIN) silently drops the
-      // datagram on every platform. A send Error closes the socket.
+      // shape. `_SocketResultRetry` (EWOULDBLOCK/EAGAIN/ENOBUFS) silently drops
+      // the datagram on every platform. A send Error closes the socket.
       var count: USize = 0
       match \exhaustive\ _SocketResultDecoder(
         @pony_os_sendto(_fd, data.cpointer(), data.size(), to,

--- a/src/libponyrt/lang/socket.c
+++ b/src/libponyrt/lang/socket.c
@@ -702,7 +702,10 @@ PONY_API pony_socket_result_t pony_os_sendv(asio_event_t* ev,
 
   if(r == SOCKET_ERROR)
   {
-    if(WSAGetLastError() == WSAEWOULDBLOCK)
+    int wsa_err = WSAGetLastError();
+    // WSAENOBUFS is retryable transient buffer exhaustion, like WSAEWOULDBLOCK;
+    // see pony_os_sendv's POSIX branch for the rationale.
+    if(wsa_err == WSAEWOULDBLOCK || wsa_err == WSAENOBUFS)
     {
       *count_out = 0;
       return PONY_SOCKET_RETRY;
@@ -741,7 +744,11 @@ PONY_API pony_socket_result_t pony_os_sendv(asio_event_t* ev,
 
   if(sent < 0)
   {
-    if(errno == EWOULDBLOCK || errno == EAGAIN)
+    // ENOBUFS is transient buffer exhaustion, not a dead connection: the kernel
+    // momentarily has no send buffers (macOS does this on a congested
+    // interface). Retry with backpressure like EAGAIN instead of returning an
+    // error, which the stdlib turns into a connection-killing hard close.
+    if(errno == EWOULDBLOCK || errno == EAGAIN || errno == ENOBUFS)
     {
       *count_out = 0;
       return PONY_SOCKET_RETRY;
@@ -762,7 +769,8 @@ PONY_API pony_socket_result_t pony_os_writev(asio_event_t* ev,
 
   if(sent < 0)
   {
-    if(errno == EWOULDBLOCK || errno == EAGAIN)
+    // ENOBUFS is retryable transient buffer exhaustion; see pony_os_sendv.
+    if(errno == EWOULDBLOCK || errno == EAGAIN || errno == ENOBUFS)
     {
       *count_out = 0;
       return PONY_SOCKET_RETRY;
@@ -785,7 +793,9 @@ PONY_API pony_socket_result_t pony_os_send(asio_event_t* ev, const char* buf,
 
   if(sent == SOCKET_ERROR)
   {
-    if(WSAGetLastError() == WSAEWOULDBLOCK)
+    int wsa_err = WSAGetLastError();
+    // WSAENOBUFS is retryable transient buffer exhaustion; see pony_os_sendv.
+    if(wsa_err == WSAEWOULDBLOCK || wsa_err == WSAENOBUFS)
     {
       *count_out = 0;
       return PONY_SOCKET_RETRY;
@@ -802,7 +812,8 @@ PONY_API pony_socket_result_t pony_os_send(asio_event_t* ev, const char* buf,
 
   if(sent < 0)
   {
-    if(errno == EWOULDBLOCK || errno == EAGAIN)
+    // ENOBUFS is retryable transient buffer exhaustion; see pony_os_sendv.
+    if(errno == EWOULDBLOCK || errno == EAGAIN || errno == ENOBUFS)
     {
       *count_out = 0;
       return PONY_SOCKET_RETRY;
@@ -890,7 +901,9 @@ PONY_API pony_socket_result_t pony_os_sendto(int fd, const char* buf,
 
   if(sent == SOCKET_ERROR)
   {
-    if(WSAGetLastError() == WSAEWOULDBLOCK)
+    int wsa_err = WSAGetLastError();
+    // WSAENOBUFS is retryable transient buffer exhaustion; see pony_os_sendv.
+    if(wsa_err == WSAEWOULDBLOCK || wsa_err == WSAENOBUFS)
     {
       *count_out = 0;
       return PONY_SOCKET_RETRY;
@@ -916,7 +929,9 @@ PONY_API pony_socket_result_t pony_os_sendto(int fd, const char* buf,
 
   if(sent < 0)
   {
-    if(errno == EWOULDBLOCK || errno == EAGAIN)
+    // ENOBUFS is retryable transient buffer exhaustion; see pony_os_sendv. For
+    // UDP the retry result drops the datagram rather than closing the socket.
+    if(errno == EWOULDBLOCK || errno == EAGAIN || errno == ENOBUFS)
     {
       *count_out = 0;
       return PONY_SOCKET_RETRY;


### PR DESCRIPTION
A stream or datagram send that failed with `ENOBUFS` (POSIX) or `WSAENOBUFS` (Windows) was treated as a fatal error: `TCPConnection` hard-closed the connection — discarding unsent data and RSTing the peer — and `UDPSocket` closed the whole socket over a single congested datagram. That error is transient buffer exhaustion, not a dead connection: the kernel momentarily has no send buffers, which macOS returns readily on a congested interface. It is now retryable like `EAGAIN`/`WSAEWOULDBLOCK` — TCP applies backpressure and retries, UDP drops the datagram and keeps running.

Found while investigating the macOS TCP swarm stress-test failures, where sends against a congested loopback interface returned `ENOBUFS` and the runtime closed live connections mid-transfer.
