### PR TITLE
Simplify examples lint CI step

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -388,10 +388,7 @@ jobs:
       - name: Lint pony-lsp
         run: cd build/debug && PONYPATH=../../tools/lib/ponylang/pony_compiler ./pony-lint ../../tools/pony-lsp/
       - name: Lint examples
-        run: |
-          cd build/debug
-          PONYPATH=../../packages ./pony-lint \
-            $(find ../../examples -maxdepth 2 -name '*.pony' -printf '%h\n' | sort -u)
+        run: cd build/debug && PONYPATH=../../packages ./pony-lint ../../examples/
       - name: Lint test
         run: cd build/debug && ./pony-lint ../../test/
       - name: Lint pony-compiler


### PR DESCRIPTION
pony-lint handles directory traversal on its own, so the find-based discovery was unnecessary complexity.
