### PR TITLE
Exempt triple-quoted string literals from the 80-column lint rule

### DIFF
--- a/.release-notes/exempt-string-literals-from-line-length.md
+++ b/.release-notes/exempt-string-literals-from-line-length.md
@@ -1,0 +1,3 @@
+## Exempt triple-quoted string literals from the 80-column lint rule
+
+pony-lint's `style/line-length` rule now skips lines inside triple-quoted string literals that are not docstrings. Triple-quoted strings used as data — JSON templates, inline test fixtures, multi-line format strings — exist for readability, and forcing them to wrap at 80 columns defeats their purpose. Docstring prose is still checked.

--- a/tools/pony-lint/line_length.pony
+++ b/tools/pony-lint/line_length.pony
@@ -1,4 +1,7 @@
-primitive LineLength is TextRule
+use "collections"
+use ast = "pony_compiler"
+
+primitive LineLength is ASTRule
   """
   Flags lines exceeding 80 codepoints.
 
@@ -13,13 +16,15 @@ primitive LineLength is TextRule
   exempt because they can be split at space boundaries using compile-time
   string concatenation (`+` on string literals) at zero runtime cost.
 
-  Lines inside triple-quoted strings (docstrings) and lines containing triple-
-  quote delimiters are not eligible for exemption — docstring content should be
-  wrapped regardless.
+  Lines inside triple-quoted string literals (non-docstring `\"\"\"` blocks)
+  are exempt from the 80-column check. Triple-quoted strings used as data
+  (JSON, inline test fixtures, etc.) exist for readability; forcing them to
+  wrap defeats their purpose. Lines inside docstrings are not exempt —
+  docstring prose should be wrapped at 80 columns.
 
   Known limitations:
   - Does not handle escaped backslashes before quotes. A string ending in a
-    literal backslash (e.g., "path\\") may cause incorrect string boundary
+    literal backslash (e.g., "path\\\\") may cause incorrect string boundary
     detection. This limitation is shared with `CommentSpacing`.
   """
   fun id(): String val => "style/line-length"
@@ -27,23 +32,49 @@ primitive LineLength is TextRule
   fun description(): String val => "line exceeds 80 columns"
   fun default_status(): RuleStatus => RuleOn
 
-  fun check(source: SourceFile val): Array[Diagnostic val] val =>
+  fun node_filter(): Array[ast.TokenId] val =>
+    recover val Array[ast.TokenId] end
+
+  fun check(node: ast.AST box, source: SourceFile val)
+    : Array[Diagnostic val] val
+  =>
+    recover val Array[Diagnostic val] end
+
+  fun check_module(module_ast: ast.AST box, source: SourceFile val)
+    : Array[Diagnostic val] val
+  =>
+    """
+    Uses the module AST to identify triple-quoted string literals and
+    docstrings, then checks lines for the 80-column limit. String
+    literal content lines are fully exempt; docstring content lines
+    skip the no-space string exemption so that long quoted identifiers
+    in prose are still flagged.
+    """
+    let visitor = _StringLiteralVisitor(source)
+    module_ast.visit(visitor)
+    let exempt_lines = _collect_lines(visitor.literal_ranges())
+    let docstring_lines = _collect_lines(visitor.docstring_ranges())
+    check_text(source, exempt_lines, docstring_lines)
+
+  fun check_text(
+    source: SourceFile val,
+    exempt_lines: Set[USize] val = recover val Set[USize] end,
+    docstring_lines: Set[USize] val = recover val Set[USize] end)
+    : Array[Diagnostic val] val
+  =>
     recover val
       let result = Array[Diagnostic val]
-      var in_docstring = false
       for (idx, line) in source.lines.pairs() do
-        let triple_count = _count_triple_quotes(line)
-        let was_in_docstring = in_docstring
-        if (triple_count % 2) == 1 then
-          in_docstring = not in_docstring
-        end
-
+        let line_no = idx + 1
         let cp_count = line.codepoints()
         if cp_count > 80 then
-          let eligible =
-            (not was_in_docstring) and (triple_count == 0)
+          if exempt_lines.contains(line_no) then
+            continue
+          end
           let exempt =
-            if eligible then
+            if docstring_lines.contains(line_no) then
+              false
+            elseif _count_triple_quotes(line) == 0 then
               _has_exempt_string(line)
             else
               false
@@ -53,13 +84,24 @@ primitive LineLength is TextRule
               id(),
               "line exceeds 80 columns (" + cp_count.string() + ")",
               source.rel_path,
-              idx + 1,
+              line_no,
               81))
           end
         end
       end
       result
     end
+
+  fun _collect_lines(ranges: Array[(USize, USize)] val): Set[USize] val =>
+    let lines = recover iso Set[USize] end
+    for (start_line, end_line) in ranges.values() do
+      var l = start_line
+      while l <= end_line do
+        lines.set(l)
+        l = l + 1
+      end
+    end
+    consume lines
 
   fun _count_triple_quotes(line: String val): USize =>
     """
@@ -143,3 +185,137 @@ primitive LineLength is TextRule
       i = i + 1
     end
     false
+
+class ref _StringLiteralVisitor is ast.ASTVisitor
+  """
+  Walks the AST collecting line ranges of triple-quoted strings,
+  separated into non-docstring literals and docstrings.
+  """
+  let _source: SourceFile val
+  let _literal_ranges: Array[(USize, USize)]
+  let _docstring_ranges: Array[(USize, USize)]
+
+  new ref create(source: SourceFile val) =>
+    _source = source
+    _literal_ranges = Array[(USize, USize)]
+    _docstring_ranges = Array[(USize, USize)]
+
+  fun ref visit(node: ast.AST box): ast.VisitResult =>
+    if node.id() != ast.TokenIds.tk_string() then
+      return ast.Continue
+    end
+
+    if not _is_triple_quoted(node) then
+      return ast.Continue
+    end
+
+    let start_line = node.line()
+    let end_line =
+      match node.end_pos()
+      | let p: ast.Position => p.line()
+      else
+        start_line
+      end
+    if end_line > start_line then
+      if _is_docstring(node) then
+        _docstring_ranges.push((start_line, end_line))
+      else
+        _literal_ranges.push((start_line, end_line))
+      end
+    end
+    ast.Continue
+
+  fun literal_ranges(): Array[(USize, USize)] val =>
+    _copy_ranges(_literal_ranges)
+
+  fun docstring_ranges(): Array[(USize, USize)] val =>
+    _copy_ranges(_docstring_ranges)
+
+  fun _copy_ranges(src: Array[(USize, USize)] box)
+    : Array[(USize, USize)] val
+  =>
+    let result = recover iso Array[(USize, USize)] end
+    for r in src.values() do
+      result.push(r)
+    end
+    consume result
+
+  fun _is_docstring(node: ast.AST box): Bool =>
+    """
+    A TK_STRING is a docstring when it occupies one of these positions:
+    - Child 6 of an entity (class, actor, primitive, struct, trait,
+      interface)
+    - Child 0 of a method body (first expression in the TK_SEQ that is
+      child 6 of a tk_fun/tk_new/tk_be)
+    - Child 7 of a method (abstract method docstring slot)
+    - First child of a module (package-level docstring)
+    """
+    let parent =
+      match node.parent()
+      | let p: ast.AST => p
+      else
+        return false
+      end
+
+    let idx = node.sibling_idx()
+    let parent_id = parent.id()
+
+    // Module-level docstring
+    if (parent_id == ast.TokenIds.tk_module()) and (idx == 0) then
+      return true
+    end
+
+    // Entity docstring at child 6
+    if ast.TokenIds.is_entity(parent_id) and (idx == 6) then
+      return true
+    end
+
+    // Method docstrings
+    let is_method =
+      (parent_id == ast.TokenIds.tk_fun())
+        or (parent_id == ast.TokenIds.tk_new())
+        or (parent_id == ast.TokenIds.tk_be())
+
+    // Abstract method docstring at child 7
+    if is_method and (idx == 7) then
+      return true
+    end
+
+    // Concrete method docstring: first child of body TK_SEQ
+    if (parent_id == ast.TokenIds.tk_seq()) and (idx == 0) then
+      match parent.parent()
+      | let grandparent: ast.AST =>
+        let gp_id = grandparent.id()
+        if (gp_id == ast.TokenIds.tk_fun())
+          or (gp_id == ast.TokenIds.tk_new())
+          or (gp_id == ast.TokenIds.tk_be())
+        then
+          return true
+        end
+      end
+    end
+
+    false
+
+  fun _is_triple_quoted(node: ast.AST box): Bool =>
+    """
+    Check whether the TK_STRING at the given position in the source is
+    triple-quoted by examining the source text at the node's start
+    position.
+    """
+    let l = node.line()
+    let col = node.pos()
+    if (l == 0) or (col == 0) then return false end
+    try
+      let line_text = _source.lines(l - 1)?
+      let byte_offset = col - 1
+      if (byte_offset + 2) < line_text.size() then
+        (line_text(byte_offset)? == '"')
+          and (line_text(byte_offset + 1)? == '"')
+          and (line_text(byte_offset + 2)? == '"')
+      else
+        false
+      end
+    else
+      false
+    end

--- a/tools/pony-lint/linter.pony
+++ b/tools/pony-lint/linter.pony
@@ -556,6 +556,26 @@ class val Linter
               all_diags.push(d)
             end
           end
+
+          // Line-length check (module-level, needs AST for
+          // string literal vs docstring distinction)
+          if pkg_registry.is_enabled(
+            LineLength.id(),
+            LineLength.category(),
+            LineLength.default_status())
+          then
+            let ll_diags =
+              LineLength.check_module(mod.ast, info.source)
+            for d in ll_diags.values() do
+              if info.magic_lines.contains(d.line) then continue end
+              if info.suppressions.is_suppressed(
+                d.line, d.rule_id)
+              then
+                continue
+              end
+              all_diags.push(d)
+            end
+          end
         end
       end
     end

--- a/tools/pony-lint/main.pony
+++ b/tools/pony-lint/main.pony
@@ -95,7 +95,6 @@ actor Main
     // Build rule arrays (needed by --explain and normal linting)
     let all_rules: Array[TextRule val] val =
       recover val Array[TextRule val]
-        .> push(LineLength)
         .> push(TrailingWhitespace)
         .> push(HardTabs)
         .> push(CommentSpacing)
@@ -103,6 +102,7 @@ actor Main
     end
     let all_ast_rules: Array[ASTRule val] val =
       recover val Array[ASTRule val]
+        .> push(LineLength)
         .> push(TypeNaming)
         .> push(MemberNaming)
         .> push(AcronymCasing)

--- a/tools/pony-lint/test/_test_line_length.pony
+++ b/tools/pony-lint/test/_test_line_length.pony
@@ -1,5 +1,6 @@
 use "pony_test"
 use "pony_check"
+use ast = "pony_compiler"
 use lint = ".."
 
 class \nodoc\ _TestLineLengthExactly80 is UnitTest
@@ -9,7 +10,7 @@ class \nodoc\ _TestLineLengthExactly80 is UnitTest
   fun apply(h: TestHelper) =>
     let line = recover val String .> append("a".mul(80)) end
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestLineLengthOver80 is UnitTest
@@ -19,7 +20,7 @@ class \nodoc\ _TestLineLengthOver80 is UnitTest
   fun apply(h: TestHelper) =>
     let line = recover val String .> append("a".mul(95)) end
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](1, diags.size())
     try
       h.assert_eq[USize](81, diags(0)?.column)
@@ -40,7 +41,7 @@ class \nodoc\ _TestLineLengthMultiByteUTF8 is UnitTest
         String .> append("a".mul(79)) .> append("é")
       end
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestLineLengthEmptyLine is UnitTest
@@ -49,7 +50,7 @@ class \nodoc\ _TestLineLengthEmptyLine is UnitTest
 
   fun apply(h: TestHelper) =>
     let sf = lint.SourceFile("/tmp/t.pony", "", "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestLineLengthProperty is UnitTest
@@ -72,7 +73,7 @@ class \nodoc\ _TestLineLengthProperty is UnitTest
         let safe_line: String val = consume line
         if safe_line.codepoints() <= 80 then
           let sf = lint.SourceFile("/tmp/t.pony", safe_line, "/tmp")
-          let diags = lint.LineLength.check(sf)
+          let diags = lint.LineLength.check_text(sf)
           ph.assert_eq[USize](0, diags.size())
         end
       })?
@@ -84,7 +85,7 @@ class \nodoc\ _TestLineLengthProperty is UnitTest
         // ASCIILetters has no whitespace, so no newlines or \r
         let sf =
           lint.SourceFile("/tmp/t.pony", content, "/tmp")
-        let diags = lint.LineLength.check(sf)
+        let diags = lint.LineLength.check_text(sf)
         ph.assert_eq[USize](1, diags.size())
       })?
 
@@ -105,7 +106,7 @@ class \nodoc\ _TestLineLengthStringExemptNoSpaces is UnitTest
       end
     h.assert_true(line.codepoints() > 80)
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestLineLengthStringNotExemptSpaces is UnitTest
@@ -125,7 +126,7 @@ class \nodoc\ _TestLineLengthStringNotExemptSpaces is UnitTest
       end
     h.assert_true(line.codepoints() > 80)
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](1, diags.size())
 
 class \nodoc\ _TestLineLengthStringBeforeCol80 is UnitTest
@@ -144,7 +145,7 @@ class \nodoc\ _TestLineLengthStringBeforeCol80 is UnitTest
       end
     h.assert_true(line.codepoints() > 80)
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](1, diags.size())
 
 class \nodoc\ _TestLineLengthStringAfterCol80 is UnitTest
@@ -162,7 +163,7 @@ class \nodoc\ _TestLineLengthStringAfterCol80 is UnitTest
       end
     h.assert_true(line.codepoints() > 80)
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](1, diags.size())
 
 class \nodoc\ _TestLineLengthStringEndsAtCol80 is UnitTest
@@ -182,17 +183,23 @@ class \nodoc\ _TestLineLengthStringEndsAtCol80 is UnitTest
       end
     h.assert_true(line.codepoints() > 80)
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](1, diags.size())
 
 class \nodoc\ _TestLineLengthDocstringNoExempt is UnitTest
-  """Long line inside a docstring is not eligible for exemption."""
+  """
+  Long line inside a triple-quoted block gets the single-line string
+  exemption when checked via text-only check_text (no AST context).
+
+  The docstring-vs-literal distinction is handled by the AST layer
+  (check_module), not check_text. This test verifies that check_text
+  applies the no-space string exemption uniformly, including inside
+  triple-quoted blocks.
+  """
   fun name(): String =>
-    "LineLength: long line inside docstring -> flagged"
+    "LineLength: triple-quote content with no-space string -> exempt"
 
   fun apply(h: TestHelper) =>
-    // Three lines: opening """, long content with a no-space "string",
-    // closing """
     let content: String val =
       recover val
         String
@@ -203,8 +210,8 @@ class \nodoc\ _TestLineLengthDocstringNoExempt is UnitTest
           .> append("  \"\"\"")
       end
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
-    let diags = lint.LineLength.check(sf)
-    h.assert_eq[USize](1, diags.size())
+    let diags = lint.LineLength.check_text(sf)
+    h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestLineLengthMultipleStringsOneExempt is UnitTest
   """Two strings on one line; second one qualifies for exemption."""
@@ -222,7 +229,7 @@ class \nodoc\ _TestLineLengthMultipleStringsOneExempt is UnitTest
       end
     h.assert_true(line.codepoints() > 80)
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestLineLengthEscapedQuotes is UnitTest
@@ -241,7 +248,7 @@ class \nodoc\ _TestLineLengthEscapedQuotes is UnitTest
       end
     h.assert_true(line.codepoints() > 80)
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestLineLengthTripleQuoteLineNoExempt is UnitTest
@@ -258,7 +265,7 @@ class \nodoc\ _TestLineLengthTripleQuoteLineNoExempt is UnitTest
       end
     h.assert_true(line.codepoints() > 80)
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](1, diags.size())
 
 class \nodoc\ _TestLineLengthStringExemptUTF8 is UnitTest
@@ -280,7 +287,7 @@ class \nodoc\ _TestLineLengthStringExemptUTF8 is UnitTest
     // 13 + 35 + 35 + 1 = 84 codepoints
     h.assert_true(line.codepoints() > 80)
     let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-    let diags = lint.LineLength.check(sf)
+    let diags = lint.LineLength.check_text(sf)
     h.assert_eq[USize](0, diags.size())
 
 class \nodoc\ _TestLineLengthStringExemptProperty is UnitTest
@@ -305,7 +312,7 @@ class \nodoc\ _TestLineLengthStringExemptProperty is UnitTest
               .> append("\"")
           end
         let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-        let diags = lint.LineLength.check(sf)
+        let diags = lint.LineLength.check_text(sf)
         ph.assert_eq[USize](0, diags.size())
       })?
 
@@ -335,6 +342,198 @@ class \nodoc\ _TestLineLengthStringFlaggedProperty is UnitTest
               .> append("\"")
           end
         let sf = lint.SourceFile("/tmp/t.pony", line, "/tmp")
-        let diags = lint.LineLength.check(sf)
+        let diags = lint.LineLength.check_text(sf)
         ph.assert_eq[USize](1, diags.size())
       })?
+
+class \nodoc\ _TestLineLengthASTStringLiteralExempt is UnitTest
+  """
+  Lines inside a triple-quoted string literal (not a docstring) are
+  exempt from the 80-column check via the AST-based check_module.
+  """
+  fun name(): String =>
+    "LineLength: AST string literal lines exempt"
+
+  fun apply(h: TestHelper) ? =>
+    let long_content = recover val String .> append("a".mul(100)) end
+    let source: String val =
+      recover val
+        String
+          .> append("primitive Foo\n")
+          .> append("  fun apply(): String =>\n")
+          .> append("    let x: String =\n")
+          .> append("      \"\"\"\n")
+          .> append("      " + long_content + "\n")
+          .> append("      \"\"\"\n")
+          .> append("    x")
+      end
+    (let program, let sf) = _ASTTestHelper.compile(h, source)?
+    let mod_ast =
+      (program.package() as ast.Package).module()
+        as ast.Module
+    let diags = lint.LineLength.check_module(mod_ast.ast, sf)
+    h.assert_eq[USize](0, diags.size())
+
+class \nodoc\ _TestLineLengthASTDocstringNotExempt is UnitTest
+  """
+  Lines inside a docstring are NOT exempt from the 80-column check.
+  The AST-based check_module recognizes docstrings and does not add
+  their lines to the exempt set.
+  """
+  fun name(): String =>
+    "LineLength: AST docstring lines not exempt"
+
+  fun apply(h: TestHelper) ? =>
+    let long_content = recover val String .> append("a".mul(100)) end
+    let source: String val =
+      recover val
+        String
+          .> append("primitive Foo\n")
+          .> append("  \"\"\"\n")
+          .> append("  " + long_content + "\n")
+          .> append("  \"\"\"\n")
+          .> append("  fun apply(): None => None")
+      end
+    (let program, let sf) = _ASTTestHelper.compile(h, source)?
+    let mod_ast =
+      (program.package() as ast.Package).module()
+        as ast.Module
+    let diags = lint.LineLength.check_module(mod_ast.ast, sf)
+    h.assert_eq[USize](1, diags.size())
+    try
+      h.assert_eq[USize](3, diags(0)?.line)
+    else
+      h.fail("could not access diagnostic")
+    end
+
+class \nodoc\ _TestLineLengthASTMethodDocstringNotExempt is UnitTest
+  """
+  Lines inside a method-body docstring are NOT exempt. The AST
+  identifies child 0 of the body TK_SEQ under a method as a docstring.
+  """
+  fun name(): String =>
+    "LineLength: AST method-body docstring lines not exempt"
+
+  fun apply(h: TestHelper) ? =>
+    let long_content = recover val String .> append("a".mul(100)) end
+    let source: String val =
+      recover val
+        String
+          .> append("primitive Foo\n")
+          .> append("  fun apply(): None =>\n")
+          .> append("    \"\"\"\n")
+          .> append("    " + long_content + "\n")
+          .> append("    \"\"\"\n")
+          .> append("    None")
+      end
+    (let program, let sf) = _ASTTestHelper.compile(h, source)?
+    let mod_ast =
+      (program.package() as ast.Package).module()
+        as ast.Module
+    let diags = lint.LineLength.check_module(mod_ast.ast, sf)
+    h.assert_eq[USize](1, diags.size())
+    try
+      h.assert_eq[USize](4, diags(0)?.line)
+    else
+      h.fail("could not access diagnostic")
+    end
+
+class \nodoc\ _TestLineLengthASTModuleDocstringNotExempt is UnitTest
+  """
+  Lines inside a module-level docstring are NOT exempt. The AST
+  identifies child 0 of the module as the package docstring.
+  """
+  fun name(): String =>
+    "LineLength: AST module-level docstring lines not exempt"
+
+  fun apply(h: TestHelper) ? =>
+    let long_content = recover val String .> append("a".mul(100)) end
+    let source: String val =
+      recover val
+        String
+          .> append("\"\"\"\n")
+          .> append(long_content + "\n")
+          .> append("\"\"\"\n")
+          .> append("\n")
+          .> append("primitive Foo")
+      end
+    (let program, let sf) = _ASTTestHelper.compile(h, source)?
+    let mod_ast =
+      (program.package() as ast.Package).module()
+        as ast.Module
+    let diags = lint.LineLength.check_module(mod_ast.ast, sf)
+    h.assert_eq[USize](1, diags.size())
+    try
+      h.assert_eq[USize](2, diags(0)?.line)
+    else
+      h.fail("could not access diagnostic")
+    end
+
+class \nodoc\ _TestLineLengthASTDocstringQuotedIdFlagged is UnitTest
+  """
+  A docstring line with a quoted identifier (no spaces) crossing column
+  80 is still flagged. The no-space string exemption does not apply
+  inside docstrings because quoted text in prose is not a string literal.
+  """
+  fun name(): String =>
+    "LineLength: AST docstring quoted identifier -> flagged"
+
+  fun apply(h: TestHelper) ? =>
+    let long_name =
+      recover val String .> append("a".mul(75)) end
+    let source: String val =
+      recover val
+        String
+          .> append("primitive Foo\n")
+          .> append("  \"\"\"\n")
+          .> append("  Wraps \"" + long_name + "\" type.\n")
+          .> append("  \"\"\"\n")
+          .> append("  fun apply(): None => None")
+      end
+    (let program, let sf) = _ASTTestHelper.compile(h, source)?
+    let mod_ast =
+      (program.package() as ast.Package).module()
+        as ast.Module
+    let diags = lint.LineLength.check_module(mod_ast.ast, sf)
+    h.assert_eq[USize](1, diags.size())
+    try
+      h.assert_eq[USize](3, diags(0)?.line)
+    else
+      h.fail("could not access diagnostic")
+    end
+
+class \nodoc\ _TestLineLengthASTMixedDocstringAndLiteral is UnitTest
+  """
+  A file with both a docstring and a string literal, each containing
+  long lines. Only the docstring's long line should be flagged.
+  """
+  fun name(): String =>
+    "LineLength: AST mixed docstring and literal"
+
+  fun apply(h: TestHelper) ? =>
+    let long_content = recover val String .> append("a".mul(100)) end
+    let source: String val =
+      recover val
+        String
+          .> append("primitive Foo\n")
+          .> append("  \"\"\"\n")
+          .> append("  " + long_content + "\n")
+          .> append("  \"\"\"\n")
+          .> append("  fun apply(): String =>\n")
+          .> append("    let x: String =\n")
+          .> append("      \"\"\"\n")
+          .> append("      " + long_content + "\n")
+          .> append("      \"\"\"\n")
+          .> append("    x")
+      end
+    (let program, let sf) = _ASTTestHelper.compile(h, source)?
+    let mod_ast =
+      (program.package() as ast.Package).module()
+        as ast.Module
+    let diags = lint.LineLength.check_module(mod_ast.ast, sf)
+    h.assert_eq[USize](1, diags.size())
+    try
+      h.assert_eq[USize](3, diags(0)?.line)
+    else
+      h.fail("could not access diagnostic")
+    end

--- a/tools/pony-lint/test/_test_linter.pony
+++ b/tools/pony-lint/test/_test_linter.pony
@@ -8,6 +8,59 @@ primitive \nodoc\ _NoASTRules
   fun apply(): Array[lint.ASTRule val] val =>
     recover val Array[lint.ASTRule val] end
 
+primitive \nodoc\ _NoTextRules
+  """Empty text rules array for AST-only linter tests."""
+  fun apply(): Array[lint.TextRule val] val =>
+    recover val Array[lint.TextRule val] end
+
+primitive \nodoc\ _LineLengthRules
+  """LineLength as the sole AST rule."""
+  fun apply(): Array[lint.ASTRule val] val =>
+    recover val [as lint.ASTRule val: lint.LineLength] end
+
+primitive \nodoc\ _LineLengthOnlyConfig
+  """Config that disables everything except style/line-length."""
+  fun apply(): lint.LintConfig =>
+    let rules =
+      recover val
+        let m = Map[String, lint.RuleStatus]
+        m("style") = lint.RuleOff
+        m("style/line-length") = lint.RuleOn
+        m
+      end
+    lint.LintConfig(recover val Set[String] end, rules)
+
+primitive \nodoc\ _WriteLongPony
+  """Write a valid Pony file with a comment line exceeding 80 columns."""
+  fun apply(file: File ref, long_line: String val) =>
+    file.print("actor Main")
+    file.print("  new create(env: Env) =>")
+    file.print("    // " + long_line)
+    file.print("    None")
+
+primitive \nodoc\ _PonyPath
+  """Extract PONYPATH from environment and split into package paths."""
+  fun apply(
+    vars: (Array[String val] val | None))
+    : Array[String val] val
+  =>
+    match vars
+    | let env_vars: Array[String val] val =>
+      for pair in env_vars.values() do
+        if pair.at("PONYPATH=") then
+          let pp: String val = pair.substring(ISize(9))
+          return recover val
+            let result = Array[String val]
+            for p in Path.split_list(pp).values() do
+              result.push(p)
+            end
+            result
+          end
+        end
+      end
+    end
+    recover val Array[String val] end
+
 class \nodoc\ _TestLinterSingleFile is UnitTest
   """Linting a single file with a violation produces diagnostics."""
   fun name(): String => "Linter: single file with violation"
@@ -21,15 +74,17 @@ class \nodoc\ _TestLinterSingleFile is UnitTest
           FileAuth(auth), Path.join(tmp.path, "test.pony"))
       let file = File(pony_file)
       let long_line = recover val String .> append("a".mul(100)) end
-      file.print(long_line)
+      _WriteLongPony(file, long_line)
       file.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
-      let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path, pkg_paths)
       let targets = recover val [as String val: tmp.path] end
       (let diags, let exit_code) = linter.run(targets)
       h.assert_true(diags.size() > 0)
@@ -63,18 +118,21 @@ class \nodoc\ _TestLinterCleanFile is UnitTest
       file.print("    None")
       file.dispose()
 
-      let rules: Array[lint.TextRule val] val =
+      let text_rules: Array[lint.TextRule val] val =
         recover val
           Array[lint.TextRule val]
-            .> push(lint.LineLength)
             .> push(lint.TrailingWhitespace)
             .> push(lint.HardTabs)
             .> push(lint.CommentSpacing)
         end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
-      let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
+          text_rules, _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path, pkg_paths)
       let targets = recover val [as String val: tmp.path] end
       (let diags, let exit_code) = linter.run(targets)
       h.assert_eq[USize](0, diags.size())
@@ -108,15 +166,17 @@ class \nodoc\ _TestLinterSkipsCorral is UnitTest
           FileAuth(auth), Path.join(corral_dir.path, "dep.pony"))
       let file = File(corral_file)
       let long_line = recover val String .> append("a".mul(100)) end
-      file.print(long_line)
+      _WriteLongPony(file, long_line)
       file.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
-      let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path, pkg_paths)
       let targets = recover val [as String val: tmp.path] end
       (let diags, _) = linter.run(targets)
       h.assert_eq[USize](0, diags.size())
@@ -142,16 +202,25 @@ class \nodoc\ _TestLinterSuppressedDiagnosticsFiltered is UnitTest
       let file = File(pony_file)
       let long_line = recover val String .> append("a".mul(100)) end
       let content: String val =
-        "// pony-lint: allow style/line-length\n" + long_line + "\n"
+        recover val
+          String
+            .> append("actor Main\n")
+            .> append("  new create(env: Env) =>\n")
+            .> append("    // pony-lint: allow style/line-length\n")
+            .> append("    // " + long_line + "\n")
+            .> append("    None\n")
+        end
       file.write(content)
       file.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
-      let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path, pkg_paths)
       let targets = recover val [as String val: tmp.path] end
       (let diags, _) = linter.run(targets)
       h.assert_eq[USize](0, diags.size())
@@ -171,27 +240,32 @@ class \nodoc\ _TestLinterDiagnosticsSorted is UnitTest
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
       // Create two files with violations — sorted order by filename
+      let long_line = recover val String .> append("a".mul(100)) end
+
       let file_b =
         FilePath(
           FileAuth(auth), Path.join(tmp.path, "b.pony"))
       let fb = File(file_b)
-      let long_line = recover val String .> append("a".mul(100)) end
-      fb.print(long_line)
+      fb.print("primitive B")
+      fb.print("  // " + long_line)
       fb.dispose()
 
       let file_a =
         FilePath(
           FileAuth(auth), Path.join(tmp.path, "a.pony"))
       let fa = File(file_a)
-      fa.print(long_line)
+      fa.print("primitive A")
+      fa.print("  // " + long_line)
       fa.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
-      let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path, pkg_paths)
       let targets = recover val [as String val: tmp.path] end
       (let diags, _) = linter.run(targets)
       h.assert_eq[USize](2, diags.size())
@@ -215,13 +289,15 @@ class \nodoc\ _TestLinterNonExistentTarget is UnitTest
 
   fun apply(h: TestHelper) =>
     let auth = h.env.root
-    let rules: Array[lint.TextRule val] val =
-      recover val [as lint.TextRule val: lint.LineLength] end
     let registry =
       lint.RuleRegistry(
-        rules, _NoASTRules(), lint.LintConfig.default())
+        _NoTextRules(), _LineLengthRules(),
+        lint.LintConfig.default())
     let cwd = Path.cwd()
-    let linter = lint.Linter(registry, FileAuth(auth), cwd)
+    let pkg_paths = _PonyPath(h.env.vars)
+    let linter =
+      lint.Linter(
+        registry, FileAuth(auth), cwd, pkg_paths)
     let targets =
       recover val [as String val: "no_such_file_or_dir_xyzzy"] end
     (let diags, let exit_code) = linter.run(targets)
@@ -269,7 +345,7 @@ class \nodoc\ _TestLinterRespectsGitignore is UnitTest
           FileAuth(auth), Path.join(gen_dir.path, "gen.pony"))
       let gf = File(gen_file)
       let long_line = recover val String .> append("a".mul(100)) end
-      gf.print(long_line)
+      _WriteLongPony(gf, long_line)
       gf.dispose()
       // Create a non-ignored .pony file that is clean
       let clean_file =
@@ -279,12 +355,14 @@ class \nodoc\ _TestLinterRespectsGitignore is UnitTest
       cf.print("actor Main")
       cf.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
-      let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path, pkg_paths)
       let targets = recover val [as String val: tmp.path] end
       (let diags, let exit_code) = linter.run(targets)
       // The generated/ file should be ignored, only clean.pony is linted
@@ -334,15 +412,17 @@ class \nodoc\ _TestLinterExplicitFileBypassesIgnore is UnitTest
           FileAuth(auth), Path.join(tmp.path, "test.pony"))
       let f = File(pony_file)
       let long_line = recover val String .> append("a".mul(100)) end
-      f.print(long_line)
+      _WriteLongPony(f, long_line)
       f.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
-      let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path, pkg_paths)
       // Target the file directly, not the directory
       let targets =
         recover val
@@ -398,7 +478,7 @@ class \nodoc\ _TestLinterRespectsGitignoreFromParent is UnitTest
           FileAuth(auth), Path.join(gen_dir.path, "gen.pony"))
       let gf = File(gen_file)
       let long_line = recover val String .> append("a".mul(100)) end
-      gf.print(long_line)
+      _WriteLongPony(gf, long_line)
       gf.dispose()
       // Create a clean file in src/
       let clean_file =
@@ -408,15 +488,14 @@ class \nodoc\ _TestLinterRespectsGitignoreFromParent is UnitTest
       cf.print("actor Main")
       cf.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
-      // Target is src/, not the repo root — tests that _GitRepoFinder
-      // walks up to find .git and that _load_intermediate_ignores loads
-      // root's .gitignore for the subdirectory target
-      let linter = lint.Linter(registry, FileAuth(auth), tmp.path)
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
+      let linter =
+        lint.Linter(
+          registry, FileAuth(auth), tmp.path, pkg_paths)
       let targets = recover val [as String val: src_dir.path] end
       (let diags, let exit_code) = linter.run(targets)
       // generated/ should be ignored via parent .gitignore
@@ -449,14 +528,14 @@ class \nodoc\ _TestLinterSubdirConfigDisablesRule is UnitTest
     let auth = h.env.root
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+      let long_line = recover val String .> append("a".mul(100)) end
 
       // Root file with a long line (violation)
       let root_file =
         FilePath(
           FileAuth(auth), Path.join(tmp.path, "root.pony"))
       let rf = File(root_file)
-      let long_line = recover val String .> append("a".mul(100)) end
-      rf.print(long_line)
+      _WriteLongPony(rf, long_line)
       rf.dispose()
 
       // Create examples/ subdirectory
@@ -480,17 +559,17 @@ class \nodoc\ _TestLinterSubdirConfigDisablesRule is UnitTest
         FilePath(
           FileAuth(auth), Path.join(examples_dir.path, "ex.pony"))
       let ef = File(ex_file)
-      ef.print(long_line)
+      _WriteLongPony(ef, long_line)
       ef.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
       let linter =
         lint.Linter(
-          registry, FileAuth(auth), tmp.path
+          registry, FileAuth(auth), tmp.path, pkg_paths
           where root_dir = tmp.path)
       let targets = recover val [as String val: tmp.path] end
       (let diags, _) = linter.run(targets)
@@ -524,6 +603,7 @@ class \nodoc\ _TestLinterSubdirConfigEnablesRule is UnitTest
     let auth = h.env.root
     try
       let tmp = FilePath.mkdtemp(FileAuth(auth), "pony-lint-test")?
+      let long_line = recover val String .> append("a".mul(100)) end
 
       // Root .pony-lint.json disables line-length
       let root_config =
@@ -540,8 +620,7 @@ class \nodoc\ _TestLinterSubdirConfigEnablesRule is UnitTest
         FilePath(
           FileAuth(auth), Path.join(tmp.path, "root.pony"))
       let rf = File(root_file)
-      let long_line = recover val String .> append("a".mul(100)) end
-      rf.print(long_line)
+      _WriteLongPony(rf, long_line)
       rf.dispose()
 
       // Create strict/ subdirectory
@@ -565,25 +644,26 @@ class \nodoc\ _TestLinterSubdirConfigEnablesRule is UnitTest
         FilePath(
           FileAuth(auth), Path.join(strict_dir.path, "strict.pony"))
       let sf = File(strict_file)
-      sf.print(long_line)
+      _WriteLongPony(sf, long_line)
       sf.dispose()
 
-      // Load root config manually since test creates its own
       let file_auth = FileAuth(auth)
       let root_rules =
         recover val
           let m = Map[String, lint.RuleStatus]
+          m("style") = lint.RuleOff
           m("style/line-length") = lint.RuleOff
           m
         end
       let config =
         lint.LintConfig(recover val Set[String] end, root_rules)
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
-      let registry = lint.RuleRegistry(rules, _NoASTRules(), config)
+      let registry =
+        lint.RuleRegistry(
+          _NoTextRules(), _LineLengthRules(), config)
+      let pkg_paths = _PonyPath(h.env.vars)
       let linter =
         lint.Linter(
-          registry, file_auth, tmp.path
+          registry, file_auth, tmp.path, pkg_paths
           where root_dir = tmp.path)
       let targets = recover val [as String val: tmp.path] end
       (let diags, _) = linter.run(targets)
@@ -643,14 +723,14 @@ class \nodoc\ _TestLinterSubdirConfigError is UnitTest
       sf.print("actor Main")
       sf.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
       let linter =
         lint.Linter(
-          registry, FileAuth(auth), tmp.path
+          registry, FileAuth(auth), tmp.path, pkg_paths
           where root_dir = tmp.path)
       let targets = recover val [as String val: tmp.path] end
       (let diags, let exit_code) = linter.run(targets)
@@ -721,15 +801,15 @@ class \nodoc\ _TestLinterSubdirConfigCategoryCleaning is UnitTest
           FileAuth(auth), Path.join(examples_dir.path, "ex.pony"))
       let ef = File(ex_file)
       let long_line = recover val String .> append("a".mul(100)) end
-      ef.print(long_line)
+      _WriteLongPony(ef, long_line)
       ef.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
-      let registry = lint.RuleRegistry(rules, _NoASTRules(), config)
+      let registry =
+        lint.RuleRegistry(_NoTextRules(), _LineLengthRules(), config)
+      let pkg_paths = _PonyPath(h.env.vars)
       let linter =
         lint.Linter(
-          registry, FileAuth(auth), tmp.path
+          registry, FileAuth(auth), tmp.path, pkg_paths
           where root_dir = tmp.path)
       let targets =
         recover val [as String val: examples_dir.path] end
@@ -780,17 +860,17 @@ class \nodoc\ _TestLinterExplicitFileSubdirConfig is UnitTest
           FileAuth(auth), Path.join(examples_dir.path, "ex.pony"))
       let ef = File(ex_file)
       let long_line = recover val String .> append("a".mul(100)) end
-      ef.print(long_line)
+      _WriteLongPony(ef, long_line)
       ef.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
       let linter =
         lint.Linter(
-          registry, FileAuth(auth), tmp.path
+          registry, FileAuth(auth), tmp.path, pkg_paths
           where root_dir = tmp.path)
       // Target the file directly, not the directory
       let targets =
@@ -852,18 +932,18 @@ class \nodoc\ _TestLinterIntermediateConfigLoading is UnitTest
           FileAuth(auth), Path.join(sub_dir.path, "test.pony"))
       let sf = File(sub_file)
       let long_line = recover val String .> append("a".mul(100)) end
-      sf.print(long_line)
+      _WriteLongPony(sf, long_line)
       sf.dispose()
 
-      let rules: Array[lint.TextRule val] val =
-        recover val [as lint.TextRule val: lint.LineLength] end
       let registry =
         lint.RuleRegistry(
-          rules, _NoASTRules(), lint.LintConfig.default())
+          _NoTextRules(), _LineLengthRules(),
+          _LineLengthOnlyConfig())
+      let pkg_paths = _PonyPath(h.env.vars)
       // Target is sub/, so mid/ is an intermediate directory
       let linter =
         lint.Linter(
-          registry, FileAuth(auth), tmp.path
+          registry, FileAuth(auth), tmp.path, pkg_paths
           where root_dir = tmp.path)
       let targets = recover val [as String val: sub_dir.path] end
       (let diags, _) = linter.run(targets)

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -104,6 +104,12 @@ actor \nodoc\ Main is TestList
     test(_TestLineLengthStringExemptUTF8)
     test(_TestLineLengthStringExemptProperty)
     test(_TestLineLengthStringFlaggedProperty)
+    test(_TestLineLengthASTStringLiteralExempt)
+    test(_TestLineLengthASTDocstringNotExempt)
+    test(_TestLineLengthASTMethodDocstringNotExempt)
+    test(_TestLineLengthASTModuleDocstringNotExempt)
+    test(_TestLineLengthASTDocstringQuotedIdFlagged)
+    test(_TestLineLengthASTMixedDocstringAndLiteral)
 
     // TrailingWhitespace tests
     test(_TestTrailingWhitespaceSpace)


### PR DESCRIPTION
pony-lint's `style/line-length` rule flagged lines inside triple-quoted string literals that exist for readability — JSON templates, inline test fixtures, format strings. Wrapping those at 80 columns makes the code harder to read, not easier.

The rule now uses the parsed AST to distinguish docstrings from string literals. Lines inside non-docstring triple-quoted strings are exempt from the 80-column check. Docstring prose is still checked, and the no-space string exemption (for URLs, paths) is disabled inside docstrings so that long quoted identifiers in prose are still flagged.

LineLength is converted from a TextRule to an ASTRule with a module-level check, following the same pattern as FileNaming and BlankLines.
