### PR TITLE
Point pony-lsp-tests directly at tools/pony-lsp/test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,11 +735,9 @@ else()
         PATHS ${CMAKE_SOURCE_DIR}/tools/lib/ponylang/pony_compiler
         WATCH ${CMAKE_SOURCE_DIR}/tools/pony-lint)
 
-    # pony-lsp-tests compiles tools/ (tools/_test.pony pulls in pony-lsp/test via
-    # `use`), not tools/pony-lsp/test.
     add_pony_binary(pony-lsp-tests
         NAME pony-lsp-tests
-        SOURCE ${CMAKE_SOURCE_DIR}/tools
+        SOURCE ${CMAKE_SOURCE_DIR}/tools/pony-lsp/test
         PATHS ${CMAKE_SOURCE_DIR}/tools/lib/ponylang/pony_compiler
         WATCH ${CMAKE_SOURCE_DIR}/tools/pony-lsp)
 

--- a/tools/_test.pony
+++ b/tools/_test.pony
@@ -1,9 +1,0 @@
-use "pony_test"
-use lsp = "pony-lsp/test"
-
-actor \nodoc\ Main is TestList
-  new create(env: Env) => PonyTest(env, this)
-  new make() => None
-
-  fun tag tests(test: PonyTest) =>
-    lsp.Main.make().tests(test)


### PR DESCRIPTION
`tools/_test.pony` sat at the `tools/` root but only delegated to `pony-lsp/test` — unlike the other three tool test targets, which already compile their own `test/` subdirectory directly. Remove the unnecessary indirection so pony-lsp-tests matches the others.
