### PR TITLE
Exclude benchmarks from pony-lint

### DIFF
--- a/benchmark/.pony-lint.json
+++ b/benchmark/.pony-lint.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "style": "off",
+    "safety": "off"
+  }
+}


### PR DESCRIPTION
Adds a `.pony-lint.json` to `benchmark/` with all rules off. The Pony files under `benchmark/memory-profile/` are performance workloads, not library or tool code — lint rules don't apply. This prevents any future broadening of lint scope from picking them up.
