### PR TITLE
Fix compiler crash when combining traits with abstract and default method

### DIFF
--- a/.release-notes/fix-crash-trait-abstract-default-body.md
+++ b/.release-notes/fix-crash-trait-abstract-default-body.md
@@ -1,0 +1,19 @@
+## Fix compiler crash when combining traits with abstract and default method
+
+When a type implemented two traits that declared the same method — one without a body and one with a default body — the compiler crashed instead of compiling the program. The crash depended on the order of traits in the provides list: it occurred when the trait without a body appeared before the trait with a default body.
+
+```pony
+// no_body.pony
+trait HasHello
+  fun hello(env: Env)
+
+// greeting.pony
+trait Greeting
+  fun hello(env: Env) =>
+    env.out.print("hello!")
+
+// main.pony — crashed with `(HasHello & Greeting)`, compiled fine with `(Greeting & HasHello)`
+actor Main is (HasHello & Greeting)
+  new create(env: Env) =>
+    hello(env)
+```

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -61,6 +61,7 @@ typedef struct method_t
 
 
 static bool trait_entity(ast_t* entity, pass_opt_t* options);
+static void local_types(ast_t* ast);
 
 
 // Report whether the given node is a method.
@@ -462,6 +463,7 @@ static ast_result_t rescope(ast_t** astp, pass_opt_t* options)
       pony_assert(ast_child(ast) != NULL);
       ast_set(ast, ast_name(ast_child(ast)), ast, SYM_UNDEFINED, true,
         options->strtab);
+      local_types(ast);
       break;
     }
 

--- a/test/full-program-tests/trait-default-body-abstract-then-concrete-var/greeting.pony
+++ b/test/full-program-tests/trait-default-body-abstract-then-concrete-var/greeting.pony
@@ -1,0 +1,5 @@
+trait Greeting
+  fun hello(env: Env) =>
+    var msg: String = "hello"
+    msg = msg + " world"
+    env.out.print(msg)

--- a/test/full-program-tests/trait-default-body-abstract-then-concrete-var/main.pony
+++ b/test/full-program-tests/trait-default-body-abstract-then-concrete-var/main.pony
@@ -1,0 +1,3 @@
+actor Main is (HasHello & Greeting)
+  new create(env: Env) =>
+    hello(env)

--- a/test/full-program-tests/trait-default-body-abstract-then-concrete-var/no_body.pony
+++ b/test/full-program-tests/trait-default-body-abstract-then-concrete-var/no_body.pony
@@ -1,0 +1,2 @@
+trait HasHello
+  fun hello(env: Env)

--- a/test/full-program-tests/trait-default-body-abstract-then-concrete/greeting.pony
+++ b/test/full-program-tests/trait-default-body-abstract-then-concrete/greeting.pony
@@ -1,0 +1,7 @@
+use "collections"
+
+trait Greeting
+  fun hello(env: Env) =>
+    let hi = Map[String, String]
+    hi.insert("hello", "world!")
+    try env.out.print(hi("hello")?) end

--- a/test/full-program-tests/trait-default-body-abstract-then-concrete/main.pony
+++ b/test/full-program-tests/trait-default-body-abstract-then-concrete/main.pony
@@ -1,0 +1,3 @@
+actor Main is (HasHello & Greeting)
+  new create(env: Env) =>
+    hello(env)

--- a/test/full-program-tests/trait-default-body-abstract-then-concrete/no_body.pony
+++ b/test/full-program-tests/trait-default-body-abstract-then-concrete/no_body.pony
@@ -1,0 +1,2 @@
+trait HasHello
+  fun hello(env: Env)


### PR DESCRIPTION
When `rescope` adopted a trait's default method body into an abstract method slot, TK_LET and TK_VAR nodes in the body kept their source trait's PASS_TRAITS flag. The main pass walker then skipped them, so `local_types` never ran and `ast_type` stayed NULL — crashing in `refer_local`'s assertion.

Call `local_types` from `rescope`'s TK_LET/TK_VAR case so adopted body nodes get their types set regardless of pass flags.

Closes #5825
