### PR TITLE
Add pony-lint coverage for test/rt-stress and test/rt-systematic

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -392,10 +392,8 @@ jobs:
           cd build/debug
           PONYPATH=../../packages ./pony-lint \
             $(find ../../examples -maxdepth 2 -name '*.pony' -printf '%h\n' | sort -u)
-      - name: Lint full-program-runner
-        run: cd build/debug && ./pony-lint ../../test/full-program-runner/
-      - name: Lint full-program-tests
-        run: cd build/debug && ./pony-lint ../../test/full-program-tests/
+      - name: Lint test
+        run: cd build/debug && ./pony-lint ../../test/
       - name: Lint pony-compiler
         run: cd build/debug && ./pony-lint ../../tools/lib/ponylang/pony_compiler/
 

--- a/test/rt-stress/generative/generative.pony
+++ b/test/rt-stress/generative/generative.pony
@@ -1,0 +1,22 @@
+"""
+Generative runtime stress harness.
+
+A swarm-driven Pony program that exercises the runtime's message
+passing, ORCA tracing, the cycle detector's collection path, the
+explicit backpressure / muting path, ORCA's transfer of ownership
+of a nested mutable object subgraph between actors, and ORCA's
+actor-reference counting. One run draws one of five closed,
+count-driven workloads (`--workload`): `mesh`, `cyclic`,
+`backpressure`, `iso`, and `actorref`.
+
+The workloads are closed: a fixed amount of work is injected and
+the run terminates when it drains. All randomness is seeded only
+from `--seed` (never the clock). Each workload's
+driver/collector folds its scheduler-visible arrivals into an
+FNV-1a `ORDER_SIG`, a pure function of the scheduler interleaving
+for the determinism oracle.
+
+Two orchestrators drive this program:
+`orchestrate_systematic.py` (serialized, reproducible) and
+`orchestrate_normal.py` (real-parallel runtime).
+"""

--- a/test/rt-stress/generative/main.pony
+++ b/test/rt-stress/generative/main.pony
@@ -1,127 +1,3 @@
-"""
-Generative runtime stress harness.
-
-A swarm-driven Pony program that exercises the runtime's message passing, ORCA
-tracing, the cycle detector's collection path (via the `cyclic` workload), the
-explicit backpressure / muting path (via the `backpressure` workload), ORCA's
-transfer of ownership of a nested mutable object subgraph between actors (via the
-`iso` workload), and ORCA's actor-reference counting -- the acquire / release of
-actor `tag`s passed as message cargo (via the `actorref` workload). One run draws
-one of five closed, count-driven workloads (`--workload`):
-
-* `mesh` (M0): a closed mesh of `Pinger` actors. A fixed number of chains are
-  injected, each carrying a hop counter (TTL); a `Pinger` receiving a ping with
-  hops > 0 forwards exactly one ping (hops - 1) to a random neighbor, and a ping
-  with hops == 0 terminates and signals the coordinator. Because each ping
-  produces exactly one successor message the run terminates deterministically
-  once every chain has terminated, and
-
-      sent == received == chains * (ttl + 1)
-
-  is an exact, checkable invariant the coordinator verifies by polling every
-  `Pinger`'s send/receive tally.
-
-* `cyclic` (M1): successive generations of `CyclicWorker` groups. Each worker in
-  a group holds the whole group's `val` array, so a group is one strongly
-  connected reference cycle that reference counting alone can never reclaim. The
-  group's external reference is dropped after its chains are injected, so it
-  becomes garbage only the cycle detector can collect. This is the proven shape of
-  `test/rt-systematic/cycle-collection-order-signature`, parameterized and wired
-  to this engine's CLI/config/ORDER_SIG conventions (an independent program, not a
-  shared module -- the two can diverge without breaking each other). Because the
-  workers become garbage they cannot be polled for tallies, so conservation here
-  is completion-count only: exactly `generations * chains` terminal completions
-  must arrive. A lost forward mid-chain leaves a chain that never completes -- the
-  count never reaches its target and the run is caught by the orchestrator's
-  liveness watchdog as a timeout, not as an in-engine conservation failure. A
-  duplicate or late completion drives the count past its target and trips
-  `_Fatal`. This is strictly weaker than the mesh's independent send/receive
-  tally; it is the strongest oracle available once the actors are garbage.
-
-* `backpressure` (M1): a star of `Producer` actors flooding one `Consumer`. Each
-  producer sends `messages` work messages then a `finished` report; the consumer
-  explicitly participates in runtime backpressure via the stdlib `backpressure`
-  package -- after every `apply_every` messages it calls `Backpressure.apply`
-  (marking itself UNDER_PRESSURE, so its producers are muted) and self-sends a
-  `lift` that calls `Backpressure.release`. The self-send is never muted, so apply
-  is always paired with release and the closed flood cannot deadlock. This drives
-  the explicit UNDER_PRESSURE muting path that the `mesh` never reaches -- the mesh
-  drives only the runtime's *automatic* OVERLOAD muting. Conservation is the mesh's
-  strength, not the cyclic's weakness: completion triggers on
-  `finished_count == producers` (independent of the received count), then asserts
-  `received == sent == producers * messages` from the producers' own send tallies,
-  so a lost work is caught as a conservation failure here, not merely as a timeout.
-
-* `iso` (M1): the `mesh` topology, but the shared `val` payload is replaced by a
-  freshly built nested `iso` object graph -- a `Parcel` tree of `--node-depth`
-  levels with `--node-breadth` children per node, every node a separate allocation
-  holding its own byte array -- `consume`d hop-to-hop. Each hop moves ownership of
-  the whole mutable subgraph to the next actor, so the receiver acquires a foreign
-  *mutable* multi-object graph node by node -- a trace path no other workload
-  reaches (the others only ever make a raw byte buffer mutable, never a typed
-  object struct, and never transfer a mutable subgraph). The swarm draws the graph
-  shape, so runs span a single flat node through a 15-node tree. At the terminal
-  hop the graph is consumed into a `ref` and every node's sentinel bytes are
-  verified, so a silent GC corruption or premature free of the moved subgraph is
-  caught, not just a crash. Conservation is the mesh's full send/receive tally
-  (`sent == received == chains * (ttl + 1)`); the `Carrier`s are live at quiescence
-  (the `Dispatcher` holds them), so they are polled exactly like the mesh.
-
-* `actorref` (M1): the `mesh` topology, but the cargo is a `Referent tag` -- a
-  reference to a bare actor -- instead of a `val` payload. A FRESH `Referent` is
-  built per injected chain and its tag rides the chain hop-to-hop; each `Relay`
-  forwards the tag onward and NEVER stores it. A freshly received foreign actor
-  reference sits at reference count 1, so forwarding it exhausts its weighted
-  budget on that send -- the forward drives ORCA's actor-reference ACQUIRE, and
-  dropping it (never stored) drives the RELEASE -- so `send_remote_actor` /
-  `recv_remote_actor` / `acquire_actor` fire proportional to `chains * ttl`, the
-  actor-reference machinery no other workload exercises under load (measured: the
-  others hit `acquire_actor` 0-1 times a run, all at setup). A fixed referent pool
-  was rejected by measurement -- a shared referent's weighted budget stays high, so
-  forwards stop acquiring and the path goes cold; fresh-per-chain also makes a lost
-  release leak in proportion to `chains`. Conservation is the mesh's full
-  send/receive tally (`sent == received == chains * (ttl + 1)`); the `Relay`s are
-  live at quiescence (the `Referrer` holds them), so they are polled exactly like
-  the mesh, while the referents become garbage as their chains drain.
-
-The workloads are closed, unlike an open cascade stopped by a wall-clock timer:
-a fixed amount of work is injected and the run terminates when it drains. The
-closed shape is a deliberate constraint, not the end goal -- a continuous, open
-workload is the better stress model, but closed is what's feasible under
-systematic testing today (it needs no timer; time is not virtualized there). When
-open becomes feasible, revisit this.
-
-On success the engine prints its result line with a synchronous `@printf` and then
-*returns*, letting the program reach natural quiescence rather than forcing an
-exit. Two reasons: the `cyclic` workload's garbage is only collected as the
-program quiesces (a forced exit kills the process before the detector sweeps), and
-letting the runtime shut down cleanly turns shutdown itself into something the
-harness tests -- the systematic park-site hang fixed by #5576/#5585 surfaces here
-as a watchdog timeout if it ever regresses (the re-park loops that prevent it live
-in `src/libponyrt/sched/systematic_testing.c`). Only a conservation *failure* forces `@exit(1)`:
-once a bug is detected, fail fast rather than risk quiescing a broken run.
-
-All randomness is seeded only from `--seed` (never the clock). The routing graph
-is not a function of `--seed` alone, though: which draw lands on which ping depends
-on the order an actor processes its mailbox, so the routing -- and the run --
-reproduce only when the interleaving does: a fixed `--ponysystematictestingseed`
-under a systematic build. (#5566/#5570 made that replay independent of memory
-layout, so disabling ASLR is no longer needed.) Each workload's driver/collector
-folds its scheduler-visible arrivals -- chain completions for mesh/cyclic/iso; for
-backpressure, every work arrival (the mute/unmute interleaving) plus the producer
-`finished` reports -- into an FNV-1a `ORDER_SIG`, a pure function of the scheduler
-interleaving and the observable for the determinism oracle.
-
-This program holds no `@runtime_override_defaults`: every runtime knob (scaling,
-cycle detector, GC, thread count, the systematic seed) is a `--pony*` flag set by
-the orchestrator, and every workload parameter is a `--flag value` arg parsed
-here. Two orchestrators in this directory drive it: `orchestrate_systematic.py`
-(serialized, reproducible -- draws all five workloads, with `--ponynoblock` drawn as
-a swarm knob so the cycle detector runs under the oracle on the runs where it is
-absent) and `orchestrate_normal.py` (a normal, real-parallel runtime -- also draws
-all five workloads; the conservation invariant holds there too, but `ORDER_SIG` does
-not reproduce, so that mode runs each seed once).
-"""
 use "backpressure"
 use "cli"
 use "random"
@@ -134,26 +10,34 @@ use @exit[None](status: I32)
 
 type Payload is (String val | U64)
   """
-  A message's traced cargo: a heap-allocated `String val` (gives ORCA something to
-  trace across the actor boundary) or a `U64` primitive (a no-GC control). The
-  kind is fixed for a whole run by `--payload`; `--payload-mode` then decides
-  whether one payload object is reused (forwarded the whole chain, or re-sent by a
-  producer) or a fresh one is allocated at each send. Shared by the mesh, cyclic,
-  and backpressure workloads (the `iso` workload has its own `Parcel` cargo).
+  A message's traced cargo: a heap-allocated `String val`
+  (gives ORCA something to trace across the actor boundary)
+  or a `U64` primitive (a no-GC control). The kind is fixed
+  for a whole run by `--payload`; `--payload-mode` then
+  decides whether one payload object is reused (forwarded the
+  whole chain, or re-sent by a producer) or a fresh one is
+  allocated at each send. Shared by the mesh, cyclic, and
+  backpressure workloads (the `iso` workload has its own
+  `Parcel` cargo).
   """
 
 primitive _Payloads
   """
-  Builds a message payload of the configured kind. `--payload-mode forward` reuses
-  one object across a sender's sends (exercising ORCA's shared-`val` refcounting);
-  `fresh` calls this at every send (exercising allocation + tracing + collection
-  churn). Used by the mesh, cyclic, and backpressure workloads (the `iso` workload
+  Builds a message payload of the configured kind.
+  `--payload-mode forward` reuses one object across a
+  sender's sends (exercising ORCA's shared-`val`
+  refcounting); `fresh` calls this at every send (exercising
+  allocation + tracing + collection churn). Used by the mesh,
+  cyclic, and backpressure workloads (the `iso` workload
   builds its own `Parcel` cargo instead).
   """
   fun make(config: _Config): Payload =>
     if config.payload_string then
       let s: String val =
-        String.from_array(recover val Array[U8].init('p', config.payload_size) end)
+        String.from_array(
+          recover val
+            Array[U8].init('p', config.payload_size)
+          end)
       s
     else
       U64(42)
@@ -161,26 +45,32 @@ primitive _Payloads
 
 primitive _Heartbeat
   """
-  The no-progress watchdog's progress signal. A receiving actor calls `emit` every
-  `interval(...)` messages it handles; the normal orchestrator's watchdog reads
-  these to tell a slow-but-advancing run from a hung one, killing only on silence
-  (see stress_common.py). The line carries no data -- only its arrival matters, and
-  it adds no message and no fan-out, so the conservation and ORDER_SIG oracles are
-  untouched.
+  The no-progress watchdog's progress signal. A receiving
+  actor calls `emit` every `interval(...)` messages it
+  handles; the normal orchestrator's watchdog reads these to
+  tell a slow-but-advancing run from a hung one, killing only
+  on silence (see stress_common.py). The line carries no
+  data -- only its arrival matters, and it adds no message
+  and no fan-out, so the conservation and ORDER_SIG oracles
+  are untouched.
 
-  Flushing is load-bearing: a bare @printf to a piped stdout is block-buffered, so
-  the line would not reach the watchdog until the buffer fills or the program exits,
-  defeating the watchdog. @fflush forces it out per heartbeat (verified to arrive in
-  real time both directly and under lldb).
+  Flushing is load-bearing: a bare @printf to a piped
+  stdout is block-buffered, so the line would not reach
+  the watchdog until the buffer fills or the program exits,
+  defeating the watchdog. @fflush forces it out per
+  heartbeat (verified to arrive in real time both directly
+  and under lldb).
   """
   fun interval(total_messages: USize, emitters: USize): USize =>
     """
-    Per-emitter message count between heartbeats, or 0 to disable. Disabled when the
-    run is small enough to finish well within the watchdog's no-progress window (so
-    it needs no heartbeat -- the cyclic workload and small mesh/backpressure draws);
-    otherwise ~`_target` heartbeats per emitter, floored at 1. COUPLING: this cadence
-    is paired with the orchestrator's no_progress threshold -- a live run must
-    heartbeat well within it.
+    Per-emitter message count between heartbeats, or 0 to
+    disable. Disabled when the run is small enough to finish
+    well within the watchdog's no-progress window (so it
+    needs no heartbeat -- the cyclic workload and small
+    mesh/backpressure draws); otherwise ~`_target` heartbeats
+    per emitter, floored at 1. COUPLING: this cadence is
+    paired with the orchestrator's no_progress threshold --
+    a live run must heartbeat well within it.
     """
     if (emitters == 0) or (total_messages < _min()) then
       0
@@ -198,10 +88,11 @@ primitive _Heartbeat
 actor Main
   new create(env: Env) =>
     """
-    Parse the workload args with the `cli` package and dispatch on the workload
-    kind. `--help` prints usage and exits 0; a syntax error (unknown flag, missing
-    value, bad number) or a failed value check exits non-zero without starting the
-    workload.
+    Parse the workload args with the `cli` package and
+    dispatch on the workload kind. `--help` prints usage
+    and exits 0; a syntax error (unknown flag, missing
+    value, bad number) or a failed value check exits
+    non-zero without starting the workload.
     """
     let spec =
       try
@@ -213,14 +104,15 @@ actor Main
       end
     match \exhaustive\ CommandParser(spec).parse(env.args)
     | let cmd: Command =>
-      match _Cli.config(cmd)
+      match \exhaustive\ _Cli.config(cmd)
       | let config: _Config =>
-        match config.workload
+        match \exhaustive\ config.workload
         | let mesh: _Mesh => Coordinator(config, mesh)
         | let cyclic: _Cyclic => Churner(config, cyclic)
         | let bp: _Backpressure =>
-          // Only this workload needs the backpressure auth token, built from the
-          // root authority here and threaded into the Consumer.
+          // Only this workload needs the backpressure
+          // auth token, built from the root authority
+          // here and threaded into the Consumer.
           Consumer(config, bp, ApplyReleaseBackpressureAuth(env.root))
         | let iso': _Iso => Dispatcher(config, iso')
         | let ar: _ActorRef => Referrer(config, ar)
@@ -238,11 +130,13 @@ actor Main
 
 actor Coordinator
   """
-  The `mesh` workload driver. Builds the mesh, injects the chains, counts
-  completions to detect quiescence, collects per-`Pinger` send/receive tallies,
-  and evaluates the conservation oracle. On completion it prints `ORDER_SIG` plus
-  the tallies; on a conservation failure it forces a non-zero exit, otherwise it
-  returns and lets the program quiesce.
+  The `mesh` workload driver. Builds the mesh, injects
+  the chains, counts completions to detect quiescence,
+  collects per-`Pinger` send/receive tallies, and
+  evaluates the conservation oracle. On completion it
+  prints `ORDER_SIG` plus the tallies; on a conservation
+  failure it forces a non-zero exit, otherwise it returns
+  and lets the program quiesce.
   """
   let _config: _Config
   let _mesh: _Mesh
@@ -257,11 +151,13 @@ actor Coordinator
     _config = config
     _mesh = mesh
 
-    // Create the mesh. Pingers are built outside the `recover` block (so we can
-    // pass `this`) and pushed into the iso array via automatic receiver
-    // recovery -- `push`'s argument, a `Pinger tag`, is sendable.
-    // Per-Pinger heartbeat cadence: ~_target prints per Pinger over the run, off
-    // for runs too small to need a progress signal. Computed once and shared.
+    // Create the mesh. Pingers are built outside the
+    // `recover` block (so we can pass `this`) and pushed
+    // into the iso array via automatic receiver recovery --
+    // `push`'s argument, a `Pinger tag`, is sendable.
+    // Per-Pinger heartbeat cadence: ~_target prints per
+    // Pinger over the run, off for runs too small to need a
+    // progress signal. Computed once and shared.
     let hb = _Heartbeat.interval(mesh.chains * (mesh.ttl + 1), mesh.pingers)
     let ps: Array[Pinger] iso = recover Array[Pinger](mesh.pingers) end
     var id: USize = 0
@@ -293,11 +189,13 @@ actor Coordinator
 
   be completed(chain: USize, terminal_id: USize, received_snapshot: U64) =>
     """
-    A chain reached its terminal (hops == 0) ping. Fold the arrival into the
-    order signature; once every chain has terminated the system is quiesced (see
-    `Pinger.set_neighbors` and the module docstring), so ask every `Pinger` for
-    its final counts. A completion beyond `chains` is a duplicate or late message
-    -- a real fault -- so it trips `_Fatal`.
+    A chain reached its terminal (hops == 0) ping. Fold
+    the arrival into the order signature; once every chain
+    has terminated the system is quiesced (see
+    `Pinger.set_neighbors` and the module docstring), so
+    ask every `Pinger` for its final counts. A completion
+    beyond `chains` is a duplicate or late message -- a
+    real fault -- so it trips `_Fatal`.
     """
     _mix(chain.u64())
     _mix(terminal_id.u64())
@@ -340,13 +238,17 @@ actor Coordinator
       + " ORDER_SIG=" + _sig.string() + "\n"
     @printf("%s".cstring(), line.cstring())
 
-    // On success: return and let the program reach natural quiescence (no forced
-    // exit). The mesh + coordinator form one reference cycle that, once this
-    // behavior returns, is unreachable; with the cycle detector on it is collected
-    // as the program shuts down -- bonus detector exercise -- and either way the
-    // runtime quiesces cleanly (the shutdown hang a forced exit once dodged is
-    // fixed by #5576/#5585). Only a conservation FAILURE forces a non-zero exit:
-    // fail fast once a bug is detected rather than risk quiescing a broken run.
+    // On success: return and let the program reach natural
+    // quiescence (no forced exit). The mesh + coordinator
+    // form one reference cycle that, once this behavior
+    // returns, is unreachable; with the cycle detector on
+    // it is collected as the program shuts down -- bonus
+    // detector exercise -- and either way the runtime
+    // quiesces cleanly (the shutdown hang a forced exit
+    // once dodged is fixed by #5576/#5585). Only a
+    // conservation FAILURE forces a non-zero exit: fail
+    // fast once a bug is detected rather than risk
+    // quiescing a broken run.
     if not conserved then
       let diag = "CONSERVATION FAILURE: received=" + _total_received.string()
         + " sent=" + total_sent.string()
@@ -373,7 +275,12 @@ actor Pinger
   var _reported: Bool = false
   let _rand: Rand
 
-  new create(coord: Coordinator, id: USize, config: _Config, hb_interval: USize) =>
+  new create(
+    coord: Coordinator,
+    id: USize,
+    config: _Config,
+    hb_interval: USize)
+  =>
     _coord = coord
     _id = id
     _config = config
@@ -436,13 +343,13 @@ actor Pinger
 actor Churner
   """
   The `cyclic` workload driver. Spawns `generations` successive groups of
-  `CyclicWorker` actors; each worker holds the whole group's array, so a group is
-  one strongly connected reference cycle. After a generation's chains are injected
-  the group's only external reference (the local below) is dropped, so the group
-  becomes garbage only the cycle detector can reclaim. Generations overlap --
-  reclaiming an earlier group races the pinging of a later one -- so the detector
-  works under sustained load. Adapted from
-  `test/rt-systematic/cycle-collection-order-signature`.
+  `CyclicWorker` actors; each worker holds the whole group's array, so a group
+  is one strongly connected reference cycle. After a generation's chains are
+  injected the group's only external reference (the local below) is dropped, so
+  the group becomes garbage only the cycle detector can reclaim. Generations
+  overlap -- reclaiming an earlier group races the pinging of a later one -- so
+  the detector works under sustained load. Adapted from `test/rt-
+  systematic/cycle-collection-order-signature`.
   """
   let _config: _Config
   let _generations: USize
@@ -467,19 +374,19 @@ actor Churner
     Build generation `gen`'s group, wire every member to the whole group (one
     strongly connected cycle), inject its chains, then self-send the next
     generation. The group's only external reference is this behavior's local, so
-    once the chains drain the group is unreachable garbage the cycle detector must
-    reclaim. Self-sending the next generation before this one drains is what makes
-    the generations overlap.
+    once the chains drain the group is unreachable garbage the cycle detector
+    must reclaim. Self-sending the next generation before this one drains is
+    what makes the generations overlap.
     """
     if gen >= _generations then
       return
     end
 
     // Build one group and give every member the whole group's array, so the
-    // group is one strongly connected reference cycle. The array is held only in
-    // this local; once the chains kicked off below drain, nothing outside the
-    // group references any member and the group is garbage the cycle detector
-    // must reclaim.
+    // group is one strongly connected reference cycle. The array is held only
+    // in this local; once the chains kicked off below drain, nothing outside
+    // the group references any member and the group is garbage the cycle
+    // detector must reclaim.
     let k = _group
     let group: Array[CyclicWorker] iso = recover Array[CyclicWorker](k) end
     var i: USize = 0
@@ -490,24 +397,25 @@ actor Churner
     // Give every member the group before injecting any chain, so by causal
     // delivery each member's set_group is ordered ahead of any ping that can
     // reach it (same reasoning as Pinger.set_neighbors): the first ping comes
-    // from this Churner, which sends set_group to all members first (same-sender
-    // FIFO), and a forwarded ping can only come from a member that has therefore
-    // already run set_group. So `_group` is always non-empty when ping() runs.
+    // from this Churner, which sends set_group to all members first (same-
+    // sender FIFO), and a forwarded ping can only come from a member that has
+    // therefore already run set_group. So `_group` is always non-empty when
+    // ping() runs.
     let members: Array[CyclicWorker] val = consume group
     for w in members.values() do
       w.set_group(members)
     end
 
     // Inject this generation's chains from random starts. Routing is random, so
-    // the path -- and each worker's receive count when a chain terminates -- is a
-    // pure function of the interleaving.
+    // the path -- and each worker's receive count when a chain terminates -- is
+    // a pure function of the interleaving.
     let r = Rand(_config.seed, gen.u64())
     var c: USize = 0
     while c < _chains do
       let start = r.int(k.u64()).usize()
       try
-        members(start)?.ping(_Payloads.make(_config), _ttl,
-          (gen * _chains) + c)
+        members(start)?.ping(
+          _Payloads.make(_config), _ttl, (gen * _chains) + c)
       else
         _Unreachable("cyclic injection start index out of range")
       end
@@ -522,10 +430,10 @@ actor Churner
 actor CyclicWorker
   """
   A member of one strongly connected group. Forwards exactly one successor
-  message per received ping (the same one-in/one-out invariant as `Pinger`), then
-  the group becomes unreachable and the worker is collected by the cycle detector.
-  It is never polled for tallies (it is garbage by quiescence), so it keeps no
-  report path.
+  message per received ping (the same one-in/one-out invariant as `Pinger`),
+  then the group becomes unreachable and the worker is collected by the cycle
+  detector. It is never polled for tallies (it is garbage by quiescence), so it
+  keeps no report path.
   """
   let _collector: CyclicCollector
   let _config: _Config
@@ -534,14 +442,19 @@ actor CyclicWorker
   var _received: U64 = 0
   let _rand: Rand
 
-  new create(collector: CyclicCollector, config: _Config, gen: USize, id: USize) =>
+  new create(
+    collector: CyclicCollector,
+    config: _Config,
+    gen: USize,
+    id: USize)
+  =>
     _collector = collector
     _config = config
     _id = id
     _group = recover val Array[CyclicWorker] end
-    // Per-worker draw stream. The value stream is fixed by the seed; which value
-    // lands on which ping depends on mailbox arrival order, so routing is a
-    // function of the seed AND the interleaving.
+    // Per-worker draw stream. The value stream is fixed by the seed; which
+    // value lands on which ping depends on mailbox arrival order, so routing is
+    // a function of the seed AND the interleaving.
     _rand = Rand(config.seed, ((gen * 31) + id).u64())
 
   be set_group(group: Array[CyclicWorker] val) =>
@@ -555,9 +468,9 @@ actor CyclicWorker
 
   be ping(payload: Payload, hops: USize, chain: USize) =>
     """
-    Produce exactly one successor message per received ping: a forward when
-    hops > 0, otherwise one completion signal. The same one-in/one-out invariant
-    as `Pinger.ping` -- it is what makes exactly `generations * chains` completions
+    Produce exactly one successor message per received ping: a forward when hops
+    > 0, otherwise one completion signal. The same one-in/one-out invariant as
+    `Pinger.ping` -- it is what makes exactly `generations * chains` completions
     the sound quiescence/conservation barrier (module docstring).
     """
     _received = _received + 1
@@ -582,8 +495,8 @@ actor CyclicCollector
   letting the program quiesce. A completion beyond the expected total is a
   duplicate or late message -- a real fault -- so it trips `_Fatal`. (A *lost*
   message instead leaves the count short forever; that surfaces as the
-  orchestrator's liveness timeout, not here.) The collector stays reachable for a
-  genuine duplicate because the worker that produced it still references the
+  orchestrator's liveness timeout, not here.) The collector stays reachable for
+  a genuine duplicate because the worker that produced it still references the
   collector.
   """
   let _expected: USize
@@ -596,8 +509,8 @@ actor CyclicCollector
   be completed(chain: USize, terminal_id: USize, received_snapshot: U64) =>
     """
     Fold one chain's terminal arrival into `ORDER_SIG` and count it. On the
-    expected-th completion print the result (then quiesce); a completion beyond the
-    expected total is a duplicate or late message, so trip `_Fatal`.
+    expected-th completion print the result (then quiesce); a completion beyond
+    the expected total is a duplicate or late message, so trip `_Fatal`.
     """
     _mix(chain.u64())
     _mix(terminal_id.u64())
@@ -605,7 +518,8 @@ actor CyclicCollector
     _received = _received + 1
     if _received == _expected then
       // Synchronous print so the result survives natural quiescence (no SENT --
-      // the garbage workers cannot be polled for a send tally; see module docs).
+      // the garbage workers cannot be polled for a send tally; see module
+      // docs).
       let line = "RECEIVED=" + _received.string()
         + " EXPECTED=" + _expected.string()
         + " ORDER_SIG=" + _sig.string() + "\n"
@@ -619,12 +533,13 @@ actor CyclicCollector
 
 actor Producer
   """
-  A `backpressure`-workload producer. Sends `messages` work messages to the single
-  consumer, then one `finished` report carrying its id and send tally, and stops.
-  Each foreign `work` send is a muting point: while the consumer is UNDER_PRESSURE
-  the producer is muted, so its self-sent `produce` is deferred until the consumer
-  releases -- that deferral IS the backpressure. Many producers flood one consumer
-  (a star), so every muted producer concentrates in that one receiver's muteset.
+  A `backpressure`-workload producer. Sends `messages` work messages to the
+  single consumer, then one `finished` report carrying its id and send tally,
+  and stops. Each foreign `work` send is a muting point: while the consumer is
+  UNDER_PRESSURE the producer is muted, so its self-sent `produce` is deferred
+  until the consumer releases -- that deferral IS the backpressure. Many
+  producers flood one consumer (a star), so every muted producer concentrates in
+  that one receiver's muteset.
   """
   let _consumer: Consumer
   let _config: _Config
@@ -639,9 +554,9 @@ actor Producer
     _id = id
     _remaining = messages
     // `forward` mode reuses this one payload object for every send (a muted
-    // producer then holds a shared `val` ref -- ORCA under backpressure); `fresh`
-    // mode allocates a new one at each send (allocation churn). Built once here so
-    // forward mode has an object to reuse.
+    // producer then holds a shared `val` ref -- ORCA under backpressure);
+    // `fresh` mode allocates a new one at each send (allocation churn). Built
+    // once here so forward mode has an object to reuse.
     _payload = _Payloads.make(config)
     produce()
 
@@ -649,8 +564,8 @@ actor Producer
     """
     Send exactly one work message, then self-send to continue; after `messages`
     have been sent, report `finished` and stop. The self-send is deferred while
-    this producer is muted, so production pauses under backpressure and resumes on
-    release -- without any explicit rate logic here.
+    this producer is muted, so production pauses under backpressure and resumes
+    on release -- without any explicit rate logic here.
     """
     if _remaining == 0 then
       _consumer.finished(_id, _sent)
@@ -667,25 +582,31 @@ actor Consumer
   """
   The `backpressure` workload's driver, sink, conservation oracle, and ORDER_SIG
   collector in one actor (mirroring how the mesh's `Coordinator` both drives and
-  evaluates). It spawns the producers, counts received work, participates in runtime
-  backpressure, folds each arrival into `ORDER_SIG` (see `work`/`finished`), and on
-  completion checks conservation.
+  evaluates). It spawns the producers, counts received work, participates in
+  runtime backpressure, folds each arrival into `ORDER_SIG` (see
+  `work`/`finished`), and on completion checks conservation.
 
-  Backpressure: after every `apply_every` received work messages it calls
-  `Backpressure.apply` (marking itself UNDER_PRESSURE, so producers sending to it
-  are muted) and self-sends `lift`; processing the `lift` calls
-  `Backpressure.release` (unmuting them). The `lift` self-send is immune to muting
-  (a self-send never mutes -- the `ctx->current != to` rule in actor.c
-  `maybe_mark_should_mute`), so every apply is followed by a release: the closed
-  flood cannot deadlock. This drives the explicit UNDER_PRESSURE muting path that
-  the mesh's automatic OVERLOAD muting never reaches.
+  Backpressure: after every `apply_every` received work
+  messages it calls `Backpressure.apply` (marking itself
+  UNDER_PRESSURE, so producers sending to it are muted) and
+  self-sends `lift`; processing the `lift` calls
+  `Backpressure.release` (unmuting them). The `lift`
+  self-send is immune to muting (a self-send never mutes --
+  the `ctx->current != to` rule in actor.c
+  `maybe_mark_should_mute`), so every apply is followed by a
+  release: the closed flood cannot deadlock. This drives the
+  explicit UNDER_PRESSURE muting path that the mesh's
+  automatic OVERLOAD muting never reaches.
 
-  Conservation: each producer sends `finished(id, sent)` after its last work; by
-  same-sender FIFO that report follows all of its work, so when all `producers`
-  have reported, all work has been received. The oracle then asserts
-  received == total_sent == expected (producers * messages): a lost work shows as
-  received < total_sent (a conservation failure caught here, not just a timeout), a
-  duplicate trips `_Fatal`. On success it returns and the program quiesces.
+  Conservation: each producer sends `finished(id, sent)`
+  after its last work; by same-sender FIFO that report
+  follows all of its work, so when all `producers` have
+  reported, all work has been received. The oracle then
+  asserts received == total_sent == expected (producers *
+  messages): a lost work shows as received < total_sent (a
+  conservation failure caught here, not just a timeout), a
+  duplicate trips `_Fatal`. On success it returns and the
+  program quiesces.
   """
   let _auth: ApplyReleaseBackpressureAuth
   let _producers: USize
@@ -700,7 +621,9 @@ actor Consumer
   var _done: Bool = false
   var _sig: U64 = 14695981039346656037 // FNV-1a 64-bit offset basis
 
-  new create(config: _Config, bp: _Backpressure,
+  new create(
+    config: _Config,
+    bp: _Backpressure,
     auth: ApplyReleaseBackpressureAuth)
   =>
     _auth = auth
@@ -710,8 +633,8 @@ actor Consumer
     // Single consumer, so it is the sole heartbeat emitter for this workload.
     _hb_interval = _Heartbeat.interval(bp.producers * bp.messages, 1)
 
-    // Spawn the producers pointing at this consumer (the Coordinator pattern: the
-    // driver creates the workers with `this`). Each floods `messages` work
+    // Spawn the producers pointing at this consumer (the Coordinator pattern:
+    // the driver creates the workers with `this`). Each floods `messages` work
     // messages and then reports `finished`.
     var id: USize = 0
     while id < bp.producers do
@@ -726,12 +649,15 @@ actor Consumer
     (the consumer doesn't retain it). A work after completion is a leaked/late
     message -- a real fault -- so it trips `_Fatal`.
 
-    The sending producer's `id` is folded into `ORDER_SIG` on every arrival: a
-    work send is this workload's muting point, so the sequence of arrivals at the
-    consumer IS the mute/unmute interleaving. Fingerprinting it per message (not
-    just the terminal `finished` reports) is what makes the determinism oracle
-    sensitive to a muting-induced reordering -- the whole reason this workload is
-    worth running under systematic replay.
+    The sending producer's `id` is folded into
+    `ORDER_SIG` on every arrival: a work send is this
+    workload's muting point, so the sequence of arrivals
+    at the consumer IS the mute/unmute interleaving.
+    Fingerprinting it per message (not just the terminal
+    `finished` reports) is what makes the determinism
+    oracle sensitive to a muting-induced reordering --
+    the whole reason this workload is worth running under
+    systematic replay.
     """
     if _done then
       _Fatal("work after done (leaked/late message)")
@@ -744,13 +670,13 @@ actor Consumer
     if not _pressured then
       _since_apply = _since_apply + 1
       if _since_apply >= _apply_every then
-        // DEADLOCK-FREEDOM INVARIANT: this Consumer must never do a foreign send.
-        // While UNDER_PRESSURE, a foreign send could mute this Consumer itself, and
-        // the explicit Backpressure.release is the SOLE guaranteed unmute for a
-        // pressure-mute (the runtime's automatic overload-clear is subordinate --
-        // gated by !UNDER_PRESSURE), so a muted Consumer could never release and the
-        // flood would hang. Its only send is the `lift` self-send below, which is
-        // immune to muting.
+        // DEADLOCK-FREEDOM INVARIANT: this Consumer must never do a foreign
+        // send. While UNDER_PRESSURE, a foreign send could mute this Consumer
+        // itself, and the explicit Backpressure.release is the SOLE guaranteed
+        // unmute for a pressure-mute (the runtime's automatic overload-clear is
+        // subordinate -- gated by !UNDER_PRESSURE), so a muted Consumer could
+        // never release and the flood would hang. Its only send is the `lift`
+        // self-send below, which is immune to muting.
         Backpressure.apply(_auth)
         _pressured = true
         lift()
@@ -759,9 +685,10 @@ actor Consumer
 
   be lift() =>
     """
-    Release backpressure. Reached only via the self-send queued when pressure was
-    applied; a self-send is never muted, so this always runs and always releases --
-    the apply/release pairing that makes the closed flood deadlock-free.
+    Release backpressure. Reached only via the self-send queued when pressure
+    was applied; a self-send is never muted, so this always runs and always
+    releases -- the apply/release pairing that makes the closed flood deadlock-
+    free.
     """
     if _pressured then
       Backpressure.release(_auth)
@@ -771,14 +698,15 @@ actor Consumer
 
   be finished(producer_id: USize, sent: U64) =>
     """
-    Fold one producer's terminal report into `ORDER_SIG` (the producer-`finished`
-    race, folded on top of the per-arrival work fold above) and accumulate its send
-    tally. When all producers have reported, evaluate conservation. A duplicate or
-    late `finished` arrives after `_finish` has set `_done` (the report that reaches
-    `_producers` triggers `_finish` synchronously), so the `_done` guard catches it.
-    A *lost* `finished` instead leaves `_finished` short forever -- caught by the
-    orchestrator's liveness timeout, not here (the symmetric case to a lost `work`,
-    which conservation catches; mirrors the cyclic workload's lost-completion note).
+    Fold one producer's terminal report into `ORDER_SIG` (the
+    producer-`finished` race, folded on top of the per-arrival work fold above)
+    and accumulate its send tally. When all producers have reported, evaluate
+    conservation. A duplicate or late `finished` arrives after `_finish` has set
+    `_done` (the report that reaches `_producers` triggers `_finish`
+    synchronously), so the `_done` guard catches it. A *lost* `finished` instead
+    leaves `_finished` short forever -- caught by the orchestrator's liveness
+    timeout, not here (the symmetric case to a lost `work`, which conservation
+    catches; mirrors the cyclic workload's lost-completion note).
     """
     if _done then
       _Fatal("finished after done (duplicate/late report)")
@@ -797,25 +725,25 @@ actor Consumer
     // mesh's); a lost work shows here as received < total_sent.
     let conserved = (_received == _total_sent) and (_total_sent == _expected)
 
-    // Release if still under pressure so the program quiesces cleanly rather than
-    // depending on a pending `lift` running first. Idempotent: `lift` guards on
-    // `_pressured`, so a queued `lift` then no-ops.
+    // Release if still under pressure so the program quiesces cleanly rather
+    // than depending on a pending `lift` running first. Idempotent: `lift`
+    // guards on `_pressured`, so a queued `lift` then no-ops.
     if _pressured then
       Backpressure.release(_auth)
       _pressured = false
     end
 
-    // Synchronous print so the result survives natural quiescence (env.out.print
-    // is async and could be lost if a later exit raced it).
+    // Synchronous print so the result survives natural quiescence
+    // (env.out.print is async and could be lost if a later exit raced it).
     let line = "RECEIVED=" + _received.string()
       + " SENT=" + _total_sent.string()
       + " EXPECTED=" + _expected.string()
       + " ORDER_SIG=" + _sig.string() + "\n"
     @printf("%s".cstring(), line.cstring())
 
-    // On success: return and let the program reach natural quiescence (no forced
-    // exit), same as the mesh/cyclic. Only a conservation FAILURE forces a
-    // non-zero exit: fail fast once a bug is detected.
+    // On success: return and let the program reach natural quiescence (no
+    // forced exit), same as the mesh/cyclic. Only a conservation FAILURE forces
+    // a non-zero exit: fail fast once a bug is detected.
     if not conserved then
       let diag = "CONSERVATION FAILURE: received=" + _received.string()
         + " sent=" + _total_sent.string()
@@ -829,29 +757,34 @@ actor Consumer
 
 class Parcel
   """
-  The `iso` workload's cargo: a multi-object MUTABLE subgraph, shaped by the swarm.
-  Each node is a typed struct (traced `PONY_TRACE_MUTABLE` while owned through an
-  `iso`) holding its own byte array AND an array of child `Parcel`s, so one
-  `Parcel iso` is a tree of `depth` levels, `breadth` children per node, every node
-  separately allocated. Built fresh per injected chain and moved (`consume`d) at
-  each hop; never reused (an `iso` is single-owner). Every byte is the sentinel 'p',
-  so the terminal hop can verify the whole moved subgraph survived uncorrupted.
+  The `iso` workload's cargo: a multi-object MUTABLE subgraph, shaped by the
+  swarm. Each node is a typed struct (traced `PONY_TRACE_MUTABLE` while owned
+  through an `iso`) holding its own byte array AND an array of child `Parcel`s,
+  so one `Parcel iso` is a tree of `depth` levels, `breadth` children per node,
+  every node separately allocated. Built fresh per injected chain and moved
+  (`consume`d) at each hop; never reused (an `iso` is single-owner). Every byte
+  is the sentinel 'p', so the terminal hop can verify the whole moved subgraph
+  survived uncorrupted.
 
-  `bytes` and `kids` are `let`, NOT `embed`, on purpose -- separate heap
-  allocations, so a receiver acquires each node as a distinct foreign mutable
-  object. An `embed` would co-allocate them, collapsing the multi-object subgraph
-  this workload exists to trace. The workload's coverage rests on this type being
-  built and handed off as `iso` (not `val`) and staying multi-object (`let`, not
-  `embed`): changing either silently loses the coverage while every oracle stays
-  green -- pony-ref's "prefer embed" guidance does not apply here.
+  `bytes` and `kids` are `let`, NOT `embed`, on purpose --
+  separate heap allocations, so a receiver acquires each
+  node as a distinct foreign mutable object. An `embed`
+  would co-allocate them, collapsing the multi-object
+  subgraph this workload exists to trace. The workload's
+  coverage rests on this type being built and handed off as
+  `iso` (not `val`) and staying multi-object (`let`, not
+  `embed`): changing either silently loses the coverage
+  while every oracle stays green -- pony-ref's "prefer
+  embed" guidance does not apply here.
   """
   let bytes: Array[U8]
   let kids: Array[Parcel]
 
   new create(size: USize, depth: USize, breadth: USize) =>
     bytes = Array[U8].init('p', size)
-    // A node has `breadth` children only when it is not the last level; the last
-    // level (depth == 1) has none. `depth == 1` or `breadth == 0` is a single node.
+    // A node has `breadth` children only when it is not the last level; the
+    // last level (depth == 1) has none. `depth == 1` or `breadth == 0` is a
+    // single node.
     let n = if depth > 1 then breadth else 0 end
     kids = Array[Parcel](n)
     var i: USize = 0
@@ -862,11 +795,12 @@ class Parcel
 
 actor Carrier
   """
-  An `iso`-workload node. Mirrors `Pinger`: produces exactly one successor message
-  per received handoff and tracks how many it has sent and received. The successor
-  carries the `consume`d parcel itself -- moving ownership of the mutable subgraph
-  one hop further -- so the trace path the workload exists to drive runs on every
-  forward. At the terminal hop it verifies the parcel before dropping it.
+  An `iso`-workload node. Mirrors `Pinger`: produces exactly one successor
+  message per received handoff and tracks how many it has sent and received. The
+  successor carries the `consume`d parcel itself -- moving ownership of the
+  mutable subgraph one hop further -- so the trace path the workload exists to
+  drive runs on every forward. At the terminal hop it verifies the parcel before
+  dropping it.
   """
   let _dispatcher: Dispatcher
   let _id: USize
@@ -880,11 +814,11 @@ actor Carrier
     _dispatcher = dispatcher
     _id = id
     _neighbors = recover val Array[Carrier] end
-    // Per-Carrier deterministic draw stream, seeded only from `--seed` + id (the
-    // same scheme as `Pinger`); which value lands on which handoff depends on
-    // mailbox arrival order, so routing is a function of the seed AND the
-    // interleaving. No `_Config` is stored: a `Carrier` needs nothing from it but
-    // the seed (it has no payload logic, unlike `Pinger`).
+    // Per-Carrier deterministic draw stream, seeded only from `--seed` + id
+    // (the same scheme as `Pinger`); which value lands on which handoff depends
+    // on mailbox arrival order, so routing is a function of the seed AND the
+    // interleaving. No `_Config` is stored: a `Carrier` needs nothing from it
+    // but the seed (it has no payload logic, unlike `Pinger`).
     _rand = Rand(seed, id.u64())
 
   be set_neighbors(neighbors: Array[Carrier] val) =>
@@ -900,9 +834,9 @@ actor Carrier
     """
     Produce exactly one successor per received handoff: a forward of the
     `consume`d parcel when hops > 0, otherwise verify it and signal completion.
-    This one-in/one-out invariant is what makes the dispatcher's completion count a
-    sound quiescence barrier (module docstring) -- do not make this fan out.
-    `consume` moves the parcel; it is never aliased, so the U64 tallies are
+    This one-in/one-out invariant is what makes the dispatcher's completion
+    count a sound quiescence barrier (module docstring) -- do not make this fan
+    out. `consume` moves the parcel; it is never aliased, so the U64 tallies are
     untouched by the move.
     """
     if _reported then
@@ -934,9 +868,10 @@ actor Carrier
     Integrity oracle (recursive): every byte of every node in the graph was the
     sentinel 'p' at construction and the subgraph was only moved (never mutated)
     since, so each node's first and last byte must still be 'p'. Walk the whole
-    tree (`node_size >= 1` is a `_Config` invariant, so the endpoint reads are in
-    range). A mismatch is a silent GC/ORCA corruption or premature free of the
-    moved subgraph -- a real fault none of the message-counting oracles can see.
+    tree (`node_size >= 1` is a `_Config` invariant, so the endpoint reads are
+    in range). A mismatch is a silent GC/ORCA corruption or premature free of
+    the moved subgraph -- a real fault none of the message-counting oracles can
+    see.
     """
     try
       let n = parcel.bytes.size()
@@ -956,12 +891,12 @@ actor Carrier
 
 actor Dispatcher
   """
-  The `iso` workload's driver, injector, and conservation oracle in one actor (the
-  mesh `Coordinator` pattern). Builds the `Carrier` mesh, injects the parcels,
-  counts completions to detect quiescence, collects per-`Carrier` send/receive
-  tallies, and evaluates conservation. On completion it prints `ORDER_SIG` plus the
-  tallies; on a conservation failure it forces a non-zero exit, otherwise it
-  returns and lets the program quiesce.
+  The `iso` workload's driver, injector, and conservation oracle in one actor
+  (the mesh `Coordinator` pattern). Builds the `Carrier` mesh, injects the
+  parcels, counts completions to detect quiescence, collects per-`Carrier`
+  send/receive tallies, and evaluates conservation. On completion it prints
+  `ORDER_SIG` plus the tallies; on a conservation failure it forces a non-zero
+  exit, otherwise it returns and lets the program quiesce.
   """
   let _iso: _Iso
   let _carriers: Array[Carrier] val
@@ -975,10 +910,11 @@ actor Dispatcher
   new create(config: _Config, iso': _Iso) =>
     _iso = iso'
 
-    // Build the mesh. Carriers are created outside the `recover` block (so we can
-    // pass `this`) and pushed into the iso array via automatic receiver recovery
-    // -- `push`'s argument, a `Carrier tag`, is sendable. Only `config.seed` is
-    // needed (in this constructor), so no `_Config` field is stored.
+    // Build the mesh. Carriers are created outside the `recover` block (so we
+    // can pass `this`) and pushed into the iso array via automatic receiver
+    // recovery -- `push`'s argument, a `Carrier tag`, is sendable. Only
+    // `config.seed` is needed (in this constructor), so no `_Config` field is
+    // stored.
     let cs: Array[Carrier] iso = recover Array[Carrier](iso'.pingers) end
     var id: USize = 0
     while id < iso'.pingers do
@@ -1003,8 +939,11 @@ actor Dispatcher
         // Fresh graph per chain -- an `iso` is single-owner, so there is no
         // forward-mode reuse; the graph is always newly built and moved.
         carriers(start)?.carry(
-          recover iso Parcel(iso'.node_size, iso'.depth, iso'.breadth) end,
-          iso'.ttl, chain)
+          recover iso
+            Parcel(iso'.node_size, iso'.depth, iso'.breadth)
+          end,
+          iso'.ttl,
+          chain)
       else
         _Unreachable("iso injection start index out of range")
       end
@@ -1016,7 +955,8 @@ actor Dispatcher
     A parcel reached its terminal (hops == 0) carrier. Fold the arrival into the
     order signature; once every parcel has terminated the system is quiesced, so
     ask every `Carrier` for its final counts. A completion beyond the expected
-    total is a duplicate or late message -- a real fault -- so it trips `_Fatal`.
+    total is a duplicate or late message -- a real fault -- so it trips
+    `_Fatal`.
     """
     if _done then _Fatal("completion after done (leaked/late message)") end
     _mix(chain.u64())
@@ -1051,17 +991,17 @@ actor Dispatcher
     let conserved =
       (total_sent == _total_received) and (_total_received == expected)
 
-    // Synchronous print so the result survives natural quiescence (env.out.print
-    // is async and could be lost if a later exit raced it).
+    // Synchronous print so the result survives natural quiescence
+    // (env.out.print is async and could be lost if a later exit raced it).
     let line = "RECEIVED=" + _total_received.string()
       + " SENT=" + total_sent.string()
       + " EXPECTED=" + expected.string()
       + " ORDER_SIG=" + _sig.string() + "\n"
     @printf("%s".cstring(), line.cstring())
 
-    // On success: return and let the program reach natural quiescence (no forced
-    // exit), same as the other workloads. Only a conservation FAILURE forces a
-    // non-zero exit: fail fast once a bug is detected.
+    // On success: return and let the program reach natural quiescence (no
+    // forced exit), same as the other workloads. Only a conservation FAILURE
+    // forces a non-zero exit: fail fast once a bug is detected.
     if not conserved then
       let diag = "CONSERVATION FAILURE: received=" + _total_received.string()
         + " sent=" + total_sent.string()
@@ -1076,32 +1016,32 @@ actor Dispatcher
 actor Referent
   """
   The `actorref` workload's cargo: a bare actor whose `tag` is the traced
-  reference the relays churn. It has no fields and no behaviors -- it exists only
-  to BE referenced. Passing its tag across an actor boundary drives ORCA's
+  reference the relays churn. It has no fields and no behaviors -- it exists
+  only to BE referenced. Passing its tag across an actor boundary drives ORCA's
   actor-reference machinery (`ponyint_gc_sendactor` / `recv_remote_actor` /
-  `acquire_actor` in `src/libponyrt/gc/gc.c`); the runtime's message loop handles
-  the ACQUIRE / RELEASE system messages, so no user code is needed. A fresh
-  `Referent` is built per injected chain (see `Referrer`) and referenced only by
-  that chain's in-flight `cite` plus, transiently, its creator -- so it becomes
-  garbage as its chain drains, which is what makes a premature free (crash) or a
-  lost release (memory growth) observable.
+  `acquire_actor` in `src/libponyrt/gc/gc.c`); the runtime's message loop
+  handles the ACQUIRE / RELEASE system messages, so no user code is needed. A
+  fresh `Referent` is built per injected chain (see `Referrer`) and referenced
+  only by that chain's in-flight `cite` plus, transiently, its creator -- so it
+  becomes garbage as its chain drains, which is what makes a premature free
+  (crash) or a lost release (memory growth) observable.
   """
   new create() => None
 
 actor Relay
   """
   A node in the `actorref` routing mesh. Mirrors `Pinger`: forwards exactly one
-  successor `cite` per received `cite` (one-in/one-out) and tracks how many it has
-  sent and received. The cargo is a `Referent tag` it NEVER stores -- it re-sends
-  the just-received tag when hops remain, or drops it at the terminal. A freshly
-  received foreign actor reference sits at reference count 1, so forwarding it
-  exhausts the referent's weighted budget on that send, and the forward drives
-  `acquire_actor` -- the actor-reference path no other workload reaches under load.
-  Not storing the referent is load-bearing: it lets the reference drop so the next
-  hop acquires afresh. Holding the neighbor RELAYS permanently is fine -- a
-  neighbor is a `cite` recipient, not traced cargo -- only the cargo referent must
-  stay unheld. Stays
-  live at quiescence so the `Referrer` polls it (the mesh's strong tally).
+  successor `cite` per received `cite` (one-in/one-out) and tracks how many it
+  has sent and received. The cargo is a `Referent tag` it NEVER stores -- it re-
+  sends the just-received tag when hops remain, or drops it at the terminal. A
+  freshly received foreign actor reference sits at reference count 1, so
+  forwarding it exhausts the referent's weighted budget on that send, and the
+  forward drives `acquire_actor` -- the actor-reference path no other workload
+  reaches under load. Not storing the referent is load-bearing: it lets the
+  reference drop so the next hop acquires afresh. Holding the neighbor RELAYS
+  permanently is fine -- a neighbor is a `cite` recipient, not traced cargo --
+  only the cargo referent must stay unheld. Stays live at quiescence so the
+  `Referrer` polls it (the mesh's strong tally).
   """
   let _referrer: Referrer
   let _id: USize
@@ -1118,34 +1058,34 @@ actor Relay
     _hb_interval = hb_interval
     _neighbors = recover val Array[Relay] end
     // Per-Relay deterministic draw stream, seeded only from `--seed` + id (the
-    // same scheme as `Pinger`/`Carrier`): the value stream is fixed by the seed,
-    // but which value lands on which cite depends on mailbox arrival order, so
-    // routing is a function of the seed AND the interleaving. No `_Config` is
-    // stored -- a `Relay` has no payload logic (its cargo is the passed tag),
-    // like `Carrier`.
+    // same scheme as `Pinger`/`Carrier`): the value stream is fixed by the
+    // seed, but which value lands on which cite depends on mailbox arrival
+    // order, so routing is a function of the seed AND the interleaving. No
+    // `_Config` is stored -- a `Relay` has no payload logic (its cargo is the
+    // passed tag), like `Carrier`.
     _rand = Rand(seed, id.u64())
 
   be set_neighbors(neighbors: Array[Relay] val) =>
     """
-    Install the routing mesh BEFORE any cite can arrive (causal ordering, the same
-    load-bearing reasoning as `Pinger.set_neighbors`). This holds RELAYS, not the
-    cargo referent, so holding it permanently is fine -- see the class docstring for
-    why only the cargo referent must stay unheld.
+    Install the routing mesh BEFORE any cite can arrive (causal ordering, the
+    same load-bearing reasoning as `Pinger.set_neighbors`). This holds RELAYS,
+    not the cargo referent, so holding it permanently is fine -- see the class
+    docstring for why only the cargo referent must stay unheld.
     """
     _neighbors = neighbors
 
   be cite(referent: Referent tag, hops: USize, chain: USize) =>
     """
-    Forward exactly one successor cite carrying the same referent tag when
-    hops > 0, else drop the referent and signal completion. The referent is NEVER
+    Forward exactly one successor cite carrying the same referent tag when hops
+    > 0, else drop the referent and signal completion. The referent is NEVER
     stored: re-sending the just-received tag (weighted budget 1) is what fires
-    `acquire_actor` -- the whole point of this workload. One-in/one-out keeps the
-    completion count a sound quiescence barrier (module docstring) -- do not fan
-    out.
+    `acquire_actor` -- the whole point of this workload. One-in/one-out keeps
+    the completion count a sound quiescence barrier (module docstring) -- do not
+    fan out.
     """
     if _reported then
-      // Quiescence is proven before `report()` is sent, so no cite should arrive
-      // afterwards. One that does is a leaked or duplicated message.
+      // Quiescence is proven before `report()` is sent, so no cite should
+      // arrive afterwards. One that does is a leaked or duplicated message.
       _Fatal("cite after report (leaked/late message)")
     end
     _received = _received + 1
@@ -1172,14 +1112,14 @@ actor Referrer
   """
   The `actorref` workload driver (the mesh `Dispatcher` pattern). Builds the
   `Relay` routing mesh (relays stay LIVE -- held in `_relays` -- so they can be
-  polled: the mesh's strong conservation tally), then injects `chains` chains, each
-  carrying a FRESH `Referent`'s tag as cargo down the mesh with a hop count (TTL).
-  Counts completions to detect quiescence, collects per-`Relay` send/receive
-  tallies, folds `ORDER_SIG`, and evaluates conservation; on completion it prints
-  the result and returns (natural quiescence), forcing a non-zero exit only on a
-  conservation failure. Why the referent is built FRESH per chain (not drawn from a
-  fixed pool) and never stored is the workload's load-bearing coverage property --
-  see the injection loop below.
+  polled: the mesh's strong conservation tally), then injects `chains` chains,
+  each carrying a FRESH `Referent`'s tag as cargo down the mesh with a hop count
+  (TTL). Counts completions to detect quiescence, collects per-`Relay`
+  send/receive tallies, folds `ORDER_SIG`, and evaluates conservation; on
+  completion it prints the result and returns (natural quiescence), forcing a
+  non-zero exit only on a conservation failure. Why the referent is built FRESH
+  per chain (not drawn from a fixed pool) and never stored is the workload's
+  load-bearing coverage property -- see the injection loop below.
   """
   let _actorref: _ActorRef
   let _relays: Array[Relay] val
@@ -1193,15 +1133,17 @@ actor Referrer
   new create(config: _Config, actorref: _ActorRef) =>
     _actorref = actorref
 
-    // Per-Relay heartbeat cadence: ~_target prints per Relay over the run, off for
-    // runs too small to need a progress signal. Computed once and shared.
-    let hb = _Heartbeat.interval(actorref.chains * (actorref.ttl + 1),
-      actorref.relays)
+    // Per-Relay heartbeat cadence: ~_target prints per Relay over the run, off
+    // for runs too small to need a progress signal. Computed once and shared.
+    let hb =
+      _Heartbeat.interval(
+        actorref.chains * (actorref.ttl + 1),
+        actorref.relays)
 
-    // Build the relay mesh. Relays are held in a field (_relays) so they are LIVE
-    // at quiescence and can be polled -- the mesh's strong send/recv tally. Built
-    // outside the `recover` block (so we can pass `this`) and pushed via automatic
-    // receiver recovery -- a `Relay tag` is sendable.
+    // Build the relay mesh. Relays are held in a field (_relays) so they are
+    // LIVE at quiescence and can be polled -- the mesh's strong send/recv
+    // tally. Built outside the `recover` block (so we can pass `this`) and
+    // pushed via automatic receiver recovery -- a `Relay tag` is sendable.
     let rs: Array[Relay] iso = recover Array[Relay](actorref.relays) end
     var id: USize = 0
     while id < actorref.relays do
@@ -1217,14 +1159,15 @@ actor Referrer
       r.set_neighbors(relays)
     end
 
-    // Inject. Each chain gets a FRESH `Referent`, whose tag rides the whole chain
-    // as cargo. A relay forwarding a just-received referent it does not hold
-    // exhausts the weighted budget on the first send, so the forward drives
-    // `acquire_actor` -- the cold path this workload exists to exercise. The fresh
-    // referent is NOT retained here (only the in-flight cite references it), and
-    // this loop's continued allocation makes the Referrer sweep and release
-    // earlier referents, so each becomes garbage as its chain drains. Each
-    // injected cite is one Referrer send (added back in `_finish`).
+    // Inject. Each chain gets a FRESH `Referent`, whose tag rides the whole
+    // chain as cargo. A relay forwarding a just-received referent it does not
+    // hold exhausts the weighted budget on the first send, so the forward
+    // drives `acquire_actor` -- the cold path this workload exists to exercise.
+    // The fresh referent is NOT retained here (only the in-flight cite
+    // references it), and this loop's continued allocation makes the Referrer
+    // sweep and release earlier referents, so each becomes garbage as its chain
+    // drains. Each injected cite is one Referrer send (added back in
+    // `_finish`).
     let r = Rand(config.seed)
     var chain: USize = 0
     while chain < actorref.chains do
@@ -1239,10 +1182,10 @@ actor Referrer
 
   be completed(chain: USize, terminal_id: USize, received_snapshot: U64) =>
     """
-    A chain reached its terminal (hops == 0) relay. Fold the arrival into the order
-    signature; once every chain has terminated the system is quiesced, so ask every
-    `Relay` for its final counts. A completion beyond `chains` is a duplicate or
-    late message -- a real fault -- so it trips `_Fatal`.
+    A chain reached its terminal (hops == 0) relay. Fold the arrival into the
+    order signature; once every chain has terminated the system is quiesced, so
+    ask every `Relay` for its final counts. A completion beyond `chains` is a
+    duplicate or late message -- a real fault -- so it trips `_Fatal`.
     """
     if _done then _Fatal("completion after done (leaked/late message)") end
     _mix(chain.u64())
@@ -1268,24 +1211,24 @@ actor Referrer
 
   fun ref _finish() =>
     _done = true
-    // The Referrer itself performed `chains` initial sends (the injected cites);
-    // every `Relay` forward is already in `_total_sent`.
+    // The Referrer itself performed `chains` initial sends (the injected
+    // cites); every `Relay` forward is already in `_total_sent`.
     let total_sent = _total_sent + _actorref.chains.u64()
     let expected = _actorref.chains.u64() * (_actorref.ttl.u64() + 1)
     let conserved =
       (total_sent == _total_received) and (_total_received == expected)
 
-    // Synchronous print so the result survives natural quiescence (env.out.print
-    // is async and could be lost if a later exit raced it).
+    // Synchronous print so the result survives natural quiescence
+    // (env.out.print is async and could be lost if a later exit raced it).
     let line = "RECEIVED=" + _total_received.string()
       + " SENT=" + total_sent.string()
       + " EXPECTED=" + expected.string()
       + " ORDER_SIG=" + _sig.string() + "\n"
     @printf("%s".cstring(), line.cstring())
 
-    // On success: return and let the program reach natural quiescence (no forced
-    // exit), same as the other workloads. Only a conservation FAILURE forces a
-    // non-zero exit: fail fast once a bug is detected.
+    // On success: return and let the program reach natural quiescence (no
+    // forced exit), same as the other workloads. Only a conservation FAILURE
+    // forces a non-zero exit: fail fast once a bug is detected.
     if not conserved then
       let diag = "CONSERVATION FAILURE: received=" + _total_received.string()
         + " sent=" + total_sent.string()
@@ -1299,11 +1242,11 @@ actor Referrer
 
 class val _Mesh
   """
-  The `mesh` workload's shape. Built only by `_Cli.config` (after validation), so
-  `pingers >= 1` and `chains >= 1` can be trusted. Carries the chain count and hop
-  count itself (rather than sharing them through `_Config`) so a `backpressure`
-  config -- which has no chains/ttl -- cannot carry those fields at all; an illegal
-  cross-workload field mix is unrepresentable.
+  The `mesh` workload's shape. Built only by `_Cli.config` (after validation),
+  so `pingers >= 1` and `chains >= 1` can be trusted. Carries the chain count
+  and hop count itself (rather than sharing them through `_Config`) so a
+  `backpressure` config -- which has no chains/ttl -- cannot carry those fields
+  at all; an illegal cross-workload field mix is unrepresentable.
   """
   let pingers: USize
   let chains: USize
@@ -1317,16 +1260,19 @@ class val _Mesh
 class val _Cyclic
   """
   The `cyclic` workload's shape. Built only by `_Cli.config` (after validation),
-  so `generations >= 1`, `group >= 2` (a group needs at least two members to be a
-  non-trivial cycle), and `chains >= 1` can be trusted. Carries chains/ttl itself
-  for the same reason as `_Mesh`.
+  so `generations >= 1`, `group >= 2` (a group needs at least two members to be
+  a non-trivial cycle), and `chains >= 1` can be trusted. Carries chains/ttl
+  itself for the same reason as `_Mesh`.
   """
   let generations: USize
   let group: USize
   let chains: USize
   let ttl: USize
 
-  new val create(generations': USize, group': USize, chains': USize,
+  new val create(
+    generations': USize,
+    group': USize,
+    chains': USize,
     ttl': USize)
   =>
     generations = generations'
@@ -1337,10 +1283,10 @@ class val _Cyclic
 class val _Backpressure
   """
   The `backpressure` workload's shape. Built only by `_Cli.config` (after
-  validation), so `producers >= 1`, `messages >= 1`, and `apply_every >= 1` can be
-  trusted. Has no chains/ttl: a flood is not a chain of hops, so those fields are
-  structurally absent here (the reason chains/ttl live on `_Mesh`/`_Cyclic`/`_Iso`
-  rather than on the shared `_Config`).
+  validation), so `producers >= 1`, `messages >= 1`, and `apply_every >= 1` can
+  be trusted. Has no chains/ttl: a flood is not a chain of hops, so those fields
+  are structurally absent here (the reason chains/ttl live on
+  `_Mesh`/`_Cyclic`/`_Iso` rather than on the shared `_Config`).
   """
   let producers: USize
   let messages: USize
@@ -1354,13 +1300,13 @@ class val _Backpressure
 class val _Iso
   """
   The `iso` workload's shape. Built only by `_Cli.config` (after validation), so
-  `pingers >= 1`, `chains >= 1`, `node_size >= 1`, and `depth >= 1` can be trusted
-  (`ttl` and `breadth` have no lower bound -- breadth 0 or depth 1 is a single-node
-  graph). Carries its own shape for the same reason as `_Mesh`/`_Cyclic`: a
-  `backpressure` config cannot carry it, so an illegal cross-workload field mix is
-  unrepresentable. Has its OWN cargo knobs (node_size/depth/breadth shape the iso
-  graph), NOT the shared String-payload knobs -- an `iso` can't ride the
-  `(String val | U64)` Payload.
+  `pingers >= 1`, `chains >= 1`, `node_size >= 1`, and `depth >= 1` can be
+  trusted (`ttl` and `breadth` have no lower bound -- breadth 0 or depth 1 is a
+  single-node graph). Carries its own shape for the same reason as
+  `_Mesh`/`_Cyclic`: a `backpressure` config cannot carry it, so an illegal
+  cross-workload field mix is unrepresentable. Has its OWN cargo knobs
+  (node_size/depth/breadth shape the iso graph), NOT the shared String-payload
+  knobs -- an `iso` can't ride the `(String val | U64)` Payload.
   """
   let pingers: USize
   let chains: USize
@@ -1369,8 +1315,13 @@ class val _Iso
   let depth: USize
   let breadth: USize
 
-  new val create(pingers': USize, chains': USize, ttl': USize,
-    node_size': USize, depth': USize, breadth': USize)
+  new val create(
+    pingers': USize,
+    chains': USize,
+    ttl': USize,
+    node_size': USize,
+    depth': USize,
+    breadth': USize)
   =>
     pingers = pingers'
     chains = chains'
@@ -1381,17 +1332,17 @@ class val _Iso
 
 class val _ActorRef
   """
-  The `actorref` workload's shape. Built only by `_Cli.config` (after validation),
-  so `relays >= 1` and `chains >= 1` can be trusted (`ttl` has no lower bound at the
-  CLI, though the orchestrators draw `ttl >= 1` -- a zero-hop (ttl=0) chain injects
-  but never forwards, so it drives no acquire). Its fields match `_Mesh`'s
-  (relays/chains/ttl are a routing mesh with a hop count), but it is a DISTINCT type
-  on purpose: `Main` dispatches on the variant type to pick `Referrer` vs
-  `Coordinator`, and the two workloads carry different semantics (actor-`tag` cargo
-  vs a `(String val | U64)` payload). Carries its own shape for the same reason as
-  `_Mesh`/`_Iso`. Has NO payload knobs -- its cargo is a fresh actor per chain, not
-  a `(String val | U64)` payload, so like `iso` it does not ride the shared payload
-  union.
+  The `actorref` workload's shape. Built only by `_Cli.config` (after
+  validation), so `relays >= 1` and `chains >= 1` can be trusted (`ttl` has no
+  lower bound at the CLI, though the orchestrators draw `ttl >= 1` -- a zero-hop
+  (ttl=0) chain injects but never forwards, so it drives no acquire). Its fields
+  match `_Mesh`'s (relays/chains/ttl are a routing mesh with a hop count), but
+  it is a DISTINCT type on purpose: `Main` dispatches on the variant type to
+  pick `Referrer` vs `Coordinator`, and the two workloads carry different
+  semantics (actor-`tag` cargo vs a `(String val | U64)` payload). Carries its
+  own shape for the same reason as `_Mesh`/`_Iso`. Has NO payload knobs -- its
+  cargo is a fresh actor per chain, not a `(String val | U64)` payload, so like
+  `iso` it does not ride the shared payload union.
   """
   let relays: USize
   let chains: USize
@@ -1404,13 +1355,13 @@ class val _ActorRef
 
 class val _Config
   """
-  A validated workload configuration: the fields shared by all workloads (seed and
-  payload kind/size/mode) plus the workload-specific shape (`_Mesh`, `_Cyclic`,
-  `_Backpressure`, `_Iso`, or `_ActorRef`). The chain/hop counts are NOT here --
-  only the four chain-based workloads (mesh/cyclic/iso/actorref) have them, so they
-  live on those variants. Built only by `_Cli.config`, so the rest of the program
-  can trust its invariants (payload_size >= 1 when payload_string, plus the
-  per-shape invariants on the variant).
+  A validated workload configuration: the fields shared by all workloads (seed
+  and payload kind/size/mode) plus the workload-specific shape (`_Mesh`,
+  `_Cyclic`, `_Backpressure`, `_Iso`, or `_ActorRef`). The chain/hop counts are
+  NOT here -- only the four chain-based workloads (mesh/cyclic/iso/actorref)
+  have them, so they live on those variants. Built only by `_Cli.config`, so the
+  rest of the program can trust its invariants (payload_size >= 1 when
+  payload_string, plus the per-shape invariants on the variant).
   """
   let seed: U64
   let payload_string: Bool
@@ -1418,9 +1369,13 @@ class val _Config
   let payload_fresh: Bool
   let workload: (_Mesh | _Cyclic | _Backpressure | _Iso | _ActorRef)
 
-  new val create(seed': U64, payload_string': Bool, payload_size': USize,
+  new val create(
+    seed': U64,
+    payload_string': Bool,
+    payload_size': USize,
     payload_fresh': Bool,
-    workload': (_Mesh | _Cyclic | _Backpressure | _Iso | _ActorRef))
+    workload': (
+      _Mesh | _Cyclic | _Backpressure | _Iso | _ActorRef))
   =>
     seed = seed'
     payload_string = payload_string'
@@ -1433,71 +1388,111 @@ primitive _Cli
   Builds the workload command spec and extracts a validated `_Config` from a
   parsed command. The `cli` package handles unknown flags, missing values, bad
   numbers, and `--help`; this adds the value-set and lower-bound checks it can't
-  express. Runtime `--pony*` flags are stripped by the runtime before `Main` sees
-  `env.args`, so they never reach the parser. Every option carries a default, so a
-  caller (e.g. the systematic orchestrator) that omits a workload's specific flags
-  still parses cleanly as a `mesh` run. The CLI spec is deliberately flat -- every
-  flag is accepted for every run, with "ignored for ..." help text -- while the
-  validated `_Config` it builds is a per-kind union; only the union enforces that a
-  workload carries only its own shape fields.
+  express. Runtime `--pony*` flags are stripped by the runtime before `Main`
+  sees `env.args`, so they never reach the parser. Every option carries a
+  default, so a caller (e.g. the systematic orchestrator) that omits a
+  workload's specific flags still parses cleanly as a `mesh` run. The CLI spec
+  is deliberately flat -- every flag is accepted for every run, with "ignored
+  for ..." help text -- while the validated `_Config` it builds is a per-kind
+  union; only the union enforces that a workload carries only its own shape
+  fields.
   """
   fun spec(): CommandSpec ? =>
-    CommandSpec.leaf("generative",
-      "Generative runtime stress workload (driven by the orchestrate_*.py harnesses)",
+    CommandSpec.leaf(
+      "generative",
+      "Generative runtime stress workload"
+        + " (driven by the orchestrate_*.py"
+        + " harnesses)",
       [
-        OptionSpec.u64("seed",
+        OptionSpec.u64(
+          "seed",
           "engine RNG seed"
           where default' = 1)
-        OptionSpec.string("workload",
-          "workload kind: mesh | cyclic | backpressure | iso | actorref"
+        OptionSpec.string(
+          "workload",
+          "workload kind: mesh | cyclic"
+            + " | backpressure | iso | actorref"
           where default' = "mesh")
-        OptionSpec.u64("pingers",
-          "mesh/iso/actorref only (ignored otherwise): number of mesh actors "
-          + "(>= 1)"
+        OptionSpec.u64(
+          "pingers",
+          "mesh/iso/actorref only"
+            + " (ignored otherwise):"
+            + " number of mesh actors (>= 1)"
           where default' = 8)
-        OptionSpec.u64("generations",
-          "cyclic only (ignored otherwise): garbage-group generations (>= 1)"
+        OptionSpec.u64(
+          "generations",
+          "cyclic only (ignored otherwise):"
+            + " garbage-group generations"
+            + " (>= 1)"
           where default' = 1)
-        OptionSpec.u64("group",
-          "cyclic only (ignored otherwise): actors per garbage group (>= 2)"
+        OptionSpec.u64(
+          "group",
+          "cyclic only (ignored otherwise):"
+            + " actors per garbage group"
+            + " (>= 2)"
           where default' = 2)
-        OptionSpec.u64("producers",
-          "backpressure only (ignored otherwise): flooding producers (>= 1)"
+        OptionSpec.u64(
+          "producers",
+          "backpressure only"
+            + " (ignored otherwise):"
+            + " flooding producers (>= 1)"
           where default' = 64)
-        OptionSpec.u64("messages",
-          "backpressure only (ignored otherwise): work msgs per producer (>= 1)"
+        OptionSpec.u64(
+          "messages",
+          "backpressure only"
+            + " (ignored otherwise):"
+            + " work msgs per producer (>= 1)"
           where default' = 1000)
-        OptionSpec.u64("apply-every",
-          "backpressure only (ignored otherwise): received msgs between "
-          + "apply/release toggles (>= 1)"
+        OptionSpec.u64(
+          "apply-every",
+          "backpressure only"
+            + " (ignored otherwise):"
+            + " received msgs between"
+            + " apply/release toggles (>= 1)"
           where default' = 200)
-        OptionSpec.u64("node-size",
-          "iso only (ignored otherwise): bytes per graph node array (>= 1)"
+        OptionSpec.u64(
+          "node-size",
+          "iso only (ignored otherwise):"
+            + " bytes per graph node array"
+            + " (>= 1)"
           where default' = 64)
-        OptionSpec.u64("node-depth",
-          "iso only (ignored otherwise): graph nesting levels (>= 1)"
+        OptionSpec.u64(
+          "node-depth",
+          "iso only (ignored otherwise):"
+            + " graph nesting levels (>= 1)"
           where default' = 2)
-        OptionSpec.u64("node-breadth",
-          "iso only (ignored otherwise): child nodes per graph node"
+        OptionSpec.u64(
+          "node-breadth",
+          "iso only (ignored otherwise):"
+            + " child nodes per graph node"
           where default' = 1)
-        OptionSpec.u64("chains",
-          "mesh/cyclic/iso/actorref only (ignored for backpressure): chains to "
-          + "inject (>= 1)"
+        OptionSpec.u64(
+          "chains",
+          "mesh/cyclic/iso/actorref only"
+            + " (ignored for backpressure):"
+            + " chains to inject (>= 1)"
           where default' = 8)
-        OptionSpec.u64("ttl",
-          "mesh/cyclic/iso/actorref only (ignored for backpressure): hops per "
-          + "chain"
+        OptionSpec.u64(
+          "ttl",
+          "mesh/cyclic/iso/actorref only"
+            + " (ignored for backpressure):"
+            + " hops per chain"
           where default' = 16)
-        OptionSpec.string("payload",
+        OptionSpec.string(
+          "payload",
           "traced payload kind: string | u64"
           where default' = "string")
-        OptionSpec.u64("payload-size",
-          "string payload size in bytes (>= 1)"
+        OptionSpec.u64(
+          "payload-size",
+          "string payload size in bytes"
+            + " (>= 1)"
           where default' = 64)
-        OptionSpec.string("payload-mode",
-          "per-send payload allocation: forward | fresh"
+        OptionSpec.string(
+          "payload-mode",
+          "per-send payload allocation:"
+            + " forward | fresh"
           where default' = "forward")
-      ])?.>add_help()?
+      ])? .> add_help()?
 
   fun config(cmd: Command): (_Config | String) =>
     let seed = cmd.option("seed").u64()
@@ -1540,7 +1535,8 @@ primitive _Cli
     end
 
     // chains is validated only where it is used (the chain-based workloads:
-    // mesh/cyclic/iso/actorref); backpressure has no chains, so it carries none.
+    // mesh/cyclic/iso/actorref); backpressure has no chains, so it carries
+    // none.
     let workload: (_Mesh | _Cyclic | _Backpressure | _Iso | _ActorRef) =
       if workload_name == "mesh" then
         if pingers < 1 then return "--pingers must be >= 1" end
@@ -1567,8 +1563,9 @@ primitive _Cli
         if chains < 1 then return "--chains must be >= 1" end
         _ActorRef(pingers, chains, ttl)
       else
-        return "bad --workload (expected 'mesh', 'cyclic', 'backpressure', 'iso' "
-          + "or 'actorref')"
+        return "bad --workload (expected 'mesh',"
+          + " 'cyclic', 'backpressure', 'iso'"
+          + " or 'actorref')"
       end
 
     _Config(seed, payload_string, payload_size, payload_fresh, workload)
@@ -1577,13 +1574,13 @@ primitive _Fatal
   """
   The harness's runtime-fault detector: print a diagnostic to stderr and exit
   non-zero. Used by the late/duplicate-message oracles across all workloads -- a
-  ping, `iso` handoff, or `actorref` cite arriving after its node has reported, a
-  mesh, cyclic, `iso`, or `actorref` completion beyond the expected total, or a
-  backpressure `work`/`finished` after the `Consumer` is done (or more `finished`
-  reports than producers) -- and by the `iso` workload's parcel-integrity oracle (a
-  sentinel-byte mismatch in a delivered graph). Each is a real runtime fault -- a
-  duplicated or delayed message, or a silently corrupted one -- so the stress run
-  fails loudly with a location rather than passing.
+  ping, `iso` handoff, or `actorref` cite arriving after its node has reported,
+  a mesh, cyclic, `iso`, or `actorref` completion beyond the expected total, or
+  a backpressure `work`/`finished` after the `Consumer` is done (or more
+  `finished` reports than producers) -- and by the `iso` workload's parcel-
+  integrity oracle (a sentinel-byte mismatch in a delivered graph). Each is a
+  real runtime fault -- a duplicated or delayed message, or a silently corrupted
+  one -- so the stress run fails loudly with a location rather than passing.
   """
   fun apply(msg: String, loc: SourceLoc = __loc) =>
     let line = "FATAL: " + msg + " (" + loc.file() + ":"
@@ -1595,11 +1592,11 @@ primitive _Unreachable
   """
   A branch the compiler can't prove is dead but we know is: every guarded array
   access here is in range by construction -- a neighbor or injection-start index
-  from `Rand.int(size)` with `size >= 1`, or an `iso`-parcel array index guarded by
-  the `node_size >= 1` invariant. If one ever fires it is a real bug, so crash with
-  a location rather than continue with corrupt state (the "unreachable try/else"
-  rule). Distinct from `_Fatal`: this flags a fault that should be impossible, not
-  one the harness is built to catch.
+  from `Rand.int(size)` with `size >= 1`, or an `iso`-parcel array index guarded
+  by the `node_size >= 1` invariant. If one ever fires it is a real bug, so
+  crash with a location rather than continue with corrupt state (the
+  "unreachable try/else" rule). Distinct from `_Fatal`: this flags a fault that
+  should be impossible, not one the harness is built to catch.
   """
   fun apply(msg: String, loc: SourceLoc = __loc) =>
     let line = "UNREACHABLE: " + msg + " (" + loc.file() + ":"

--- a/test/rt-stress/suspend-drain/main.pony
+++ b/test/rt-stress/suspend-drain/main.pony
@@ -1,46 +1,3 @@
-"""
-Suspend-and-drain stress engine.
-
-Drives the allocator's suspend-and-drain path with real schedulers: memory
-allocated on every scheduler thread is freed after those threads have
-suspended, and the freeing must bring the physical memory back without
-activating any of them into scheduling work.
-
-Phases:
-
-1. Allocate: N actors, spread across all scheduler threads, each
-   allocate `--blocks` raw pool blocks of `--block-size` bytes (one
-   freed block at the default 512 KiB crosses the arena allocator's
-   dirty-sweep threshold by itself, so its return is deterministic)
-   and hand the pointers to one collector.
-2. Scale down: the allocators go idle; the schedulers scale down. The
-   collector polls `pony_active_schedulers` until the count reaches
-   `--min-schedulers`.
-3. Drain: the collector frees every raw block from its own thread —
-   all of them foreign, owned by the suspended threads the allocators
-   ran on. No actor work is involved, so with the collector's own busy
-   polling keeping the runtime from reclaiming through any global path,
-   the only thing that can bring the memory back is each owner draining
-   its own inbox on its polling tick. The collector returns its own
-   held memory each poll through the allocator's idle-return path —
-   its busy polling means that moment never arrives on its own — so
-   what the phase measures is the owners' drains, not the collector's
-   holdings. The collector polls resident
-   memory (VmRSS) until at least `--reclaim-fraction` of the payload
-   has returned and the active count has held at the floor for a run of
-   polls; a rise that persists with no work to run means draining
-   activated a suspended thread into scheduling, which it must not.
-4. Scale up: fresh work is spawned; the count must rise above the
-   minimum, proving the suspended threads still activate after their
-   drain episodes.
-
-Exit code 0 with a report on success; 1 with the failed phase on failure.
-Run with `--ponyminthreads 1` to keep one scheduler always active:
-that scheduler runs the poll timer itself, so the count settles at 1
-and the default `--min-schedulers` floor of 1 is reachable. The
-machine must provide more schedulers than the floor; phase 4 needs
-the count to rise above it.
-"""
 use "cli"
 use "time"
 
@@ -74,6 +31,12 @@ actor Allocator
     collector.allocator_done()
 
 actor Collector
+  """
+  Orchestrates the four-phase stress sequence: waits for
+  allocators, polls for scale-down, frees blocks from a foreign
+  thread and polls for memory reclaim, then spawns fresh work to
+  verify scale-up.
+  """
   let _env: Env
   var _blocks: Array[USize] = _blocks.create()
   let _expected_blocks: USize
@@ -91,8 +54,13 @@ actor Collector
   var _released: Bool = false
   let _timers: Timers = Timers
 
-  new create(env: Env, allocator_count: USize, blocks: USize,
-    block_size: USize, min_schedulers: U32, reclaim_fraction: F64)
+  new create(
+    env: Env,
+    allocator_count: USize,
+    blocks: USize,
+    block_size: USize,
+    min_schedulers: U32,
+    reclaim_fraction: F64)
   =>
     _env = env
     _expected_blocks = allocator_count * blocks
@@ -130,11 +98,13 @@ actor Collector
     would never scale down.
     """
     let c: Collector tag = this
-    _timers(Timer(object iso is TimerNotify
-      fun apply(timer: Timer, count: U64): Bool =>
-        c.poll()
-        false
-    end, 250_000_000))
+    _timers(Timer(
+      object iso is TimerNotify
+        fun apply(timer: Timer, count: U64): Bool =>
+          c.poll()
+          false
+      end,
+      250_000_000))
 
   be poll() =>
     match _phase
@@ -190,6 +160,11 @@ actor Collector
     end
 
   fun ref wait_for_reclaim() =>
+    """
+    Phase 3: free every block from this thread (all foreign) and
+    poll VmRSS until the suspended owners drain their inboxes and
+    return the memory.
+    """
     if not _released then
       // Free every block from this thread: all of them foreign to it,
       // owned by whichever threads the allocators ran on — threads that
@@ -378,6 +353,10 @@ actor Spinner
     spin(2_000)
 
   be spin(rounds: U64) =>
+    """
+    Run one round of busy work, then self-send for the remaining
+    rounds so the scheduler sees runnable actors.
+    """
     var i: U64 = 0
     var acc: U64 = _n
 
@@ -396,22 +375,34 @@ actor Main
   new create(env: Env) =>
     let cs =
       try
-        CommandSpec.leaf("suspend-drain",
-          "Suspend-and-drain stress engine", [
-          OptionSpec.u64("allocators", "Allocating actors"
-            where default' = 8)
-          OptionSpec.u64("blocks", "Blocks per allocator"
-            where default' = 32)
-          OptionSpec.u64("block-size", "Bytes per block"
-            where default' = 524288)
-          OptionSpec.u64("min-schedulers",
-            "The floor phase 2 must reach; run with --ponyminthreads 1 "
-            + "and keep this floor below the machine's scheduler count"
-            where default' = 1)
-          OptionSpec.f64("reclaim-fraction",
-            "Payload fraction that must return in phase 3"
-            where default' = 0.5)
-        ], [])?
+        CommandSpec.leaf(
+          "suspend-drain",
+          "Suspend-and-drain stress engine",
+          [
+            OptionSpec.u64(
+              "allocators",
+              "Allocating actors"
+              where default' = 8)
+            OptionSpec.u64(
+              "blocks",
+              "Blocks per allocator"
+              where default' = 32)
+            OptionSpec.u64(
+              "block-size",
+              "Bytes per block"
+              where default' = 524288)
+            OptionSpec.u64(
+              "min-schedulers",
+              "The floor phase 2 must reach; "
+                + "run with --ponyminthreads 1"
+              where default' = 1)
+            OptionSpec.f64(
+              "reclaim-fraction",
+              "Payload fraction that must "
+                + "return in phase 3"
+              where default' = 0.5)
+          ],
+          [])?
       else
         env.exitcode(1)
         return
@@ -425,7 +416,8 @@ actor Main
         return
       end
 
-    Collector(env,
+    Collector(
+      env,
       cmd.option("allocators").u64().usize(),
       cmd.option("blocks").u64().usize(),
       cmd.option("block-size").u64().usize(),

--- a/test/rt-stress/suspend-drain/suspend_drain.pony
+++ b/test/rt-stress/suspend-drain/suspend_drain.pony
@@ -1,0 +1,9 @@
+"""
+Suspend-and-drain stress engine.
+
+Drives the allocator's suspend-and-drain path with real
+schedulers: memory allocated on every scheduler thread is freed
+after those threads have suspended, and the freeing must bring the
+physical memory back without activating any of them into
+scheduling work.
+"""

--- a/test/rt-stress/tcp-swarm/main.pony
+++ b/test/rt-stress/tcp-swarm/main.pony
@@ -1,58 +1,3 @@
-"""
-Swarm TCP stress engine.
-
-A closed, count-driven TCP workload for stressing the runtime's net stack. Every
-behaviour is a CLI flag set by the orchestrator; the engine draws nothing and sets
-no runtime defaults. A fixed number of client connections is churned through a
-listener at a bounded concurrency; each client sends a stamped payload, the server
-echoes it, and the client verifies the echo byte-for-byte before closing.
-
-The swarm dimensions are each tied to a distinct code path in
-`packages/net/tcp_connection.pony` (see test/rt-stress/tcp-swarm/README.md):
-
-* `--payload-size` / `--messages` -- how much each connection sends, and in how
-  many messages.
-* `--write-shape` (`write` | `writev`) -- single vs vectored writes.
-* `--writev-chunks` (N, writev only) -- how many buffers a `writev` splits its
-  payload into. Above `@pony_os_writev_max()` -- IOV_MAX (1024 on Linux/macOS) on
-  POSIX, 1 on Windows -- the send takes TCPConnection's multi-batch path, sending
-  one
-  `writev_max`-sized batch per pass and re-entering the send loop, which is the
-  only thing that makes the mid-write yield below actually fire on POSIX.
-* `--expect` (0 = off, N = frame size) -- fixed-size framed reads vs whole-buffer.
-* `--close` (`graceful` | `hard`) -- a graceful `dispose()` (FIN, drains the send
-  buffer) vs a muted `dispose()`, which takes TCPConnection's `hard_close` path
-  (immediate teardown, no lingering drain). The client closes only after its whole
-  echo is back, so the hard path drops no data here -- it exercises the distinct
-  teardown/unsubscribe code, not write loss.
-* `--read-buffer-size` / `--yield-after-reading` / `--yield-after-writing` -- the
-  TCPConnection read-buffer size and the byte counts at which it yields back to the
-  scheduler mid-read/mid-write. A small `--yield-after-reading` yields on any
-  payload big enough to fill the read buffer more than once. `--yield-after-writing`
-  is different: the send loop only re-checks it when a write spans more than one
-  `writev_max` batch, so on POSIX it needs a `--writev-chunks` above IOV_MAX to
-  bite at all (on Windows, where writev_max is 1, any multi-chunk writev triggers
-  it).
-
-Oracles:
-
-* Echo integrity -- each connection sends a unique, non-repeating byte stream
-  (byte at stream position p is a splitmix64 hash of (connection-id, p)), and
-  verifies every echoed byte against it. Because the stream is unique per
-  connection and never repeats, this catches not only a corrupted byte or a short
-  read but a byte delivered out of order, duplicated, or from another connection.
-  Every connection must verify: the client closes only after it has read its whole
-  echo back, so even a hard close tears down an already-drained connection. Fewer
-  verified than spawned is a failure (see `_report`).
-* Conservation -- every spawned connection reaches a terminal state
-  (closed or connect-failed); the engine reports the tally.
-* Crash / assert -- debug build, asserts on.
-
-On success (every connection verified) the engine prints its RESULT line and PASS,
-then returns, letting the program reach natural quiescence (clean runtime shutdown
-is itself exercised). Anything short of full verification -- a connect failure, a
-short echo, or a byte mismatch -- prints FAIL and forces a non-zero exit.
-"""
 use "collections"
 use "net"
 use "time"
@@ -125,22 +70,28 @@ class val _Config
     messages = _usize(m, "messages", 1)
     close_hard = _str(m, "close", "graceful") == "hard"
     use_writev = _str(m, "write-shape", "write") == "writev"
-    // How many buffers a single `writev` splits its payload into. Above
-    // `@pony_os_writev_max()` -- IOV_MAX (1024 on Linux/macOS) on POSIX, 1 on
-    // Windows -- it drives TCPConnection's multi-batch send and the mid-write
-    // yield, so on POSIX it bites only when payload_size >= writev_chunks > 1024.
-    // Default 4; writev only.
+    // How many buffers a single `writev` splits its payload
+    // into. Above `@pony_os_writev_max()` -- IOV_MAX (1024 on
+    // Linux/macOS) on POSIX, 1 on Windows -- it drives
+    // TCPConnection's multi-batch send and the mid-write yield,
+    // so on POSIX it bites only when
+    // payload_size >= writev_chunks > 1024. Default 4; writev
+    // only.
     writev_chunks = _usize(m, "writev-chunks", 4).max(1)
     read_buffer_size = _usize(m, "read-buffer-size", 16384)
-    // Clamp expect to the read buffer: TCPConnection.expect() errors when the frame
-    // exceeds it, so clamping here keeps the call from erroring (the call sites then
-    // assert that with _Unreachable). The orchestrator already draws
-    // expect <= read-buffer; this clamp only makes a directly-run engine safe from
-    // that one error. NOTE: it does NOT save a directly-run engine from a
-    // non-dividing --expect: for framed reads to terminate, payload_size * messages
-    // must be a whole number of frames, or the trailing partial frame is never
-    // delivered and the client hangs. The orchestrator guarantees divisibility by
-    // drawing only power-of-two sizes; a hand-run engine must arrange it itself.
+    // Clamp expect to the read buffer:
+    // TCPConnection.expect() errors when the frame exceeds it,
+    // so clamping here keeps the call from erroring (the call
+    // sites then assert that with _Unreachable). The
+    // orchestrator already draws expect <= read-buffer; this
+    // clamp only makes a directly-run engine safe from that one
+    // error. NOTE: it does NOT save a directly-run engine from
+    // a non-dividing --expect: for framed reads to terminate,
+    // payload_size * messages must be a whole number of frames,
+    // or the trailing partial frame is never delivered and the
+    // client hangs. The orchestrator guarantees divisibility by
+    // drawing only power-of-two sizes; a hand-run engine must
+    // arrange it itself.
     expect_frame = _usize(m, "expect", 0).min(read_buffer_size)
     yield_after_reading = _usize(m, "yield-after-reading", 16384)
     yield_after_writing = _usize(m, "yield-after-writing", 16384)
@@ -157,14 +108,15 @@ class val _Config
 
 primitive _Keystream
   """
-  The echo oracle checks a unique, non-repeating byte stream per connection: the
-  byte at stream position `p` is the low 8 bits of a splitmix64 hash of
-  (seed, p). `seed` identifies the connection. Because the stream is unique per
-  connection and does not repeat, a byte that arrives out of order, duplicated, or
-  from another connection fails the check -- not only a corrupted or truncated one.
-  It is generated per position (no template to bulk-copy), which is the price of a
-  stream that is meant to be unique everywhere; the per-run byte volume is bounded
-  by the orchestrator so the build is not the bottleneck.
+  Per-connection unique byte stream for the echo oracle. The
+  byte at stream position `p` is the low 8 bits of a splitmix64
+  hash of (seed, p). `seed` identifies the connection. Because
+  the stream is unique per connection and does not repeat, a
+  byte that arrives out of order, duplicated, or from another
+  connection fails the check -- not only a corrupted or
+  truncated one. Generated per position (no template to
+  bulk-copy); the per-run byte volume is bounded by the
+  orchestrator so the build is not the bottleneck.
   """
   fun byte(seed: U64, p: USize): U8 =>
     var z: U64 = seed + (p.u64() * 0x9E3779B97F4A7C15)
@@ -191,12 +143,14 @@ primitive _Keystream
     `writev` -- contiguous over `start .. start + total`, so the echo verifies
     identically regardless of write shape.
     """
-    // COUPLING: this allocates `nchunks` buffer objects per call regardless of
-    // payload size (the extras are zero-length when nchunks > total). The
-    // orchestrator's memory budget models peak memory as
-    // OBJ_BYTES * concurrency * messages * writev_chunks off exactly this count
-    // (est_peak_bytes in orchestrate_tcp.py) -- change how many objects this creates
-    // and the budget can let an OOM through.
+    // COUPLING: this allocates `nchunks` buffer objects per
+    // call regardless of payload size (the extras are
+    // zero-length when nchunks > total). The orchestrator's
+    // memory budget models peak memory as
+    // OBJ_BYTES * concurrency * messages * writev_chunks off
+    // exactly this count (est_peak_bytes in
+    // orchestrate_tcp.py) -- change how many objects this
+    // creates and the budget can let an OOM through.
     recover val
       let out = Array[ByteSeq]
       let n = if nchunks == 0 then 1 else nchunks end
@@ -221,13 +175,13 @@ primitive _Keystream
 
 actor Spawner
   """
-  Drives the run. Once the listener is up it keeps `concurrency` connections in
-  flight at a time, refilling as each finishes, until `connections` have been
-  spawned. It tallies every connection's terminal state (verified, mismatched,
-  short, connect-failed), emits a heartbeat carrying the completed count on a fixed
-  wall-clock timer (the orchestrator's watchdog reads that count and fails the run
-  only if it stops advancing), and prints the pass/fail report when the last
-  connection is accounted for.
+  Keeps `concurrency` connections in flight at a time, refilling
+  as each finishes, until `connections` have been spawned.
+  Tallies every connection's terminal state (verified,
+  mismatched, short, connect-failed), emits a heartbeat on a
+  wall-clock timer so the orchestrator can detect hangs, and
+  prints the pass/fail report when the last connection is
+  accounted for.
   """
   let _config: _Config
   let _connect_auth: TCPConnectAuth
@@ -253,17 +207,22 @@ actor Spawner
     _port = port
     if not _started then
       _started = true
-      // Heartbeat on a wall-clock timer, not per-completion: the orchestrator's
-      // watchdog decides "hang" from whether `done` advances between heartbeats,
-      // so liveness must be signalled on a fixed cadence a slow run can always
-      // meet, independent of how fast connections complete. COUPLING: the interval
-      // must stay well under the orchestrator's --no-progress-seconds window.
+      // Heartbeat on a wall-clock timer, not per-completion:
+      // the orchestrator's watchdog decides "hang" from whether
+      // `done` advances between heartbeats, so liveness must be
+      // signalled on a fixed cadence a slow run can always
+      // meet. COUPLING: the interval must stay well under the
+      // orchestrator's --no-progress-seconds window.
       let interval: U64 = 5_000_000_000  // 5s
       _timers(Timer(_HeartbeatTimer(this), interval, interval))
       _refill()
     end
 
   be connection_done(verified: Bool, mismatch: Bool) =>
+    """
+    Called by a client when its connection reaches a terminal
+    state. Tallies the result and refills the flight window.
+    """
     _inflight = _inflight - 1
     _completed = _completed + 1
     if verified then _verified = _verified + 1 end
@@ -276,22 +235,27 @@ actor Spawner
     _refill()
 
   be heartbeat_tick() =>
-    // Fired by _HeartbeatTimer on a fixed wall-clock cadence. Prints the current
-    // completed count so the orchestrator can see progress advancing; a run that
-    // has stopped completing connections stops advancing `done` (the line keeps
-    // coming), which is how the watchdog tells a slow run from a hang.
+    // Prints the current completed count so the orchestrator
+    // can see progress advancing; a run that has stopped
+    // completing connections stops advancing `done` (the line
+    // keeps coming), which is how the watchdog tells a slow run
+    // from a hang.
     if not _finished then _emit_heartbeat() end
 
   fun _emit_heartbeat() =>
     let done = _completed + _failed
-    // Flushed: a block-buffered line would not reach the watchdog until the buffer
-    // fills, which would defeat the no-progress detection.
+    // Flushed: a block-buffered line would not reach the
+    // watchdog until the buffer fills, which would defeat the
+    // no-progress detection.
     @printf("HEARTBEAT done=%zu of %zu\n".cstring(), done, _config.connections)
     @fflush(@pony_os_stdout())
 
   fun ref _refill() =>
-    while (_inflight < _config.concurrency) and (_spawned < _config.connections) do
-      TCPConnection(_connect_auth,
+    while (_inflight < _config.concurrency)
+      and (_spawned < _config.connections)
+    do
+      TCPConnection(
+        _connect_auth,
         SwarmClient(this, _config, _spawned),
         _config.host,
         _port,
@@ -310,14 +274,16 @@ actor Spawner
       and (_inflight == 0)
     then
       _finished = true
-      // A final heartbeat with the true completed count before the timer stops: the
-      // last wave completes after the previous tick, so this records the full total
-      // and resets the watchdog's clock at finish (the shutdown that follows gets a
-      // fresh no-progress window).
+      // A final heartbeat with the true completed count
+      // before the timer stops: the last wave completes after
+      // the previous tick, so this records the full total and
+      // resets the watchdog's clock at finish (the shutdown
+      // that follows gets a fresh no-progress window).
       _emit_heartbeat()
-      // Stop the heartbeat timer so the runtime can reach quiescence: a live
-      // repeating timer is a noisy ASIO event that would keep the program from
-      // exiting after the last connection is done.
+      // Stop the heartbeat timer so the runtime can reach
+      // quiescence: a live repeating timer is a noisy ASIO
+      // event that would keep the program from exiting after
+      // the last connection is done.
       _timers.dispose()
       _report()
       match _listener
@@ -327,31 +293,48 @@ actor Spawner
     end
 
   fun _report() =>
-    // %zu (size_t) is the portable format for USize -- %lu is 32-bit on Windows.
-    @printf(("RESULT connections=%zu spawned=%zu completed=%zu failed=%zu "
-      + "verified=%zu mismatched=%zu\n").cstring(),
-      _config.connections, _spawned, _completed, _failed, _verified,
+    // %zu (size_t) is the portable format for USize;
+    // %lu is 32-bit on Windows.
+    let fmt =
+      ("RESULT connections=%zu spawned=%zu "
+        + "completed=%zu failed=%zu "
+        + "verified=%zu mismatched=%zu\n")
+    @printf(
+      fmt.cstring(),
+      _config.connections,
+      _spawned,
+      _completed,
+      _failed,
+      _verified,
       _mismatched)
-    // This is a stress test, not fault injection: every connection must connect,
-    // exchange, and verify its echo. Anything less is a failure -- a connect that
-    // failed (a bug, or a mis-set-up harness exhausting ports), a short echo (a
-    // connection that closed with fewer bytes than it sent), or a byte mismatch.
-    // All of them leave verified < connections.
+    // Every connection must connect, exchange, and verify
+    // its echo. Anything less -- a connect failure, a short
+    // echo, or a byte mismatch -- leaves
+    // verified < connections.
     if _verified == _config.connections then
       @printf("PASS\n".cstring())
     else
-      let truncated = (_completed - _verified) - _mismatched
-      @printf(("FAIL: %zu of %zu connections did not verify "
-        + "(connect_failed=%zu truncated=%zu mismatched=%zu)\n").cstring(),
-        _config.connections - _verified, _config.connections,
-        _failed, truncated, _mismatched)
+      let truncated =
+        (_completed - _verified) - _mismatched
+      let fail_fmt =
+        ("FAIL: %zu of %zu connections did not "
+          + "verify (connect_failed=%zu "
+          + "truncated=%zu mismatched=%zu)\n")
+      @printf(
+        fail_fmt.cstring(),
+        _config.connections - _verified,
+        _config.connections,
+        _failed,
+        truncated,
+        _mismatched)
       @exit(1)
     end
 
 class _HeartbeatTimer is TimerNotify
   """
-  Fires the Spawner's wall-clock heartbeat. Repeats on a fixed interval until the
-  Spawner disposes the timer when the run finishes.
+  Fires the Spawner's wall-clock heartbeat. Repeats on a fixed
+  interval until the Spawner disposes the timer when the run
+  finishes.
   """
   let _spawner: Spawner
 
@@ -416,11 +399,13 @@ class EchoServer is TCPConnectionNotify
 
 class SwarmClient is TCPConnectionNotify
   """
-  The client half of a connection. On connect it writes its whole keystream --
-  `messages` payloads of `payload_size` bytes, via `write` or `writev` -- then
-  verifies the echo byte for byte against the same keystream as it comes back.
-  When it has read back everything it sent it closes (gracefully, or muted for a
-  hard close) and reports to the `Spawner` whether the echo verified.
+  The client half of a connection. On connect it writes its
+  whole keystream -- `messages` payloads of `payload_size`
+  bytes, via `write` or `writev` -- then verifies the echo
+  byte for byte against the same keystream as it comes back.
+  When it has read back everything it sent it closes
+  (gracefully, or muted for a hard close) and reports to the
+  Spawner whether the echo verified.
   """
   let _spawner: Spawner
   let _config: _Config
@@ -439,22 +424,35 @@ class SwarmClient is TCPConnectionNotify
     _seed = id.u64()
 
   fun ref connected(conn: TCPConnection ref) =>
+    """
+    Set the expect frame if configured, then write the full
+    keystream payload as `messages` writes or writevs.
+    """
     if _config.expect_frame > 0 then
-      // Unreachable error: expect() errors only when the frame exceeds the
-      // connection's read buffer, and _Config clamps expect_frame to it (both
-      // endpoints are created with read_buffer_size).
-      try conn.expect(_config.expect_frame)? else _Unreachable() end
+      // Unreachable error: expect() errors only when the
+      // frame exceeds the connection's read buffer, and
+      // _Config clamps expect_frame to it (both endpoints are
+      // created with read_buffer_size).
+      try conn.expect(_config.expect_frame)?
+      else _Unreachable()
+      end
     end
 
     var m: USize = 0
     while m < _config.messages do
       if _config.use_writev then
-        // Split across `writev_chunks` buffers to drive the vectored-write path.
-        // Several non-empty iovecs need payload_size >= writev_chunks; a chunk
-        // count above the payload collapses to a single iovec (writev skips the
-        // empty buffers). A chunk count above IOV_MAX drives the multi-batch send.
-        conn.writev(_Keystream.make_chunks(
-          _seed, _sent_total, _config.payload_size, _config.writev_chunks))
+        // Split across `writev_chunks` buffers to drive the
+        // vectored-write path. Several non-empty iovecs need
+        // payload_size >= writev_chunks; a chunk count above
+        // the payload collapses to a single iovec (writev
+        // skips the empty buffers). A chunk count above
+        // IOV_MAX drives the multi-batch send.
+        conn.writev(
+          _Keystream.make_chunks(
+            _seed,
+            _sent_total,
+            _config.payload_size,
+            _config.writev_chunks))
       else
         conn.write(_Keystream.make(_seed, _sent_total, _config.payload_size))
       end
@@ -466,9 +464,16 @@ class SwarmClient is TCPConnectionNotify
       _close(conn)
     end
 
-  fun ref received(conn: TCPConnection ref, data: Array[U8] iso, times: USize)
+  fun ref received(
+    conn: TCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
     : Bool
   =>
+    """
+    Verify each echoed byte against the keystream oracle. Close
+    the connection once the full echo has been received.
+    """
     let n = data.size()
     try
       var i: USize = 0
@@ -512,13 +517,14 @@ class SwarmClient is TCPConnectionNotify
 
 actor Main
   """
-  Parses the flags into a `_Config`, stands up the echo listener, and starts the
-  run. All the work happens in the `Spawner` and the per-connection notifiers.
+  Parses the flags into a `_Config`, stands up the echo
+  listener, and starts the run.
   """
   new create(env: Env) =>
     let config = _Config(_Flags(env.args))
     let spawner = Spawner(config, TCPConnectAuth(env.root))
-    TCPListener(TCPListenAuth(env.root),
+    TCPListener(
+      TCPListenAuth(env.root),
       SwarmListener(spawner, config),
       config.host,
       config.port,
@@ -529,12 +535,14 @@ actor Main
 
 primitive _Unreachable
   """
-  For a branch the compiler forces us to write but that we know is dead: if it is
-  ever reached, crash with the source location rather than silently continuing on
-  corrupt state.
+  For a branch the compiler requires but that cannot execute:
+  crash with the source location rather than silently
+  continuing on corrupt state.
   """
   fun apply(loc: SourceLoc = __loc) =>
-    @fprintf(@pony_os_stderr(),
+    @fprintf(
+      @pony_os_stderr(),
       "Reached unreachable code at %s:%s\n".cstring(),
-      loc.file().cstring(), loc.line().string().cstring())
+      loc.file().cstring(),
+      loc.line().string().cstring())
     @exit(1)

--- a/test/rt-stress/tcp-swarm/tcp_swarm.pony
+++ b/test/rt-stress/tcp-swarm/tcp_swarm.pony
@@ -1,0 +1,13 @@
+"""
+Swarm TCP stress engine.
+
+A closed, count-driven TCP workload for stressing the runtime's
+net stack. A fixed number of client connections is churned through
+a listener at a bounded concurrency; each client sends a stamped
+payload, the server echoes it, and the client verifies the echo
+byte-for-byte before closing.
+
+Every dimension of the swarm is a CLI flag set by the
+orchestrator. See the README for a mapping from each flag to the
+TCPConnection code path it exercises.
+"""

--- a/test/rt-systematic/acquire-release-order-signature/acquire_release_order_signature.pony
+++ b/test/rt-systematic/acquire-release-order-signature/acquire_release_order_signature.pony
@@ -1,0 +1,17 @@
+"""
+Reproducer fixture for the systematic-testing reproducibility
+check (#5560), covering the ORCA reference-counting send ordering
+(#5568).
+
+A mesh of Node actors forwards tokens on a spreading route
+`(id + hops) % nodes`. Each hop carries a freshly allocated
+`String val` payload owned by the forwarding node, so a receiving
+node accumulates references to payloads owned by many distinct
+nodes in its foreign GC map. When that map is swept, the runtime
+sends one `ACTORMSG_RELEASE` per surviving distinct owner;
+forwarding likewise sends one `ACTORMSG_ACQUIRE` per newly
+referenced owner. #5568 orders these sends by a stable
+creation-order id instead of the GC map's pointer-hash iteration
+order, so a fixed `--ponysystematictestingseed` replays one
+interleaving regardless of address layout.
+"""

--- a/test/rt-systematic/acquire-release-order-signature/main.pony
+++ b/test/rt-systematic/acquire-release-order-signature/main.pony
@@ -1,35 +1,3 @@
-"""
-Reproducer fixture for the systematic-testing reproducibility check (#5560),
-covering the ORCA reference-counting send ordering (#5568).
-
-A mesh of `nodes` Node actors forwards tokens, but unlike mute-order-signature
-(whose tokens carry only primitives) every hop carries a freshly allocated
-`String val` payload, and the next hop is `(id + hops) % nodes` -- a *spreading*
-route, not a ring. Because each fresh payload is owned by the node that forwards
-it, a receiving node accumulates references to `String`s owned by many distinct
-nodes in its foreign GC map. When that map is swept, the runtime sends one
-`ACTORMSG_RELEASE` per surviving distinct owner; forwarding a payload likewise
-sends one `ACTORMSG_ACQUIRE` per newly referenced owner. Before #5568 those
-sends went out in the GC map's pointer-hash iteration order, and since a send
-schedules its recipient, the resulting interleaving -- folded into ORDER_SIG by
-the Collector -- depended on actor addresses (ASLR). #5568 orders the sends by a
-stable creation-order id instead, so a fixed `--ponysystematictestingseed`
-replays one interleaving regardless of layout.
-
-A spreading route is essential: in a ring each node only ever receives from one
-predecessor, so its foreign map holds a single owner and the send order is
-trivially fixed -- nothing to reorder. The spread puts multiple distinct owners
-in the map per GC pass, which is the condition #5568 addresses.
-
-This fixture runs with the cycle detector disabled (`--ponynoblock`, wired in by
-.ci-scripts/systematic-testing/determinism_smoke.py). #5568 makes the ORCA send
-ordering layout-independent; the cycle detector's own pointer-ordered sends are
-a separate matter (#5569, covered by cycle-collection-order-signature), so
-disabling it here keeps the two fixtures from confounding each other. The
-node/token counts are sized to drive multi-owner GC sweeps at the handful of
-physical cores a CI runner typically has; see determinism_smoke.py for the
-coverage ceiling. It is not part of the normal test suites.
-"""
 use @printf[I32](fmt: Pointer[U8] tag, ...)
 use @exit[None](status: I32)
 
@@ -59,6 +27,11 @@ actor Main
     end
 
 actor Node
+  """
+  Forwards tokens on a spreading route and allocates a fresh
+  `String val` payload each hop, so receiving nodes accumulate
+  references to payloads owned by many distinct senders.
+  """
   let _collector: Collector
   let _id: USize
   let _n: USize
@@ -74,11 +47,13 @@ actor Node
 
   be ping(payload: String val, hops: USize, id: USize) =>
     if hops > 0 then
-      // Spread the route across many neighbors so each node receives payloads
-      // owned by many distinct nodes (-> multi-owner foreign GC map). `next` is
-      // always in [0, _n), so the indexed access cannot error. The incoming
-      // payload is dropped and a fresh one (owned by this node) is forwarded, so
-      // the owner of each in-flight payload is its immediate sender.
+      // Spread the route across many neighbors so each node
+      // receives payloads owned by many distinct nodes (->
+      // multi-owner foreign GC map). `next` is always in
+      // [0, _n), so the indexed access cannot error. The
+      // incoming payload is dropped and a fresh one (owned by
+      // this node) is forwarded, so the owner of each in-flight
+      // payload is its immediate sender.
       let next = (_id + hops) % _n
       let fresh: String val = "p-" + id.string() + "-" + hops.string()
       try _mesh(next)?.ping(fresh, hops - 1, id) end
@@ -87,6 +62,11 @@ actor Node
     end
 
 actor Collector
+  """
+  Folds every arrival's (token_id, node_id) into an order-sensitive
+  FNV-1a hash and prints the resulting ORDER_SIG when all tokens
+  have arrived.
+  """
   let _expected: USize
   var _received: USize = 0
   // FNV-1a-style rolling hash of the arrival order: an interleaving signature
@@ -96,6 +76,10 @@ actor Collector
     _expected = expected
 
   be recv(token_id: USize, node_id: USize) =>
+    """
+    Record one arrival and, when all have arrived, print the
+    ORDER_SIG and exit.
+    """
     _mix(token_id.u64())
     _mix(node_id.u64())
     _received = _received + 1

--- a/test/rt-systematic/cycle-collection-order-signature/cycle_collection_order_signature.pony
+++ b/test/rt-systematic/cycle-collection-order-signature/cycle_collection_order_signature.pony
@@ -1,0 +1,19 @@
+"""
+Reproducer fixture for the systematic-testing reproducibility
+check (#5560), covering the cycle detector's pointer-ordered
+message sends and its cycle reclamation (#5569).
+
+Successive groups of Worker actors form strongly connected
+reference cycles that only the cycle detector can reclaim. Within
+each group the Workers forward ping chains to random neighbors,
+and the terminal hop of every chain reports to a Collector whose
+order-sensitive ORDER_SIG captures the interleaving. The cycle
+detector probes, confirms, and reclaims the groups while the
+Workers are active, so the pointer-ordered sends the detector
+makes are folded into the signature.
+
+#5569 orders all of the detector's sends by a stable
+creation-order id instead of the pointer-hash iteration order, so
+a fixed `--ponysystematictestingseed` replays one interleaving
+regardless of address layout.
+"""

--- a/test/rt-systematic/cycle-collection-order-signature/main.pony
+++ b/test/rt-systematic/cycle-collection-order-signature/main.pony
@@ -1,56 +1,3 @@
-"""
-Reproducer fixture for the systematic-testing reproducibility check (#5560),
-covering the cycle detector's pointer-ordered message sends and its cycle
-reclamation (#5569).
-
-Unlike the other fixtures, this one is genuinely cycle-collection-heavy. A
-Churner spawns `generations` successive groups of `group` Worker actors. Each
-Worker holds the whole group's array, so a group is one strongly connected
-reference cycle that reference counting alone can never reclaim. Within a group
-the Workers forward `chains` ping chains to random neighbors -- observable work
-whose interleaving the cycle detector perturbs -- and once those chains drain
-the Churner has already dropped the group, so it becomes garbage that only the
-cycle detector can reclaim. The terminal hop of every chain reports (chain,
-terminal id, that Worker's running receive count) to a Collector, folded into
-an order-sensitive ORDER_SIG.
-
-This drives the detector's pointer-ordered paths together: it probes the busy
-Workers (`check_blocked` -> ACTORMSG_ISBLOCKED), and when a group quiesces it
-confirms the cycle's members (`send_conf` -> ACTORMSG_CONF), processes its
-deferred view set, and reclaims them (`collect`). Each walked a
-`ponyint_hash_ptr(actor)`-keyed map in pointer order before #5569; a send
-schedules its recipient, and ASLR moves the addresses every run, so the order
-folded into ORDER_SIG. #5569 orders all of them by a stable creation-order id,
-so a fixed `--ponysystematictestingseed` replays one interleaving.
-
-The observed flake here comes from the probe / confirmation / deferred ordering.
-`collect`'s cross-member release order is also sorted by #5569 but is NOT
-independently observed by this fixture: every Worker references the same single
-Collector, so reclaiming a cycle reschedules only that one out-of-cycle actor
-regardless of member order. A fixture whose cycle members referenced distinct
-live actors would observe `collect`'s ordering too; this one only guards it
-against a crash regression (below).
-
-The cycle detector is left ENABLED and swept frequently (`--ponycdinterval 10`,
-wired in by the driver) so detection coincides with the Workers' pinging.
-Isolating the divergence to the detector is sound only because #5566 (muting)
-and #5568 (ORCA acquire/release) are already merged. Run against the pre-#5569
-runtime it printed a different ORDER_SIG on most runs from two scheduler threads
-up (most seeds diverge at two threads, all tested seeds at four and at the host
-default); after the fix every seed replays one interleaving and the seeds still
-explore. Reclamation runs during the program (groups are genuinely collected
-every run -- the Collector forces exit on the final completion, which is not
-sequenced before reclamation, so this crash guard is reliable in practice rather
-than guaranteed), so the fixture also guards the detector's collection path
-against a crash regression -- a reclamation that mishandles a multi-member cycle
-aborts here rather than replaying. The counts keep the live-actor population
-well under
-CD_MAX_CHECK_BLOCKED; the detector's rate-limited probe path above that bound
-is layout-independent by construction (systematic-testing builds probe all of
-d->views each sweep) but is not exercised here. See
-.ci-scripts/systematic-testing/determinism_smoke.py. It is not part of the
-normal test suites.
-"""
 use "random"
 use @printf[I32](fmt: Pointer[U8] tag, ...)
 use @exit[None](status: I32)
@@ -81,6 +28,11 @@ actor Main
     Churner(collector, _Config.generations()).tick(0)
 
 actor Churner
+  """
+  Spawns successive groups of Worker actors that form reference
+  cycles, then drops them so only the cycle detector can reclaim
+  them. Overlaps generations so reclamation races active pinging.
+  """
   let _collector: Collector
   let _generations: USize
 
@@ -89,6 +41,10 @@ actor Churner
     _generations = generations
 
   be tick(gen: USize) =>
+    """
+    Spawn one generation of Workers, inject its chains, and
+    schedule the next generation.
+    """
     if gen >= _generations then
       return
     end
@@ -125,7 +81,9 @@ actor Churner
     while c < _Config.chains() do
       let start = r.int(k.u64()).usize()
       try
-        members(start)?.ping(_Payload.make(), _Config.ttl(),
+        members(start)?.ping(
+          _Payload.make(),
+          _Config.ttl(),
           (gen * _Config.chains()) + c)
       end
       c = c + 1
@@ -137,6 +95,12 @@ actor Churner
     tick(gen + 1)
 
 actor Worker
+  """
+  A member of a cycle group. Forwards ping chains to random group
+  members and reports the terminal hop to the Collector. Each group
+  holds its own members array, forming a strongly connected
+  reference cycle.
+  """
   let _collector: Collector
   let _id: USize
   var _group: Array[Worker] val = recover val Array[Worker] end
@@ -168,6 +132,11 @@ actor Worker
     end
 
 actor Collector
+  """
+  Folds every chain completion's (chain, terminal_id,
+  received_snapshot) into an order-sensitive FNV-1a hash and prints
+  the resulting ORDER_SIG when all chains have completed.
+  """
   let _expected: USize
   var _received: USize = 0
   // FNV-1a-style rolling hash of the arrival order: an interleaving signature.
@@ -176,7 +145,15 @@ actor Collector
   new create(expected: USize) =>
     _expected = expected
 
-  be completed(chain: USize, terminal_id: USize, received_snapshot: U64) =>
+  be completed(
+    chain: USize,
+    terminal_id: USize,
+    received_snapshot: U64)
+  =>
+    """
+    Record one chain completion and, when all have arrived, print
+    the ORDER_SIG and exit.
+    """
     _mix(chain.u64())
     _mix(terminal_id.u64())
     _mix(received_snapshot)

--- a/test/rt-systematic/mute-order-signature/main.pony
+++ b/test/rt-systematic/mute-order-signature/main.pony
@@ -1,29 +1,3 @@
-"""
-Reproducer fixture for the systematic-testing reproducibility check (#5560),
-covering the actor muting / unmuting scheduling path.
-
-A ring of 48 Node actors each forwards a token to the next node a fixed number
-of times (deterministic `(id + 1) % n` routing -- no randomness, no clock), then
-reports the token's arrival to a single Collector. The Collector folds
-(token_id, node_id) of every arrival into an order-sensitive hash printed as
-ORDER_SIG, a pure function of the scheduler interleaving.
-
-Unlike order-signature (whose senders only self-send and fan into the collector,
-so no actor ever overloads another), the volume of foreign actor-to-actor sends
-here drives backpressure: nodes overload, their senders get muted, and are later
-rescheduled when the overloaded node drains. That unmute-rescheduling step is a
-distinct part of the scheduler that order-signature does not exercise, so this
-fixture guards a different slice of the "fixed seed replays one interleaving"
-property.
-
-The muting-driven reordering only manifests when scheduler-thread count and load
-are in balance, so the node and token counts here are sized to overload actors
-at the handful of physical cores a CI runner typically has (the runtime defaults
-to one scheduler thread per physical core). See
-.ci-scripts/systematic-testing/determinism_smoke.py, which builds a
-systematic-testing ponyc, compiles this program with it, and asserts the
-property under --ponynoscale. It is not part of the normal test suites.
-"""
 use @printf[I32](fmt: Pointer[U8] tag, ...)
 use @exit[None](status: I32)
 
@@ -53,6 +27,11 @@ actor Main
     end
 
 actor Node
+  """
+  Forwards tokens around the ring. The volume of sends drives
+  backpressure: the receiver overloads, the sender gets muted,
+  and the unmute-reschedule path is exercised.
+  """
   let _collector: Collector
   let _id: USize
   var _ring: Array[Node] val = recover val Array[Node] end
@@ -76,6 +55,11 @@ actor Node
     end
 
 actor Collector
+  """
+  Folds every arrival's (token_id, node_id) into an order-sensitive
+  FNV-1a hash and prints the resulting ORDER_SIG when all tokens
+  have arrived.
+  """
   let _expected: USize
   var _received: USize = 0
   // FNV-1a-style rolling hash of the arrival order: an interleaving signature
@@ -85,6 +69,10 @@ actor Collector
     _expected = expected
 
   be recv(token_id: USize, node_id: USize) =>
+    """
+    Record one arrival and, when all have arrived, print the
+    ORDER_SIG and exit.
+    """
     _mix(token_id.u64())
     _mix(node_id.u64())
     _received = _received + 1

--- a/test/rt-systematic/mute-order-signature/mute_order_signature.pony
+++ b/test/rt-systematic/mute-order-signature/mute_order_signature.pony
@@ -1,0 +1,21 @@
+"""
+Reproducer fixture for the systematic-testing reproducibility
+check (#5560), covering the actor muting / unmuting scheduling
+path.
+
+A ring of 48 Node actors each forwards a token to the next node a
+fixed number of times (deterministic `(id + 1) % n` routing), then
+reports the token's arrival to a single Collector. The Collector
+folds (token_id, node_id) of every arrival into an order-sensitive
+hash printed as ORDER_SIG, a pure function of the scheduler
+interleaving.
+
+Unlike order-signature (whose senders only self-send and fan into
+the collector, so no actor ever overloads another), the volume of
+foreign actor-to-actor sends here drives backpressure: nodes
+overload, their senders get muted, and are later rescheduled when
+the overloaded node drains. That unmute-rescheduling step is a
+distinct part of the scheduler that order-signature does not
+exercise, so this fixture guards a different slice of the "fixed
+seed replays one interleaving" property.
+"""

--- a/test/rt-systematic/order-signature/main.pony
+++ b/test/rt-systematic/order-signature/main.pony
@@ -1,18 +1,3 @@
-"""
-Reproducer fixture for the systematic-testing reproducibility check (#5560).
-
-Eight Sender actors each send 64 messages to a single Collector. The arrival
-order is a pure function of the scheduler's interleaving; the Collector folds
-(sender_id, seq) of every arrival into an order-sensitive hash and prints it as
-ORDER_SIG. There is no randomness and no clock reads in the program itself, so
-under systematic testing a seed-deterministic scheduler must print the same
-ORDER_SIG for two runs at the same --ponysystematictestingseed, and different
-seeds must be free to produce different ones.
-
-Driven by .ci-scripts/systematic-testing/determinism_smoke.py, which builds
-a systematic-testing ponyc, compiles this program with it, and asserts that
-property under --ponynoscale. It is not part of the normal test suites.
-"""
 use @printf[I32](fmt: Pointer[U8] tag, ...)
 use @exit[None](status: I32)
 
@@ -28,6 +13,10 @@ actor Main
     end
 
 actor Sender
+  """
+  Sends a numbered sequence of messages to the Collector, one per
+  behavior run, so each send is a scheduler interleaving point.
+  """
   let _collector: Collector
   let _id: USize
   let _total: USize
@@ -50,6 +39,11 @@ actor Sender
     end
 
 actor Collector
+  """
+  Folds every arrival's (sender_id, seq) into an order-sensitive
+  FNV-1a hash and prints the resulting ORDER_SIG when all messages
+  have arrived.
+  """
   let _expected: USize
   var _received: USize = 0
   // FNV-1a-style rolling hash of the arrival order: an interleaving signature
@@ -59,14 +53,19 @@ actor Collector
     _expected = expected
 
   be recv(sender_id: USize, seq: USize) =>
+    """
+    Record one arrival and, when all have arrived, print the
+    ORDER_SIG and exit.
+    """
     _mix(sender_id.u64())
     _mix(seq.u64())
     _received = _received + 1
     if _received == _expected then
-      // Synchronous printf then forced exit. env.out.print is async and would be
-      // lost on @exit. The forced exit also sidesteps the separate shutdown-hang
-      // symptom under systematic testing. The signature is fully computed before
-      // we exit, so the determinism result is unaffected.
+      // Synchronous printf then forced exit. env.out.print is
+      // async and would be lost on @exit. The forced exit also
+      // sidesteps the separate shutdown-hang symptom under
+      // systematic testing. The signature is fully computed
+      // before we exit, so the determinism result is unaffected.
       let line = "RECEIVED=" + _received.string()
         + " ORDER_SIG=" + _sig.string() + "\n"
       @printf("%s".cstring(), line.cstring())

--- a/test/rt-systematic/order-signature/order_signature.pony
+++ b/test/rt-systematic/order-signature/order_signature.pony
@@ -1,0 +1,13 @@
+"""
+Reproducer fixture for the systematic-testing reproducibility
+check (#5560).
+
+Eight Sender actors each send 64 messages to a single Collector.
+The arrival order is a pure function of the scheduler's
+interleaving; the Collector folds (sender_id, seq) of every
+arrival into an order-sensitive hash and prints it as ORDER_SIG.
+Under systematic testing a seed-deterministic scheduler must print
+the same ORDER_SIG for two runs at the same
+`--ponysystematictestingseed`, and different seeds must be free to
+produce different ones.
+"""


### PR DESCRIPTION
Fix all pony-lint errors in test/rt-stress/ (generative, suspend-drain, tcp-swarm) and test/rt-systematic/ (four order-signature fixtures), then add lint coverage in PR CI.

Each package gets a package docstring file, public types and methods get docstrings, comments and code are rewrapped to 80 columns, and multiline calls/declarations are reformatted. Two match blocks in generative gain `\exhaustive\` annotations.

The CI change consolidates the separate full-program-runner and full-program-tests lint steps into one `./pony-lint ../../test/` step that covers the entire test tree.

Part of #5839.
