### PR TITLE
Lint full-program-runner in PR CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -392,6 +392,8 @@ jobs:
           cd build/debug
           PONYPATH=../../packages ./pony-lint \
             $(find ../../examples -maxdepth 2 -name '*.pony' -printf '%h\n' | sort -u)
+      - name: Lint full-program-runner
+        run: cd build/debug && ./pony-lint ../../test/full-program-runner/
 
   tools-macos:
     needs: [changes, maybe-build-macos]

--- a/test/full-program-runner/CMakeLists.txt
+++ b/test/full-program-runner/CMakeLists.txt
@@ -8,6 +8,7 @@ add_custom_command(OUTPUT ${RUNNER_EXECUTABLE}
   COMMAND $<TARGET_FILE:ponyc> ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS
     main.pony
+    full_program_runner.pony
     _build_process_notify.pony
     _cli_options.pony
     _colors.pony
@@ -18,5 +19,6 @@ add_custom_command(OUTPUT ${RUNNER_EXECUTABLE}
     _tester_stdin_timer_notify.pony
     _tester_timer_notify.pony
     _tester.pony
+    _tester_notify.pony
     $<TARGET_FILE:ponyc>
 )

--- a/test/full-program-runner/_cli_options.pony
+++ b/test/full-program-runner/_cli_options.pony
@@ -26,8 +26,9 @@ class val _Options
     debug = command.option(_CliOptions._str_debug()).bool()
     debugger = command.option(_CliOptions._str_debugger()).string()
     verbose = command.option(_CliOptions._str_verbose()).bool()
-    max_parallel = USize.from[U64](
-      command.option(_CliOptions._str_max_parallel()).u64())
+    max_parallel =
+      USize.from[U64](
+        command.option(_CliOptions._str_max_parallel()).u64())
     only =
       recover
         let only' = Set[String]
@@ -60,38 +61,61 @@ primitive _CliOptions
   fun apply(env: Env): _Options ? =>
     let spec =
       recover val
-        CommandSpec.leaf("runner", "Test runner for Pony compiler tests", [
-          OptionSpec.string(_compiler_path(), "Path to the ponyc binary"
-            where short' = 'c', default' = "ponyc")
-          OptionSpec.string(_str_output(), "Output directory for test programs"
-            where short' = 'o', default' = ".")
-          OptionSpec.string(_str_pony_path(), "Path to pass to ponyc --path"
-            where short' = 'p', default' = "")
-          OptionSpec.string(_str_test_lib(),
-            "Directory containing the additional test libraries"
-            where short' = 'L', default' = "test_lib")
-          OptionSpec.u64(_str_timeout_s(),
-            "Timeout (in seconds) for any one test"
-            where short' = 't', default' = 60)
-          OptionSpec.bool(_str_debug(), "Whether to compile in debug mode"
-            where short' = 'd', default' = false)
-          OptionSpec.string(_str_debugger(), "Debugger to use when running"
-            where short' = 'g', default' = "")
-          OptionSpec.bool(_str_verbose(), "Whether to print more progress info"
-            where short' = 'v', default' = false)
-          OptionSpec.u64(_str_max_parallel(),
-            "Maximum number of tests to run in parallel"
-            where short' = 'P', default' = 1)
-          OptionSpec.string(_str_only(),
-            "Comma-separated list of test names to run"
-            where short' = 'O', default' = "")
-          OptionSpec.string(_str_exclude(),
-            "Comma-separated list of directories to exclude"
-            where short' = 'e', default' = "")
-        ], [
-          ArgSpec.string("test_path", "Directory containing test directories"
-            where default' = ".")
-        ])? .> add_help()?
+        CommandSpec.leaf(
+          "runner",
+          "Test runner for Pony compiler tests",
+          [
+            OptionSpec.string(
+              _compiler_path(),
+              "Path to the ponyc binary"
+              where short' = 'c', default' = "ponyc")
+            OptionSpec.string(
+              _str_output(),
+              "Output directory for test programs"
+              where short' = 'o', default' = ".")
+            OptionSpec.string(
+              _str_pony_path(),
+              "Path to pass to ponyc --path"
+              where short' = 'p', default' = "")
+            OptionSpec.string(
+              _str_test_lib(),
+              "Directory containing the additional test libraries"
+              where short' = 'L', default' = "test_lib")
+            OptionSpec.u64(
+              _str_timeout_s(),
+              "Timeout (in seconds) for any one test"
+              where short' = 't', default' = 60)
+            OptionSpec.bool(
+              _str_debug(),
+              "Whether to compile in debug mode"
+              where short' = 'd', default' = false)
+            OptionSpec.string(
+              _str_debugger(),
+              "Debugger to use when running"
+              where short' = 'g', default' = "")
+            OptionSpec.bool(
+              _str_verbose(),
+              "Whether to print more progress info"
+              where short' = 'v', default' = false)
+            OptionSpec.u64(
+              _str_max_parallel(),
+              "Maximum number of tests to run in parallel"
+              where short' = 'P', default' = 1)
+            OptionSpec.string(
+              _str_only(),
+              "Comma-separated list of test names to run"
+              where short' = 'O', default' = "")
+            OptionSpec.string(
+              _str_exclude(),
+              "Comma-separated list of directories to exclude"
+              where short' = 'e', default' = "")
+          ],
+          [
+            ArgSpec.string(
+              "test_path",
+              "Directory containing test directories"
+              where default' = ".")
+          ])? .> add_help()?
       end
 
     let options =

--- a/test/full-program-runner/_coordinator.pony
+++ b/test/full-program-runner/_coordinator.pony
@@ -10,12 +10,13 @@ actor _Coordinator is _TesterNotify
   let _num_to_run: USize
   let _success: Map[String, Bool]
   let _timers: Timers
-
   var _cur_output_name: (String | None) = None
   let _tester_outputs: Map[String, Array[String] ref] =
     Map[String, Array[String] ref]
 
-  new create(env: Env, options: _Options,
+  new create(
+    env: Env,
+    options: _Options,
     definitions: Array[_TestDefinition] val)
   =>
     _env = env
@@ -35,23 +36,23 @@ actor _Coordinator is _TesterNotify
     _success = Map[String, Bool](_num_to_run)
     _timers = Timers
 
-    let start_message = recover val
-      var m: String ref = "Running " + _num_to_run.string() + " tests"
+    let start_message =
+      recover val
+        var m: String ref = "Running " + _num_to_run.string() + " tests"
 
-      if _options.debug then
-        m = m + " compiled in debug mode."
-      else
-        m = m + " compiled in release mode."
+        if _options.debug then
+          m = m + " compiled in debug mode."
+        else
+          m = m + " compiled in release mode."
+        end
+        m
       end
-      m
-    end
 
     _env.out.print(_Colors.info(start_message, true))
 
     for i in Range(0, _options.max_parallel) do
       _run_test()
     end
-
 
   be _run_test() =>
     try
@@ -65,11 +66,12 @@ actor _Coordinator is _TesterNotify
       if cur_name == tester_name then
         _env.out.print(str)
       else
-        let array = try
-          _tester_outputs(tester_name)?
-        else
-          _tester_outputs.insert(tester_name, Array[String])
-        end
+        let array =
+          try
+            _tester_outputs(tester_name)?
+          else
+            _tester_outputs.insert(tester_name, Array[String])
+          end
         array.push(str)
       end
     else
@@ -102,7 +104,7 @@ actor _Coordinator is _TesterNotify
     if pick_new then
       // flush all finished tests
       let keys = Array[String](_tester_outputs.size())
-        .>concat(_tester_outputs.keys())
+        .> concat(_tester_outputs.keys())
 
       for key in keys.values() do
         if _success.contains(key) then
@@ -137,7 +139,8 @@ actor _Coordinator is _TesterNotify
       // collect the number of successes and failures
       (let num_succeeded: USize, let num_failed: USize) =
         Iter[Bool](_success.values())
-          .fold[(USize, USize)]((0, 0),
+          .fold[(USize, USize)](
+            (0, 0),
             {(sum, s) =>
               if s then (sum._1 + 1, sum._2) else (sum._1, sum._2 + 1) end
             })

--- a/test/full-program-runner/_test_definitions.pony
+++ b/test/full-program-runner/_test_definitions.pony
@@ -44,14 +44,15 @@ class val _TestDefinition
   let name: String
   let path: String
   let expected_exit_code: I32
-
   let stdin: _Stdin
-
-  // Arguments passed to the program, from the test's program-args.txt.
   let program_args: Array[String] val
 
-  new val create(name': String, path': String, expected_exit_code': I32,
-    stdin': _Stdin, program_args': Array[String] val)
+  new val create(
+    name': String,
+    path': String,
+    expected_exit_code': I32,
+    stdin': _Stdin,
+    program_args': Array[String] val)
   =>
     name = name'
     path = path'
@@ -79,7 +80,10 @@ class _TestDefinitions
   let _out: OutStream
   let _err: OutStream
 
-  new create(verbose: Bool, exclude: Set[String] val, out: OutStream,
+  new create(
+    verbose: Bool,
+    exclude: Set[String] val,
+    out: OutStream,
     err: OutStream)
   =>
     _verbose = verbose
@@ -166,8 +170,11 @@ class _TestDefinitions
     end
     result
 
-  fun _get_definition(auth: FileAuth, parent: String,
-    child: String): (_TestDefinition | _BrokenTest | None)
+  fun _get_definition(
+    auth: FileAuth,
+    parent: String,
+    child: String)
+    : (_TestDefinition | _BrokenTest | None)
   =>
     let fp = FilePath(auth, Path.join(parent, child))
 
@@ -260,8 +267,8 @@ class _TestDefinitions
       match \exhaustive\ config_error
       | let reason: String => _BrokenTest(child, reason)
       | None =>
-        _TestDefinition(child, dir.path.path, expected_exit_code, stdin,
-          program_args)
+        _TestDefinition(
+          child, dir.path.path, expected_exit_code, stdin, program_args)
       end
     end
 

--- a/test/full-program-runner/_tester.pony
+++ b/test/full-program-runner/_tester.pony
@@ -5,11 +5,6 @@ use "process"
 use "time"
 use "backpressure"
 
-interface tag _TesterNotify
-  be print(name: String, str: String)
-  be succeeded(name: String)
-  be failed(name: String)
-
 primitive _NotStarted
 primitive _Building
 primitive _Testing
@@ -24,21 +19,22 @@ actor _Tester
   let _options: _Options
   let _definition: _TestDefinition
   let _notify: _TesterNotify
-
   var _stage: _TesterStage
   let _timer: Timer tag
   var _stdin_timer: (Timer tag | None) = None
   var _start_ms: U64
   var _end_ms: U64
-
   var _build_process: (ProcessMonitor | None) = None
   var _test_process: (ProcessMonitor | None) = None
-
   let _out_buf: String iso = recover String end
   let _err_buf: String iso = recover String end
 
-  new create(env: Env, timers: Timers, options: _Options,
-    definition: _TestDefinition, notify: _TesterNotify)
+  new create(
+    env: Env,
+    timers: Timers,
+    options: _Options,
+    definition: _TestDefinition,
+    notify: _TesterNotify)
   =>
     _env = env
     _timers = timers
@@ -47,8 +43,10 @@ actor _Tester
     _notify = notify
 
     _stage = _NotStarted
-    let timer = Timer(_TesterTimerNotify(this),
-      _options.timeout_s * 1_000_000_000)
+    let timer =
+      Timer(
+        _TesterTimerNotify(this),
+        _options.timeout_s * 1_000_000_000)
     _timer = timer
     _timers(consume timer)
     _start_ms = 0
@@ -82,9 +80,11 @@ actor _Tester
         args_join.append(" ")
         args_join.append(arg)
       end
-      _notify.print(_definition.name,
+      _notify.print(
+        _definition.name,
         _Colors.info(_definition.name + ": building in: " + _definition.path))
-      _notify.print(_definition.name,
+      _notify.print(
+        _definition.name,
         _Colors.info(_definition.name + ": building:" + args_join))
     end
 
@@ -95,8 +95,13 @@ actor _Tester
     let spa = StartProcessAuth(_env.root)
     let bpa = ApplyReleaseBackpressureAuth(_env.root)
     _build_process =
-      match StartProcess(spa, bpa, _BuildProcessNotify(this),
-        ponyc_file_path, consume args, _env.vars,
+      match \exhaustive\ StartProcess(
+        spa,
+        bpa,
+        _BuildProcessNotify(this),
+        ponyc_file_path,
+        consume args,
+        _env.vars,
         FilePath(FileAuth(_env.root), _definition.path))
       | let pm: ProcessMonitor =>
         pm.done_writing()
@@ -175,7 +180,8 @@ actor _Tester
         if _options.verbose then
           for v in vars.values() do
             if v.contains("DYLD_LIBRARY_PATH") then
-              _notify.print(_definition.name,
+              _notify.print(
+                _definition.name,
                 _Colors.info(_definition.name + ": testing: " + v))
             end
           end
@@ -194,27 +200,35 @@ actor _Tester
             arg_join.append(arg)
           end
 
-          _notify.print(_definition.name,
+          _notify.print(
+            _definition.name,
             _Colors.info(_definition.name + ": testing:" + arg_join))
         end
 
         _stage = _Testing
         let spa = StartProcessAuth(_env.root)
         let bpa = ApplyReleaseBackpressureAuth(_env.root)
-        match StartProcess(spa, bpa, _TestProcessNotify(this),
-          executable_file_path, args, vars,
+        match \exhaustive\ StartProcess(
+          spa,
+          bpa,
+          _TestProcessNotify(this),
+          executable_file_path,
+          args,
+          vars,
           FilePath(FileAuth(_env.root), _definition.path))
         | let process: ProcessMonitor =>
           _test_process = process
 
-          match _definition.stdin
+          match \exhaustive\ _definition.stdin
           | _StdinClose =>
             process.done_writing()
           | let w: _StdinWrite =>
             _write_stdin_and_close(process, w.data)
           | let d: _StdinDelay =>
-            let timer = Timer(_TesterStdinTimerNotify(this),
-              d.seconds * 1_000_000_000)
+            let timer =
+              Timer(
+                _TesterStdinTimerNotify(this),
+                d.seconds * 1_000_000_000)
             _stdin_timer = timer
             _timers(consume timer)
           end
@@ -222,7 +236,8 @@ actor _Tester
           _shutdown_failed("unable to start test program: " + err.string())
         end
       else
-        _notify.print(_definition.name,
+        _notify.print(
+          _definition.name,
           _Colors.err(_definition.name + ": unable to find debugger"))
       end
     end
@@ -244,10 +259,10 @@ actor _Tester
           try
             let debugger_split =
               recover val
-                var debugger: String iso = _options.debugger.clone()
-                debugger.replace("%20", " ")
-                debugger.replace("%22", "\"")
-                debugger.split(" ")
+                _options.debugger.clone()
+                  .> replace("%20", " ")
+                  .> replace("%22", "\"")
+                  .split(" ")
               end
             var in_quote = false
             var cur_arg = String
@@ -389,8 +404,10 @@ actor _Tester
   fun ref _shutdown_succeeded() =>
     if not (_stage is _Succeeded) then
       _end_ms = Time.millis()
-      _notify.print(_definition.name, _Colors.ok(_definition.name + " ("
-        + (_end_ms - _start_ms).string() + " ms)"))
+      _notify.print(
+        _definition.name,
+        _Colors.ok(_definition.name + " ("
+          + (_end_ms - _start_ms).string() + " ms)"))
       _timers.cancel(_timer)
       _cancel_stdin_timer()
       _stage = _Succeeded
@@ -401,8 +418,10 @@ actor _Tester
     if not (_stage is _Failed) then
       _end_ms = Time.millis()
 
-      _notify.print(_definition.name, _Colors.fail(_definition.name + " ("
-        + (_end_ms - _start_ms).string() + " ms): " + msg))
+      _notify.print(
+        _definition.name,
+        _Colors.fail(_definition.name + " ("
+          + (_end_ms - _start_ms).string() + " ms): " + msg))
 
       match _build_process
       | let process: ProcessMonitor =>
@@ -431,10 +450,14 @@ actor _Tester
 
   fun ref _dump_io_streams() =>
     if _out_buf.size() > 0 then
-      _notify.print(_definition.name, _definition.name + ": STDOUT:\n"
-        + recover val _out_buf.clone() end)
+      _notify.print(
+        _definition.name,
+        _definition.name + ": STDOUT:\n"
+          + recover val _out_buf.clone() end)
     end
     if _err_buf.size() > 0 then
-      _notify.print(_definition.name, _definition.name + ": STDERR\n"
-        + recover val _err_buf.clone() end)
+      _notify.print(
+        _definition.name,
+        _definition.name + ": STDERR\n"
+          + recover val _err_buf.clone() end)
     end

--- a/test/full-program-runner/_tester_notify.pony
+++ b/test/full-program-runner/_tester_notify.pony
@@ -1,0 +1,4 @@
+interface tag _TesterNotify
+  be print(name: String, str: String)
+  be succeeded(name: String)
+  be failed(name: String)

--- a/test/full-program-runner/full_program_runner.pony
+++ b/test/full-program-runner/full_program_runner.pony
@@ -1,0 +1,4 @@
+"""
+Test runner that compiles and executes full Pony programs, checking each
+program's exit code against an expected value.
+"""

--- a/test/full-program-runner/main.pony
+++ b/test/full-program-runner/main.pony
@@ -15,8 +15,9 @@ actor Main
 
     var exit_code = I32(0)
     if FilePath(FileAuth(env.root), options.output).exists() then
-      let td = _TestDefinitions(options.verbose, options.exclude, env.out,
-        env.err)
+      let td =
+        _TestDefinitions(
+          options.verbose, options.exclude, env.out, env.err)
       match td.find(FileAuth(env.root), options.test_path)
       | let test_definitions: Array[_TestDefinition] val =>
         _Coordinator(env, options, test_definitions)


### PR DESCRIPTION
`test/full-program-runner/` was never linted. This fixes the 64 violations pony-lint reports — formatting (call-argument, assignment-indent, blank-lines, method-declaration), `\exhaustive\` annotations on complete matches, `.>` chaining — and adds a lint step to the tools-linux PR job.

The `_TesterNotify` interface was extracted from `_tester.pony` into its own file to satisfy the file-naming rule, and `full_program_runner.pony` was added for the package docstring.
