### PR TITLE
Lint full-program-tests in PR CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -394,6 +394,8 @@ jobs:
             $(find ../../examples -maxdepth 2 -name '*.pony' -printf '%h\n' | sort -u)
       - name: Lint full-program-runner
         run: cd build/debug && ./pony-lint ../../test/full-program-runner/
+      - name: Lint full-program-tests
+        run: cd build/debug && ./pony-lint ../../test/full-program-tests/
       - name: Lint pony-compiler
         run: cd build/debug && ./pony-lint ../../tools/lib/ponylang/pony_compiler/
 

--- a/test/full-program-tests/.pony-lint.json
+++ b/test/full-program-tests/.pony-lint.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "style": "off",
+    "safety": "off"
+  }
+}


### PR DESCRIPTION
Adds pony-lint coverage for `test/full-program-tests/` in PR CI. All rules
are turned off via a directory-level `.pony-lint.json` — these are compiler
test fixtures, not library code. The CI step is in place so enabling
specific rules later is a config change, not a workflow change.

Part of #5839.
