### PR TITLE
Fix pony-lint false positive on identifiers with multiple trailing primes

### DIFF
--- a/.release-notes/fix-lint-multi-prime.md
+++ b/.release-notes/fix-lint-multi-prime.md
@@ -1,0 +1,3 @@
+## Fix pony-lint false positive on identifiers with multiple trailing primes
+
+pony-lint flagged identifiers like `path''` as naming violations because it only stripped one trailing prime before checking the name. An identifier with two or more primes kept the extras and failed the snake_case or CamelCase check. pony-lint now strips all trailing primes before validating.

--- a/tools/pony-lint/naming_helpers.pony
+++ b/tools/pony-lint/naming_helpers.pony
@@ -13,11 +13,11 @@ primitive NamingHelpers
     """
     Returns true if `name` follows CamelCase conventions: starts with an
     uppercase letter (after optional leading `_`), contains only alphanumeric
-    characters, and has no underscores after the optional prefix. A trailing
-    prime (`'`) is permitted (Pony uses primes on parameter names).
+    characters, and has no underscores after the optional prefix. Trailing
+    primes (`'`) are permitted (Pony uses primes on parameter names).
     """
     if name.size() == 0 then return false end
-    // Strip trailing prime before validation
+    // Strip trailing primes before validation
     let check = _strip_prime(name)
     if check.size() == 0 then return false end
     var i: USize = 0
@@ -48,11 +48,11 @@ primitive NamingHelpers
     """
     Returns true if `name` follows snake_case conventions: starts with a
     lowercase letter (after optional leading `_`), contains only lowercase
-    letters, digits, and underscores. A trailing prime (`'`) is permitted
+    letters, digits, and underscores. Trailing primes (`'`) are permitted
     (Pony uses primes on parameter names).
     """
     if name.size() == 0 then return false end
-    // Strip trailing prime before validation
+    // Strip trailing primes before validation
     let check = _strip_prime(name)
     if check.size() == 0 then return false end
     var i: USize = 0
@@ -207,17 +207,19 @@ primitive NamingHelpers
 
   fun _strip_prime(name: String val): String val =>
     """
-    Strip a trailing prime character from the name.
+    Strip all trailing prime characters from the name.
     """
     if name.size() == 0 then return name end
+    var i = name.size()
     try
-      if name(name.size() - 1)? == '\'' then
-        name.substring(0, (name.size() - 1).isize())
-      else
-        name
+      while (i > 0) and (name(i - 1)? == '\'') do
+        i = i - 1
       end
-    else
+    end
+    if i == name.size() then
       name
+    else
+      name.substring(0, i.isize())
     end
 
   fun is_upper(ch: U8): Bool =>

--- a/tools/pony-lint/test/_test_member_naming.pony
+++ b/tools/pony-lint/test/_test_member_naming.pony
@@ -124,6 +124,36 @@ class \nodoc\ _TestMemberNamingDontcareSkipped is UnitTest
       h.fail("compilation failed")
     end
 
+class \nodoc\ _TestMemberNamingMultiPrimeClean is UnitTest
+  """Multi-prime member names are valid snake_case."""
+  fun name(): String => "MemberNaming: multi-prime local is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): U32 =>\n" +
+      "    let path' = U32(1)\n" +
+      "    let path'' = U32(2)\n" +
+      "    path' + path''\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.MemberNaming)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
 class \nodoc\ _TestMemberNamingParamViolation is UnitTest
   """Non-snake_case parameter names produce diagnostics."""
   fun name(): String => "MemberNaming: non-snake_case param flagged"

--- a/tools/pony-lint/test/_test_naming.pony
+++ b/tools/pony-lint/test/_test_naming.pony
@@ -16,9 +16,11 @@ class \nodoc\ _TestIsCamelCaseValid is UnitTest
     h.assert_true(lint.NamingHelpers.is_camel_case("A1B2"))
     h.assert_true(lint.NamingHelpers.is_camel_case("_PrivateType"))
     h.assert_true(lint.NamingHelpers.is_camel_case("_F"))
-    // Trailing prime is accepted
+    // Trailing primes are accepted
     h.assert_true(lint.NamingHelpers.is_camel_case("Foo'"))
     h.assert_true(lint.NamingHelpers.is_camel_case("_Foo'"))
+    h.assert_true(lint.NamingHelpers.is_camel_case("Foo''"))
+    h.assert_true(lint.NamingHelpers.is_camel_case("Foo'''"))
 
 class \nodoc\ _TestIsCamelCaseInvalid is UnitTest
   """Invalid CamelCase names fail."""
@@ -49,10 +51,12 @@ class \nodoc\ _TestIsSnakeCaseValid is UnitTest
     h.assert_true(lint.NamingHelpers.is_snake_case("_private"))
     h.assert_true(lint.NamingHelpers.is_snake_case("_f"))
     h.assert_true(lint.NamingHelpers.is_snake_case("create"))
-    // Trailing prime is accepted
+    // Trailing primes are accepted
     h.assert_true(lint.NamingHelpers.is_snake_case("foo'"))
     h.assert_true(lint.NamingHelpers.is_snake_case("rule_id'"))
     h.assert_true(lint.NamingHelpers.is_snake_case("_private'"))
+    h.assert_true(lint.NamingHelpers.is_snake_case("path''"))
+    h.assert_true(lint.NamingHelpers.is_snake_case("x'''"))
 
 class \nodoc\ _TestIsSnakeCaseInvalid is UnitTest
   """Invalid snake_case names fail."""

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -226,6 +226,7 @@ actor \nodoc\ Main is TestList
     test(_TestMemberNamingMethodViolation)
     test(_TestMemberNamingFieldViolation)
     test(_TestMemberNamingDontcareSkipped)
+    test(_TestMemberNamingMultiPrimeClean)
     test(_TestMemberNamingParamViolation)
 
     // AcronymCasing tests


### PR DESCRIPTION
`_strip_prime` only removed one trailing prime, so names like `path''` kept a prime after stripping and failed the naming check.

Strips all trailing primes before validating now.