### PR TITLE
Fix pony-lint false positive on partial operators

### DIFF
--- a/.release-notes/fix-lint-partial-operator-spacing.md
+++ b/.release-notes/fix-lint-partial-operator-spacing.md
@@ -1,0 +1,3 @@
+## Fix pony-lint false positive on partial operators
+
+pony-lint's operator-spacing rule flagged partial arithmetic operators (`*?`, `+?`, etc.) as missing a space after the base operator. The `?` that makes the operation partial shares the same AST token as the non-partial form, so the rule saw `?` where it expected a space.

--- a/tools/pony-lint/operator_spacing.pony
+++ b/tools/pony-lint/operator_spacing.pony
@@ -101,8 +101,16 @@ primitive OperatorSpacing is ASTRule
         end
       end
 
-      // Check character after operator
-      let after_idx = ((op_col - 1) + width).usize()
+      // Partial operators (+?, *?, etc.) have a TK_QUESTION child but
+      // share the base operator's token, so widen past the '?'.
+      var op_width = width
+      for c in node.children() do
+        if c.id() == ast.TokenIds.tk_question() then
+          op_width = op_width + 1
+          break
+        end
+      end
+      let after_idx = ((op_col - 1) + op_width).usize()
       try
         if line_text(after_idx)? != ' ' then
           return recover val

--- a/tools/pony-lint/test/_test_operator_spacing.pony
+++ b/tools/pony-lint/test/_test_operator_spacing.pony
@@ -441,6 +441,62 @@ class \nodoc\ _TestOperatorSpacingIdentityClean is UnitTest
       h.fail("compilation failed")
     end
 
+class \nodoc\ _TestOperatorSpacingPartialClean is UnitTest
+  """Partial operator with spaces is clean."""
+  fun name(): String => "OperatorSpacing: 'x *? y' is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "primitive Foo\n" +
+      "  fun apply(x: U32, y: U32): U32 ? =>\n" +
+      "    x *? y\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.OperatorSpacing)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestOperatorSpacingPartialModClean is UnitTest
+  """Partial mod operator with spaces is clean."""
+  fun name(): String => "OperatorSpacing: 'x %%? y' is clean"
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "primitive Foo\n" +
+      "  fun apply(x: U32, y: U32): U32 ? =>\n" +
+      "    x %%? y\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.OperatorSpacing)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
 class \nodoc\ _TestOperatorSpacingSaturatingClean is UnitTest
   """Saturating operator with spaces is clean."""
   fun name(): String => "OperatorSpacing: 'x +~ y' is clean"

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -386,6 +386,8 @@ actor \nodoc\ Main is TestList
     test(_TestOperatorSpacingMultipleViolations)
     test(_TestOperatorSpacingKeywordBinaryClean)
     test(_TestOperatorSpacingIdentityClean)
+    test(_TestOperatorSpacingPartialClean)
+    test(_TestOperatorSpacingPartialModClean)
     test(_TestOperatorSpacingSaturatingClean)
     test(_TestOperatorSpacingStyleGuideExample)
     test(_TestOperatorSpacingContinuationLineClean)


### PR DESCRIPTION
The operator-spacing rule's after-operator check uses `_op_width` to find where the operator ends in the source line, then checks for a space. Partial arithmetic operators (`*?`, `+?`, etc.) share the same AST token as their non-partial form, so `_op_width` returns the base operator's width and the check sees `?` where it expects a space.

Skip a trailing `?` before checking for the space.
