### PR TITLE
Fix stdin end-of-input and error handling

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -218,3 +218,51 @@ primitive \nodoc\ _MyTests is TestList
 
 The rule is on by default. Disable it with `--disable style/testlist-nodoc` or in `.pony-lint.json`.
 
+## Fix stdin end-of-input and error handling
+
+On Windows, a program reading stdin from the console could never reach end of input. Typing Ctrl+Z — the Windows end-of-input key — delivered the byte 0x1A to the program instead of ending the stream. The program ran until killed. Ctrl+Z now ends console input.
+
+Separately, a failed read from stdin was not reported to the program on any platform. `InputNotify` now has a `read_failed` method, called before `dispose` when the stream ends because of a read failure:
+
+```pony
+env.input(
+  object iso is InputNotify
+    fun ref apply(data: Array[U8] iso) =>
+      // process data
+
+    fun ref read_failed() =>
+      env.exitcode(1)
+
+    fun ref dispose() =>
+      // cleanup
+  end)
+```
+
+Existing programs that do not override `read_failed` behave as before.
+
+## Add read_failed to InputNotify
+
+`InputNotify` has a new method, `read_failed`, called before `dispose` when a read from the stream fails. Code that structurally matches `InputNotify` without `is InputNotify` will not compile until `read_failed` is added or `is InputNotify` is declared:
+
+Before:
+
+```pony
+let notify = object iso
+  fun ref apply(data: Array[U8] iso) => // ...
+  fun ref dispose() => // ...
+end
+env.input(consume notify)
+```
+
+After:
+
+```pony
+let notify = object iso is InputNotify
+  fun ref apply(data: Array[U8] iso) => // ...
+  fun ref dispose() => // ...
+end
+env.input(consume notify)
+```
+
+Code that already uses `is InputNotify` is unaffected — it picks up the default no-op.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix trait default method bodies failing to compile with aliased use packages ([PR #5824](https://github.com/ponylang/ponyc/pull/5824))
 - Fix TCP and UDP sockets being closed when the system runs low on socket buffers ([PR #5823](https://github.com/ponylang/ponyc/pull/5823))
 - Fix compiler crash when combining traits with abstract and default method ([PR #5827](https://github.com/ponylang/ponyc/pull/5827))
+- Fix stdin end-of-input and error handling ([PR #5832](https://github.com/ponylang/ponyc/pull/5832))
 
 ### Added
 
@@ -31,6 +32,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Change JsonTokenParser to carry values on its tokens ([PR #5658](https://github.com/ponylang/ponyc/pull/5658))
 - Starting a process returns a result ([PR #5770](https://github.com/ponylang/ponyc/pull/5770))
 - ProcessMonitor requires Linux 5.3 or newer ([PR #5770](https://github.com/ponylang/ponyc/pull/5770))
+- Add read_failed to InputNotify ([PR #5832](https://github.com/ponylang/ponyc/pull/5832))
 
 ## [0.68.0] - 2026-08-01
 

--- a/examples/readline/main.pony
+++ b/examples/readline/main.pony
@@ -49,7 +49,7 @@ actor Main
       Readline(recover Handler end, env.out), env.input)
     term.prompt("0 > ")
 
-    let notify = object iso
+    let notify = object iso is InputNotify
       let term: ANSITerm = term
       fun ref apply(data: Array[U8] iso) => term(consume data)
       fun ref dispose() => term.dispose()

--- a/packages/builtin/stdin.pony
+++ b/packages/builtin/stdin.pony
@@ -14,6 +14,12 @@ interface InputNotify
     """
     None
 
+  fun ref read_failed() =>
+    """
+    Called when a read from the stream fails, before `dispose`.
+    """
+    None
+
   fun ref dispose() =>
     """
     Called when no more data will arrive on the stream.
@@ -124,7 +130,11 @@ actor Stdin is AsioEventNotify
       @pony_asio_event_destroy(event)
     elseif (_event is event) and AsioEvent.errored(flags) then
       _close_event()
-      try (_notify as InputNotify).dispose() end
+      try
+        let notify = _notify as InputNotify
+        notify.read_failed()
+        notify.dispose()
+      end
       _notify = None
     elseif (_event is event) and AsioEvent.readable(flags) then
       _read()
@@ -153,11 +163,15 @@ actor Stdin is AsioEventNotify
 
         match len
         | -1 =>
-          // Error, possibly would block. Try again.
           return true
         | 0 =>
-          // EOF. Close everything, stop reading.
           _close_event()
+          notify.dispose()
+          _notify = None
+          return false
+        | -2 =>
+          _close_event()
+          notify.read_failed()
           notify.dispose()
           _notify = None
           return false

--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -5,6 +5,7 @@
 #include "stdfd.h"
 
 #ifndef PLATFORM_IS_WINDOWS
+#include <errno.h>
 #include <poll.h>
 #include <termios.h>
 #include <unistd.h>
@@ -500,6 +501,7 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
       // Peek at the console input.
       INPUT_RECORD record[64];
       DWORD count;
+      bool eof = false;
 
       BOOL r = PeekConsoleInput(handle, record, 64, &count);
 
@@ -509,6 +511,23 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
 
         while(consumed < count)
         {
+          // Ctrl+Z (SUB, 0x1A) is the Windows end-of-input key. The console
+          // does not process it because ENABLE_LINE_INPUT is cleared, so it
+          // arrives as a key event. Consume it when nothing is buffered (EOF);
+          // leave it when data precedes it so the data is delivered first and
+          // the next read sees the EOF.
+          if(record[consumed].EventType == KEY_EVENT &&
+            record[consumed].Event.KeyEvent.bKeyDown &&
+            record[consumed].Event.KeyEvent.uChar.UnicodeChar == 0x001A)
+          {
+            if(len == 0)
+            {
+              consumed++;
+              eof = true;
+            }
+            break;
+          }
+
           if(!add_input_record(buffer, space, &len, &record[consumed]))
             break;
 
@@ -519,8 +538,7 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
         ReadConsoleInput(handle, record, consumed, &count);
       }
 
-      // We have no data, but 0 means EOF, so we return -1 which is try again
-      if(len == 0)
+      if(len == 0 && !eof)
         len = -1;
       break;
     }
@@ -548,6 +566,8 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
 
       if(ReadFile(handle, buffer, take, &actual_len, NULL))
         len = actual_len;
+      else
+        len = (size_t)-2;
 
       break;
     }
@@ -560,7 +580,10 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
       DWORD actual_len = 0;
 
       if(!ReadFile(handle, buffer, buf_size, &actual_len, NULL))
-        actual_len = 0;  // A failed read is the end of the input.
+      {
+        len = (size_t)-2;
+        break;
+      }
 
       len = actual_len;
       break;
@@ -570,7 +593,7 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
   // Resume stdin notifications only when the asio backend is managing events
   // for stdin. In loop mode (STDIN_OTHER — a file or NUL) there is no event
   // to resume.
-  if(len != 0 && ponyint_stdin_kind() != STDIN_OTHER)
+  if(len != 0 && len != (size_t)-2 && ponyint_stdin_kind() != STDIN_OTHER)
     ponyint_sock_notify_resume_stdin();
 
   return len;
@@ -585,7 +608,16 @@ PONY_API size_t pony_os_stdin_read(char* buffer, size_t space)
   if(n != 1)
     return -1;
 
-  return read(STDIN_FILENO, buffer, space);
+  ssize_t result = read(STDIN_FILENO, buffer, space);
+
+  if(result < 0)
+  {
+    if(errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+      return (size_t)-1;
+    return (size_t)-2;
+  }
+
+  return (size_t)result;
 #endif
 }
 


### PR DESCRIPTION
On Windows, console stdin never returned EOF because pony_os_stdin_read forced a non-zero return when no bytes were produced, and Ctrl+Z arrived as data (0x1A) rather than being recognized as the end-of-input key. Ctrl+Z now ends console input.

A failed ReadFile (Windows) or read() (POSIX) was not reported to the program — on Windows the failure looked like EOF, on POSIX it silently retried forever. pony_os_stdin_read now returns a distinct error sentinel, and InputNotify gains a `read_failed` method called before `dispose` when the stream ends because of a read failure. Existing programs that don't override `read_failed` behave as before.

Closes #5743
Closes #5742
