### PR TITLE
Cap the TCP swarm payload on macOS to avoid the loopback send-block

### DIFF
--- a/test/rt-stress/tcp-swarm/orchestrate_tcp.py
+++ b/test/rt-stress/tcp-swarm/orchestrate_tcp.py
@@ -90,6 +90,22 @@ CLOSE_KINDS = ["graceful", "hard"]
 # Payload sizes span the runtime's 16384-byte default read buffer: below, at, and
 # above it, so runs straddle the read-chunk boundary rather than clustering small.
 PAYLOAD_SIZES = [1, 8, 64, 256, 1024, 4096, 16384, 65536]
+# macOS-only: cap the drawn payload at 16384 (applied in resolve_config when the
+# orchestrator runs on macOS). WHY: macOS loopback has no wire rate limit, so at
+# the largest payload the swarm pushes data onto lo0 faster than the interface's
+# buffer pool drains. sendmsg then BLOCKS in the kernel waiting for buffers (and
+# returns ENOBUFS) EVEN on a non-blocking socket -- O_NONBLOCK/MSG_DONTWAIT govern
+# the socket buffer, not the interface's buffer pool. A blocked send freezes the
+# scheduler thread that issued it and stalls the whole run, which the swarm reports
+# as a failure. This is a macOS kernel behavior, not a runtime bug: the runtime
+# cannot force the send non-blocking from userspace short of moving socket I/O off
+# the scheduler threads (an I/O-model change we are deliberately not making). The
+# 65536 payload paired with small read buffers (slow drain) triggers it reliably on
+# a real runner; 16384 stays clear of it while keeping the small-read-buffer yield
+# coverage. Linux and Windows loopback do not behave this way, so they are uncapped.
+# (The separate defect where the runtime treated ENOBUFS as fatal was fixed in
+# ponyc PR #5823; that fix does not stop the send from blocking.)
+MACOS_MAX_PAYLOAD = 16384
 # Read buffer + yield thresholds: small values drive frequent yields back to the
 # scheduler on any payload size; the 16384 default anchors the "unchanged" end.
 READ_BUFFER_SIZES = [128, 1024, 16384, 65536]
@@ -277,7 +293,8 @@ def _draw_memory_levers(rng, use_writev):
     return chosen
 
 
-def resolve_config(master_seed, max_threads, max_connections=None):
+def resolve_config(master_seed, max_threads, max_connections=None,
+                   max_payload=None):
     """Draw one TCP workload from a master seed. The draw is the seed-stability
     contract: change it and every seed remaps (breaking a historical --replay), so
     change it deliberately and regenerate the pinned goldens in orchestrate_tcp_test.py
@@ -291,7 +308,14 @@ def resolve_config(master_seed, max_threads, max_connections=None):
     max_connections, if set, caps the drawn connection count after the draw (no rng
     consumed, so within-host seed stability holds). Windows CI passes a small value
     because Windows opens TCP connections very slowly -- ~5.5/s, so 10k connections
-    is ~30 min and 100k would never finish inside the job's time budget."""
+    is ~30 min and 100k would never finish inside the job's time budget.
+
+    max_payload, if set, caps the drawn payload size (macOS passes MACOS_MAX_PAYLOAD;
+    see that constant for why). Like ponymaxthreads it makes the draw host-dependent,
+    but deterministically (the same cap is always applied on the same host), so
+    --replay still holds within a host. It caps payload BEFORE payload is used for
+    `expect` and the byte ceilings, so those reflect the capped size; it consumes no
+    rng."""
     rng = random.Random(master_seed)
 
     workload = {}
@@ -302,6 +326,11 @@ def resolve_config(master_seed, max_threads, max_connections=None):
     use_writev = rng.choice(WRITE_SHAPES) == "writev"
     mem = _draw_memory_levers(rng, use_writev)
     payload = mem["payload"]
+    # macOS loopback cap (see MACOS_MAX_PAYLOAD). Applied here, before payload is
+    # used for `expect` and the byte ceilings, so a capped run stays self-consistent
+    # (e.g. expect never exceeds the payload). Consumes no rng.
+    if max_payload is not None:
+        payload = min(payload, max_payload)
     read_buffer = mem["read_buffer"]
     workload["connections"] = mem["connections"]
     workload["concurrency"] = mem["concurrency"]
@@ -770,8 +799,13 @@ def main():
 
     failures = []
 
+    # macOS caps the payload to keep the swarm clear of the loopback sendmsg-block
+    # (see MACOS_MAX_PAYLOAD). Other platforms draw uncapped.
+    max_payload = MACOS_MAX_PAYLOAD if sys.platform == "darwin" else None
+
     def run_seed(seed):
-        config = resolve_config(seed, max_threads, args.max_connections)
+        config = resolve_config(seed, max_threads, args.max_connections,
+                                max_payload)
         result = execute(binary, config, version, args.out,
                          args.timeout_seconds, mem_limit_bytes,
                          args.no_progress_seconds, args.lldb)

--- a/test/rt-stress/tcp-swarm/orchestrate_tcp_test.py
+++ b/test/rt-stress/tcp-swarm/orchestrate_tcp_test.py
@@ -353,6 +353,38 @@ def test_max_connections_cap():
     check("max_connections: actually caps some seeds (not vacuous)", capped_any)
 
 
+def test_macos_payload_cap():
+    # macOS caps the payload (MACOS_MAX_PAYLOAD) to stay clear of the loopback
+    # sendmsg-block. Confirm it caps to min(drawn, cap); keeps the run consistent
+    # (expect must never exceed the capped payload, or the framed read never
+    # completes); leaves the independent levers alone; is deterministic; and isn't
+    # vacuous. The cap MAY change messages/connections too, since the byte-ceiling
+    # clamp (clamp_run) is a function of payload -- so those are not checked here.
+    cap = o.MACOS_MAX_PAYLOAD
+    ok = True
+    capped_any = False
+    untouched = ("concurrency", "read-buffer-size", "write-shape", "writev-chunks",
+                 "yield-after-reading", "yield-after-writing", "close")
+    for seed in range(300):
+        base = o.resolve_config(seed, 8)
+        capped = o.resolve_config(seed, 8, max_payload=cap)
+        w = capped["workload"]
+        if w["payload-size"] != min(base["workload"]["payload-size"], cap):
+            ok = False
+        if w["expect"] > w["payload-size"]:
+            ok = False
+        if any(w[k] != base["workload"][k] for k in untouched):
+            ok = False
+        if capped["runtime"] != base["runtime"]:
+            ok = False
+        if o.resolve_config(seed, 8, max_payload=cap) != capped:
+            ok = False
+        if base["workload"]["payload-size"] > cap:
+            capped_any = True
+    check("macOS payload cap: caps to min(drawn, cap), expect stays <= payload", ok)
+    check("macOS payload cap: actually caps some seeds (not vacuous)", capped_any)
+
+
 def test_ponymaxthreads_is_last_and_host_dependent():
     # Everything but --ponymaxthreads must be identical across host core counts;
     # only the last draw (ponymaxthreads) may differ. This is what lets the draw
@@ -712,7 +744,7 @@ def main():
                test_memory_budget, test_memory_budget_trims,
                test_est_peak_bytes_monotonic,
                test_memory_budget_rotates_the_trimmed_lever,
-               test_max_connections_cap,
+               test_max_connections_cap, test_macos_payload_cap,
                test_resolve_config_coverage_and_invariants,
                test_ponymaxthreads_is_last_and_host_dependent,
                test_build_argv, test_parse_result, test_lldb_argv,


### PR DESCRIPTION
The macOS TCP swarm stress test intermittently fails because of a macOS loopback behavior: at the largest drawn payload, the swarm pushes data onto `lo0` faster than the interface's buffer pool drains, and `sendmsg` then *blocks in the kernel* waiting for buffers — even on a non-blocking socket, since `O_NONBLOCK`/`MSG_DONTWAIT` govern the socket buffer, not the interface pool. A blocked send freezes the scheduler thread that issued it and stalls the whole run.

That's a macOS kernel limitation, not a runtime bug — the runtime can't force the send non-blocking from userspace without moving socket I/O off the scheduler threads, which we're not doing. So this caps the drawn payload to 16384 on macOS (a per-host, deterministic clamp in the same spirit as the existing Windows `--max-connections` cap), which stays clear of the block while keeping the small-read-buffer / mid-read-yield coverage. Linux and Windows loopback don't behave this way and are left uncapped.

Tuned on a local macOS box: the `65536` payload paired with small read buffers reliably triggers the block; `16384` stayed clear even under 8× parallel stress (well past a single CI run's `lo0` pressure). The `MACOS_MAX_PAYLOAD` constant carries the full rationale so it's not mistaken for an arbitrary number later. Since this box is stronger than the CI runner, the cap is a first cut — we'll watch the daily scheduled runs and can lower it (e.g. to 4096) if macOS still trips.

No release note: this is CI-internal, with no user-visible effect.
