### PR TITLE
Fix compiler crash with multiple traits sharing a method with a default body

### DIFF
--- a/.release-notes/fix-crash-trait-param-rescope.md
+++ b/.release-notes/fix-crash-trait-param-rescope.md
@@ -1,0 +1,19 @@
+## Fix compiler crash with multiple traits sharing a method with a default body
+
+When a type implemented multiple traits declaring the same method and one of those traits provided a default body, the compiler could crash.
+
+```pony
+trait Abstract1
+  fun hello(env: Env)
+
+trait Abstract2
+  fun hello(env: Env)
+
+trait Concrete
+  fun hello(env: Env) =>
+    env.out.print("hello")
+
+actor Main is (Abstract1 & Abstract2 & Concrete)
+  new create(env: Env) =>
+    hello(env)
+```

--- a/src/libponyc/pass/traits.c
+++ b/src/libponyc/pass/traits.c
@@ -602,7 +602,7 @@ static bool add_method_from_trait(ast_t* entity, ast_t* method,
   pony_assert(ast_id(existing_body) == TK_NONE);
   import_use_aliases(entity, (ast_t*)ast_data(method), opt);
   ast_replace(&existing_body, method_body);
-  ast_visit(&existing_body, rescope, NULL, opt, PASS_ALL);
+  ast_visit(&existing_method, rescope, NULL, opt, PASS_ALL);
 
   info->body_donor = (ast_t*)ast_data(method);
   info->trait_ref = trait_ref;

--- a/test/full-program-tests/trait-default-body-abstract-concrete-abstract/abstract1.pony
+++ b/test/full-program-tests/trait-default-body-abstract-concrete-abstract/abstract1.pony
@@ -1,0 +1,2 @@
+trait Abstract1
+  fun hello(env: Env)

--- a/test/full-program-tests/trait-default-body-abstract-concrete-abstract/abstract2.pony
+++ b/test/full-program-tests/trait-default-body-abstract-concrete-abstract/abstract2.pony
@@ -1,0 +1,2 @@
+trait Abstract2
+  fun hello(env: Env)

--- a/test/full-program-tests/trait-default-body-abstract-concrete-abstract/concrete.pony
+++ b/test/full-program-tests/trait-default-body-abstract-concrete-abstract/concrete.pony
@@ -1,0 +1,3 @@
+trait Concrete
+  fun hello(env: Env) =>
+    env.out.print("hello")

--- a/test/full-program-tests/trait-default-body-abstract-concrete-abstract/main.pony
+++ b/test/full-program-tests/trait-default-body-abstract-concrete-abstract/main.pony
@@ -1,0 +1,3 @@
+actor Main is (Abstract1 & Concrete & Abstract2)
+  new create(env: Env) =>
+    hello(env)

--- a/test/full-program-tests/trait-default-body-multiple-abstract-then-concrete/abstract1.pony
+++ b/test/full-program-tests/trait-default-body-multiple-abstract-then-concrete/abstract1.pony
@@ -1,0 +1,2 @@
+trait Abstract1
+  fun hello(env: Env)

--- a/test/full-program-tests/trait-default-body-multiple-abstract-then-concrete/abstract2.pony
+++ b/test/full-program-tests/trait-default-body-multiple-abstract-then-concrete/abstract2.pony
@@ -1,0 +1,2 @@
+trait Abstract2
+  fun hello(env: Env)

--- a/test/full-program-tests/trait-default-body-multiple-abstract-then-concrete/concrete.pony
+++ b/test/full-program-tests/trait-default-body-multiple-abstract-then-concrete/concrete.pony
@@ -1,0 +1,3 @@
+trait Concrete
+  fun hello(env: Env) =>
+    env.out.print("hello")

--- a/test/full-program-tests/trait-default-body-multiple-abstract-then-concrete/main.pony
+++ b/test/full-program-tests/trait-default-body-multiple-abstract-then-concrete/main.pony
@@ -1,0 +1,3 @@
+actor Main is (Abstract1 & Abstract2 & Concrete)
+  new create(env: Env) =>
+    hello(env)


### PR DESCRIPTION
When a bodiless method was added from one trait and a body was later adopted from another, `rescope` ran only on the body subtree, leaving stale symtab entries for the method's parameters pointing to the original trait's param nodes. The refer pass then resolved paramrefs to those stale params, which were never typed by the expr pass, causing the assertion at `expr.c:708`.

Rescope the entire method when adopting a body, matching the path that already rescopes the whole method when a method-with-body is added for the first time.

Closes #5828
