### PR TITLE
Add the style/testlist-nodoc pony-lint rule

### DIFF
--- a/.release-notes/add-testlist-nodoc-rule.md
+++ b/.release-notes/add-testlist-nodoc-rule.md
@@ -1,0 +1,17 @@
+## Add the style/testlist-nodoc pony-lint rule
+
+`style/testlist-nodoc` flags types that provide `TestList` without a `\nodoc\` annotation. `TestList` implementations exist only to register tests with PonyTest and don't belong in generated documentation.
+
+```pony
+// Flagged — missing \nodoc\
+primitive _MyTests is TestList
+  new make() => None
+  fun tag tests(test: PonyTest) => None
+
+// Clean
+primitive \nodoc\ _MyTests is TestList
+  new make() => None
+  fun tag tests(test: PonyTest) => None
+```
+
+The rule is on by default. Disable it with `--disable style/testlist-nodoc` or in `.pony-lint.json`.

--- a/examples/pony_check/main.pony
+++ b/examples/pony_check/main.pony
@@ -1,7 +1,7 @@
 use "pony_test"
 use "pony_check"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) =>
     PonyTest(env, this)
 

--- a/test/full-program-tests/regression-4284/main.pony
+++ b/test/full-program-tests/regression-4284/main.pony
@@ -4,7 +4,7 @@ use "pony_test"
 // _TestIssue4284 will pass. If a regression is introduced, this
 // program will crash.
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) =>
     PonyTest(env, this)
 

--- a/test/full-program-tests/regression-4340/main.pony
+++ b/test/full-program-tests/regression-4340/main.pony
@@ -43,7 +43,7 @@ class Node
   fun print_values(env: Env) =>
     env.out.print(this.univals().string())
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) =>
     PonyTest(env, this)
 

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -129,6 +129,7 @@ actor Main
         .> push(TypeParameterFormat)
         .> push(CallArgumentFormat)
         .> push(ExhaustiveMatch)
+        .> push(TestListNodoc)
     end
 
     // Handle --explain

--- a/tools/pony-lint/test/_test_test_list_nodoc.pony
+++ b/tools/pony-lint/test/_test_test_list_nodoc.pony
@@ -1,0 +1,214 @@
+use "pony_test"
+use ast = "pony_compiler"
+use lint = ".."
+
+class \nodoc\ _TestTestListNodocFlagged is UnitTest
+  """Primitive providing TestList without \nodoc\ is flagged."""
+  fun name(): String => "TestListNodoc: missing annotation flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "use \"pony_test\"\n" +
+      "\n" +
+      "primitive _MyTests is TestList\n" +
+      "  new make() => None\n" +
+      "  fun tag tests(test: PonyTest) => None\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.TestListNodoc)
+          h.assert_eq[USize](1, diags.size())
+          try
+            h.assert_eq[String](
+              "style/testlist-nodoc", diags(0)?.rule_id)
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestTestListNodocClean is UnitTest
+  """Primitive providing TestList with \nodoc\ is clean."""
+  fun name(): String => "TestListNodoc: annotated provider is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "use \"pony_test\"\n" +
+      "\n" +
+      "primitive \\nodoc\\ _MyTests is TestList\n" +
+      "  new make() => None\n" +
+      "  fun tag tests(test: PonyTest) => None\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.TestListNodoc)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestTestListNodocNoTestList is UnitTest
+  """Type not providing TestList is not flagged."""
+  fun name(): String => "TestListNodoc: non-TestList provider clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "trait Foo\n" +
+      "  fun bar(): String\n" +
+      "\n" +
+      "primitive MyImpl is Foo\n" +
+      "  fun bar(): String => \"hello\"\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.TestListNodoc)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestTestListNodocNoProvidesClean is UnitTest
+  """Type with no provides clause is not flagged."""
+  fun name(): String => "TestListNodoc: no provides clause clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "primitive Standalone\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.TestListNodoc)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestTestListNodocActorFlagged is UnitTest
+  """Actor providing TestList without \nodoc\ is flagged."""
+  fun name(): String => "TestListNodoc: actor without annotation flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "use \"pony_test\"\n" +
+      "\n" +
+      "actor Main is TestList\n" +
+      "  new create(env: Env) => PonyTest(env, this)\n" +
+      "  new make() => None\n" +
+      "  fun tag tests(test: PonyTest) => None\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.TestListNodoc)
+          h.assert_eq[USize](1, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestTestListNodocIsectFlagged is UnitTest
+  """Type providing TestList in an intersection without \nodoc\ is flagged."""
+  fun name(): String => "TestListNodoc: intersection provider flagged"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "use \"pony_test\"\n" +
+      "\n" +
+      "trait MyTrait\n" +
+      "  fun extra(): None\n" +
+      "\n" +
+      "primitive _MyTests is (TestList & MyTrait)\n" +
+      "  new make() => None\n" +
+      "  fun tag tests(test: PonyTest) => None\n" +
+      "  fun extra(): None => None\n"
+    try
+      (let program, let sf) =
+        _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.TestListNodoc)
+          h.assert_eq[USize](1, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestTestListNodocMetadata is UnitTest
+  """Rule metadata is correct."""
+  fun name(): String => "TestListNodoc: metadata"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("style/testlist-nodoc", lint.TestListNodoc.id())
+    h.assert_eq[String]("style", lint.TestListNodoc.category())
+    match lint.TestListNodoc.required_pass()
+    | ast.PassParse => None
+    else
+      h.fail("required_pass should be PassParse")
+    end
+    match lint.TestListNodoc.default_status()
+    | lint.RuleOn => None
+    else
+      h.fail("default_status should be RuleOn")
+    end

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -485,6 +485,15 @@ actor \nodoc\ Main is TestList
     test(_TestExhaustiveMatchExplicitElse)
     test(_TestExhaustiveMatchMetadata)
 
+    // TestListNodoc tests
+    test(_TestTestListNodocFlagged)
+    test(_TestTestListNodocClean)
+    test(_TestTestListNodocNoTestList)
+    test(_TestTestListNodocNoProvidesClean)
+    test(_TestTestListNodocActorFlagged)
+    test(_TestTestListNodocIsectFlagged)
+    test(_TestTestListNodocMetadata)
+
     // CallArgumentFormat tests
     test(_TestCallArgFmtSingleLine)
     test(_TestCallArgFmtAllOnNextLine)

--- a/tools/pony-lint/test_list_nodoc.pony
+++ b/tools/pony-lint/test_list_nodoc.pony
@@ -1,0 +1,76 @@
+use ast = "pony_compiler"
+
+primitive TestListNodoc is ASTRule
+  """
+  Flags types that provide `TestList` without a `\nodoc\` annotation.
+
+  `TestList` implementations exist only to register tests with PonyTest.
+  They belong in generated documentation no more than the `UnitTest` classes
+  they register, so the convention is to annotate them with `\nodoc\`.
+  """
+  fun id(): String val => "style/testlist-nodoc"
+  fun category(): String val => "style"
+
+  fun description(): String val =>
+    "TestList provider should have \\nodoc\\ annotation"
+
+  fun default_status(): RuleStatus => RuleOn
+
+  fun node_filter(): Array[ast.TokenId] val =>
+    [
+      ast.TokenIds.tk_class(); ast.TokenIds.tk_actor()
+      ast.TokenIds.tk_primitive(); ast.TokenIds.tk_struct()
+    ]
+
+  fun check(node: ast.AST box, source: SourceFile val)
+    : Array[Diagnostic val] val
+  =>
+    if node.has_annotation("nodoc") then
+      return recover val Array[Diagnostic val] end
+    end
+
+    try
+      let provides = node(3)?
+      if provides.id() == ast.TokenIds.tk_none() then
+        return recover val Array[Diagnostic val] end
+      end
+      if _provides_testlist(provides) then
+        let name_node = node(0)?
+        return recover val
+          [ Diagnostic(
+            id(),
+            "TestList provider should have \\nodoc\\ annotation",
+            source.rel_path,
+            name_node.line(),
+            name_node.pos()) ]
+        end
+      end
+    end
+    recover val Array[Diagnostic val] end
+
+  fun _provides_testlist(node: ast.AST box): Bool =>
+    """
+    Returns true if the provides subtree names `TestList`, including
+    through intersection types.
+    """
+    let tk = node.id()
+    if tk == ast.TokenIds.tk_nominal() then
+      try
+        match node(1)?.token_value()
+        | "TestList" => return true
+        end
+      end
+    elseif (tk == ast.TokenIds.tk_provides())
+      or (tk == ast.TokenIds.tk_isecttype())
+    then
+      var i: USize = 0
+      while true do
+        try
+          if _provides_testlist(node(i)?) then return true end
+        else
+          break
+        end
+        i = i + 1
+      end
+    end
+    false

--- a/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
@@ -46,7 +46,7 @@ use "json"
 // _TConstructorWithBody.create  new, name (9,6)..(9,12)  full (9,2)..(10,10)
 // a.f_a()  call site f_a (10,6)..(10,9)
 
-primitive _CallHierarchyIntegrationTests is TestList
+primitive \nodoc\ _CallHierarchyIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_definition_integration_tests.pony
@@ -4,7 +4,7 @@ use "files"
 use "json"
 use "collections"
 
-primitive _DefinitionIntegrationTests is TestList
+primitive \nodoc\ _DefinitionIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_diagnostics_tests.pony
+++ b/tools/pony-lsp/test/_diagnostics_tests.pony
@@ -3,7 +3,7 @@ use "pony_test"
 use "files"
 use "json"
 
-primitive _DiagnosticTests is TestList
+primitive \nodoc\ _DiagnosticTests is TestList
   new make() =>
     None
 

--- a/tools/pony-lsp/test/_document_highlight_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_highlight_integration_tests.pony
@@ -4,7 +4,7 @@ use "files"
 use "json"
 use "collections"
 
-primitive _DocumentHighlightIntegrationTests is TestList
+primitive \nodoc\ _DocumentHighlightIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_document_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_document_symbol_integration_tests.pony
@@ -3,7 +3,7 @@ use "pony_test"
 use "files"
 use "json"
 
-primitive _DocumentSymbolIntegrationTests is TestList
+primitive \nodoc\ _DocumentSymbolIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_folding_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_folding_range_integration_tests.pony
@@ -3,7 +3,7 @@ use "pony_test"
 use "files"
 use "json"
 
-primitive _FoldingRangeIntegrationTests is TestList
+primitive \nodoc\ _FoldingRangeIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_hover_formatter_tests.pony
+++ b/tools/pony-lsp/test/_hover_formatter_tests.pony
@@ -1,7 +1,7 @@
 use "pony_test"
 use "../workspace"
 
-primitive _HoverFormatterTests is TestList
+primitive \nodoc\ _HoverFormatterTests is TestList
   new make() =>
     None
 

--- a/tools/pony-lsp/test/_hover_integration_tests.pony
+++ b/tools/pony-lsp/test/_hover_integration_tests.pony
@@ -4,7 +4,7 @@ use "files"
 use "json"
 use "collections"
 
-primitive _HoverIntegrationTests is TestList
+primitive \nodoc\ _HoverIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_integration_tests.pony
@@ -3,7 +3,7 @@ use "pony_test"
 use "files"
 use "json"
 
-primitive _InlayHintIntegrationTests is TestList
+primitive \nodoc\ _InlayHintIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_inlay_hint_source_tests.pony
+++ b/tools/pony-lsp/test/_inlay_hint_source_tests.pony
@@ -1,7 +1,7 @@
 use "pony_test"
 use "../workspace"
 
-primitive _InlayHintSourceTests is TestList
+primitive \nodoc\ _InlayHintSourceTests is TestList
   new make() =>
     None
 

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -4,7 +4,7 @@ use "files"
 use "json"
 use "collections"
 
-primitive _ReferencesIntegrationTests is TestList
+primitive \nodoc\ _ReferencesIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_rename_integration_tests.pony
+++ b/tools/pony-lsp/test/_rename_integration_tests.pony
@@ -4,7 +4,7 @@ use "files"
 use "json"
 use "collections"
 
-primitive _RenameIntegrationTests is TestList
+primitive \nodoc\ _RenameIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_selection_range_integration_tests.pony
+++ b/tools/pony-lsp/test/_selection_range_integration_tests.pony
@@ -3,7 +3,7 @@ use "pony_test"
 use "files"
 use "json"
 
-primitive _SelectionRangeIntegrationTests is TestList
+primitive \nodoc\ _SelectionRangeIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_signature_help_integration_tests.pony
+++ b/tools/pony-lsp/test/_signature_help_integration_tests.pony
@@ -3,7 +3,7 @@ use "pony_test"
 use "files"
 use "json"
 
-primitive _SignatureHelpIntegrationTests is TestList
+primitive \nodoc\ _SignatureHelpIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_symbol_kinds_tests.pony
+++ b/tools/pony-lsp/test/_symbol_kinds_tests.pony
@@ -1,7 +1,7 @@
 use "pony_test"
 use ".."
 
-primitive _SymbolKindsTests is TestList
+primitive \nodoc\ _SymbolKindsTests is TestList
   new make() =>
     None
 

--- a/tools/pony-lsp/test/_type_definition_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_definition_integration_tests.pony
@@ -4,7 +4,7 @@ use "files"
 use "json"
 use "collections"
 
-primitive _TypeDefinitionIntegrationTests is TestList
+primitive \nodoc\ _TypeDefinitionIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
@@ -38,7 +38,7 @@ use "json"
 // (_THierDupClass provides _THierDupBase & _THierDupBase — the duplication
 // exercises Set[AST val] dedup in _collect_supertypes.)
 
-primitive _TypeHierarchyIntegrationTests is TestList
+primitive \nodoc\ _TypeHierarchyIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_uris_tests.pony
+++ b/tools/pony-lsp/test/_uris_tests.pony
@@ -2,7 +2,7 @@ use "pony_check"
 use "pony_test"
 use ".."
 
-primitive _URITests is TestList
+primitive \nodoc\ _URITests is TestList
   new make() =>
     None
 

--- a/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
+++ b/tools/pony-lsp/test/_workspace_symbol_integration_tests.pony
@@ -3,7 +3,7 @@ use "pony_test"
 use "files"
 use "json"
 
-primitive _WorkspaceSymbolIntegrationTests is TestList
+primitive \nodoc\ _WorkspaceSymbolIntegrationTests is TestList
   new make() => None
 
   fun tag tests(test: PonyTest) =>

--- a/tools/pony-lsp/test/_workspace_tests.pony
+++ b/tools/pony-lsp/test/_workspace_tests.pony
@@ -4,7 +4,7 @@ use "files"
 use ".."
 use "../workspace"
 
-primitive _WorkspaceTests is TestList
+primitive \nodoc\ _WorkspaceTests is TestList
   new make() =>
     None
 

--- a/tools/pony-lsp/test/main.pony
+++ b/tools/pony-lsp/test/main.pony
@@ -5,7 +5,7 @@ use "json"
 use ast = "pony_compiler"
 use ".."
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) =>
     PonyTest(env, this)
 


### PR DESCRIPTION
Adds a `style/testlist-nodoc` lint rule that flags types providing `TestList`
without a `\nodoc\` annotation, and fixes all 24 existing violations across
the repo.

`TestList` providers exist only to register tests with PonyTest and don't
belong in generated documentation.

Closes #5776
