### PR TITLE
Fix Timer.abs and reverse operator continuation convention

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -304,3 +304,31 @@ pony-lint flagged identifiers like `path''` as naming violations because it only
 
 pony-lint's operator-spacing rule flagged partial arithmetic operators (`*?`, `+?`, etc.) as missing a space after the base operator. The `?` that makes the operation partial shares the same AST token as the non-partial form, so the rule saw `?` where it expected a space.
 
+## Fix Timer.abs computing wrong expiration time
+
+`Timer.abs`, which creates a timer with an absolute wall-clock expiration, has been computing the wrong expiration time since 2017. A formatting change moved a binary `-` operator to the start of a continuation line, where the Pony parser treats it as unary negation instead of subtraction. The target wall-clock time was silently discarded and the current wall-clock time was negated, producing a wrapped U64 expiration far in the future. Timers created with `Timer.abs` would effectively never fire. The bug was found by the new pony-lint operator-placement rule described below.
+
+`Timer.create`, which takes a relative nanosecond offset, was not affected.
+
+## pony-lint: binary operators on continuation lines must now be at the end of the previous line
+
+pony-lint's `style/operator-spacing` rule now flags a binary operator at the start of a continuation line. The operator belongs at the end of the previous line instead. The Pony parser treats `-` at the start of a line as unary negation, not subtraction, so placing a binary `-` there silently changes the meaning of the expression. The rule flags all binary operators at line start for consistency, not only `-`.
+
+Before (flagged):
+
+```pony
+let x = a
+  + b
+```
+
+After (clean):
+
+```pony
+let x = a +
+  b
+```
+
+## pony-lint: `- expr` with a space at the start of a line is now a lint error
+
+pony-lint's `style/operator-spacing` rule now flags `- expr` (with a space after the minus) at the start of a line. The Pony parser treats `-` there as unary negation, so a space after it — which normally signals a binary operator — is misleading. The diagnostic says the minus is negation, not subtraction, and suggests moving it to the end of the previous line.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix compiler crash with multiple traits sharing a method with a default body ([PR #5831](https://github.com/ponylang/ponyc/pull/5831))
 - Fix pony-lint false positive on identifiers with multiple trailing primes ([PR #5849](https://github.com/ponylang/ponyc/pull/5849))
 - Fix pony-lint false positive on partial operators ([PR #5850](https://github.com/ponylang/ponyc/pull/5850))
+- Fix Timer.abs computing wrong expiration time ([PR #5851](https://github.com/ponylang/ponyc/pull/5851))
 
 ### Added
 
@@ -38,6 +39,8 @@ All notable changes to the Pony compiler and standard library will be documented
 - Add read_failed to InputNotify ([PR #5832](https://github.com/ponylang/ponyc/pull/5832))
 - Exempt triple-quoted string literals from the 80-column lint rule ([PR #5837](https://github.com/ponylang/ponyc/pull/5837))
 - pony-lint line-length rule narrows unbreakable-word exemption ([PR #5847](https://github.com/ponylang/ponyc/pull/5847))
+- pony-lint: binary operators on continuation lines must now be at the end of the previous line ([PR #5851](https://github.com/ponylang/ponyc/pull/5851))
+- pony-lint: `- expr` with a space at the start of a line is now a lint error ([PR #5851](https://github.com/ponylang/ponyc/pull/5851))
 
 ## [0.68.0] - 2026-08-01
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -93,10 +93,22 @@ actor Main
   foo(x where bar = y)
   ```
 
-- The `not` operator is surrounded by spaces, but the `-` operator is not followed by a space.
+- The `not` operator is surrounded by spaces, but the unary `-` operator is not followed by a space.
 
   ```pony
   if not x then -a end
+  ```
+
+- When an expression with a binary operator spans multiple lines, the operator belongs at the end of the line, not the start of the next. `-` at the start of a line is parsed as unary negation, not binary subtraction — moving the operator to the end of the previous line avoids a silent misparse.
+
+  ```pony
+  // OK
+  let x = a +
+    b
+
+  // Not OK — and for `-`, silently changes meaning
+  let x = a
+    + b
   ```
 
 - Lambda expressions follow the rules above except that a space is placed before the closing brace only if the lambda is on one line.
@@ -303,11 +315,11 @@ var x =
 // OK
 let output =
   recover String(
-    file_name.size()
-      + file_linenum.size()
-      + file_linepos.size()
-      + msg.size()
-      + 4)
+    file_name.size() +
+      file_linenum.size() +
+      file_linepos.size() +
+      msg.size() +
+      4)
   end
 
 // Not OK

--- a/examples/fan-in/main.pony
+++ b/examples/fan-in/main.pony
@@ -46,21 +46,21 @@ actor Main
               where default' = 1000)
             OptionSpec.i64(
               "analyzer-interval",
-              "How often analyzers send messages to "
-                + "receiver in centiseconds "
-                + "(10 centiseconds = 1 second)"
+              "How often analyzers send messages to " +
+                "receiver in centiseconds " +
+                "(10 centiseconds = 1 second)"
               where default' = 100)
             OptionSpec.i64(
               "analyzer-report-count",
-              "Number of times analyzers send messages "
-                + "to receiver before shutting down, "
-                + "0 is infinite"
+              "Number of times analyzers send messages " +
+                "to receiver before shutting down, " +
+                "0 is infinite"
               where default' = 10)
             OptionSpec.i64(
               "receiver-workload",
-              "Number of microseconds the receiver "
-                + "takes to process each message "
-                + "it receives"
+              "Number of microseconds the receiver " +
+                "takes to process each message " +
+                "it receives"
               where default' = 10000)
           ],
           [
@@ -90,15 +90,15 @@ actor Main
         cmd.option("receiver-workload").i64().u64()
 
       env.out.print(
-        "# "
-          + "senders " + num_senders.string() + ", "
-          + "analyzers " + num_analyzers.string() + ", "
-          + "analyzer-interval "
-          + analyzer_interval.string() + ", "
-          + "analyzer-report-count "
-          + analyzer_report_count.string() + ", "
-          + "receiver-workload "
-          + receiver_workload.string())
+        "# " +
+          "senders " + num_senders.string() + ", " +
+          "analyzers " + num_analyzers.string() + ", " +
+          "analyzer-interval " +
+          analyzer_interval.string() + ", " +
+          "analyzer-report-count " +
+          analyzer_report_count.string() + ", " +
+          "receiver-workload " +
+          receiver_workload.string())
       env.out.print("time,run-ns,rate")
 
       let coordinator =
@@ -225,15 +225,15 @@ actor Coordinator
       let rate: I64 =
         (total_msgs.i64() * 1_000_000_000) / run_ns
       _env.out.print(
-        ts.string() + ","
-          + run_ns.string() + ","
-          + rate.string())
+        ts.string() + "," +
+          run_ns.string() + "," +
+          rate.string())
 
       if _done and (ts == _current_t) then
         _env.out.print(
-          "Done with message sending... "
-            + "Waiting for Receiver to work "
-            + "through its backlog...")
+          "Done with message sending... " +
+            "Waiting for Receiver to work " +
+            "through its backlog...")
       end
 
       try

--- a/examples/gups_basic/main.pony
+++ b/examples/gups_basic/main.pony
@@ -112,8 +112,8 @@ actor Main
       var elapsed = (Time.nanos() - _start).f64()
       var gups = _updates.f64() / elapsed
       _env.out.print(
-        "Time: " + (elapsed / 1e9).string()
-          + " GUPS: " + gups.string())
+        "Time: " + (elapsed / 1e9).string() +
+          " GUPS: " + gups.string())
     end
 
 actor Streamer

--- a/examples/gups_opt/main.pony
+++ b/examples/gups_opt/main.pony
@@ -54,10 +54,10 @@ class val Config
     logactors = cmd.option("actors").i64().usize()
 
     env.out.print(
-      "logtable: " + logtable.string()
-        + "\niterate: " + iterate.string()
-        + "\nlogchunk: " + logchunk.string()
-        + "\nlogactors: " + logactors.string())
+      "logtable: " + logtable.string() +
+        "\niterate: " + iterate.string() +
+        "\nlogchunk: " + logchunk.string() +
+        "\nlogactors: " + logactors.string())
 
 actor Main
   let _env: Env
@@ -121,8 +121,8 @@ actor Main
       let gups = _updates.f64() / elapsed
 
       _env.out.print(
-        "Time: " + (elapsed / 1e9).string()
-          + "\nGUPS: " + gups.string())
+        "Time: " + (elapsed / 1e9).string() +
+          "\nGUPS: " + gups.string())
     end
 
 actor Updater

--- a/examples/json/main.pony
+++ b/examples/json/main.pony
@@ -90,8 +90,8 @@ actor Main
     | let j: json.JsonValue =>
       env.out.print("Parsed successfully")
       match j
-      | let obj: json.JsonObject => env.out.print("Root is object with "
-        + obj.size().string() + " keys")
+      | let obj: json.JsonObject => env.out.print("Root is object with " +
+        obj.size().string() + " keys")
       end
     | let err: json.JsonParseError =>
       env.out.print("Parse error: " + err.string())
@@ -109,8 +109,8 @@ actor Main
       try
         let first_name = nav("users")(USize(0))("name").as_string()?
         let first_age = nav("users")(USize(0))("age").as_i64()?
-        env.out.print("First user: " + first_name
-          + ", age " + first_age.string())
+        env.out.print("First user: " + first_name +
+          ", age " + first_age.string())
       else
         env.out.print("Navigation failed")
       end
@@ -230,8 +230,8 @@ actor Main
       try
         let price_path = json.JsonPathParser.compile("$.store..price")?
         let prices = price_path.query(doc)
-        env.out.print("All prices (" + prices.size().string() + "): "
-          + _format_results(prices))
+        env.out.print("All prices (" + prices.size().string() + "): " +
+          _format_results(prices))
       end
 
       // query_one: first book title
@@ -373,8 +373,8 @@ actor Main
         let has_a =
           json.JsonPathParser.compile("""$.users[?search(@.name, "a")]""")?
         let results = has_a.query(doc)
-        env.out.print("Names containing 'a' (search): "
-          + results.size().string())
+        env.out.print("Names containing 'a' (search): " +
+          results.size().string())
       end
 
       // length(): filter by string length
@@ -382,8 +382,8 @@ actor Main
         let short =
           json.JsonPathParser.compile("$.users[?length(@.name) <= 3]")?
         let results = short.query(doc)
-        env.out.print("Short names (length <= 3): "
-          + _format_results(results))
+        env.out.print("Short names (length <= 3): " +
+          _format_results(results))
       end
 
       // count(): filter by array size
@@ -391,8 +391,8 @@ actor Main
         let multi =
           json.JsonPathParser.compile("$.users[?count(@.tags[*]) > 1]")?
         let results = multi.query(doc)
-        env.out.print("Multiple tags (count > 1): "
-          + results.size().string())
+        env.out.print("Multiple tags (count > 1): " +
+          results.size().string())
       end
 
     | let err: json.JsonParseError =>

--- a/examples/mandelbrot/main.pony
+++ b/examples/mandelbrot/main.pony
@@ -53,8 +53,8 @@ actor Main
     match outfile
     | let f: File =>
       f.print(
-        "P4\n " + c.width.string()
-          + " " + c.width.string() + "\n")
+        "P4\n " + c.width.string() +
+          " " + c.width.string() + "\n")
       header = f.size()
       f.set_length(
         (c.width * (c.width >> 3)) + header)

--- a/examples/mandelbrot/mandelbrot.pony
+++ b/examples/mandelbrot/mandelbrot.pony
@@ -113,25 +113,25 @@ class val Config
         [
           OptionSpec.i64(
             "iterations",
-            "Maximum amount of iterations to be "
-              + "done for each pixel."
+            "Maximum amount of iterations to be " +
+              "done for each pixel."
             where short' = 'i', default' = 50)
           OptionSpec.f64(
             "limit",
-            "Square of the limit that pixels need "
-              + "to exceed in order to escape from "
-              + "the Mandelbrot set."
+            "Square of the limit that pixels need " +
+              "to exceed in order to escape from " +
+              "the Mandelbrot set."
             where short' = 'l', default' = 4.0)
           OptionSpec.i64(
             "chunks",
-            "Maximum line count of chunks the "
-              + "image should be divided into for "
-              + "divide & conquer processing."
+            "Maximum line count of chunks the " +
+              "image should be divided into for " +
+              "divide & conquer processing."
             where short' = 'c', default' = 16)
           OptionSpec.i64(
             "width",
-            "Lateral length of the resulting "
-              + "mandelbrot image."
+            "Lateral length of the resulting " +
+              "mandelbrot image."
             where short' = 'w', default' = 16000)
           OptionSpec.string(
             "output",

--- a/examples/message-ubench/main.pony
+++ b/examples/message-ubench/main.pony
@@ -24,18 +24,18 @@ actor Main
               where default' = 8)
             OptionSpec.i64(
               "report-interval",
-              "Print report every N centiseconds "
-                + "(10 centiseconds = 1 second)"
+              "Print report every N centiseconds " +
+                "(10 centiseconds = 1 second)"
               where default' = 10)
             OptionSpec.i64(
               "report-count",
-              "Number of reports to generate, "
-                + "default 0 is infinite"
+              "Number of reports to generate, " +
+                "default 0 is infinite"
               where default' = 0)
             OptionSpec.i64(
               "initial-pings",
-              "Initial # of pings to send to each "
-                + "Pinger actor in an interval"
+              "Initial # of pings to send to each " +
+                "Pinger actor in an interval"
               where default' = 5)
           ],
           [

--- a/examples/pony_check/collection_generators.pony
+++ b/examples/pony_check/collection_generators.pony
@@ -33,8 +33,8 @@ class val _OperationOnCollection[T, R = String]
     recover
       String
         .> append(
-          "_OperationOnCollection("
-            + idx.string() + ")")
+          "_OperationOnCollection(" +
+            idx.string() + ")")
     end
 
 class _OperationOnCollectionProperty
@@ -135,8 +135,8 @@ class _OperationOnCollectionProperty
         let res = op.op(elem)
         if
           not h.assert_true(
-            res.contains("foo")
-              or res.contains("bar"))
+            res.contains("foo") or
+              res.contains("bar"))
         then
           return
         end

--- a/examples/pony_check/custom_class.pony
+++ b/examples/pony_check/custom_class.pony
@@ -52,9 +52,9 @@ class MyLittlePony is Stringable
     recover
       String(17 + name.size())
         .> append(
-          "Pony(\"" + name + "\", "
-            + cuteness.string() + ", "
-            + color.string() + ")")
+          "Pony(\"" + name + "\", " +
+            cuteness.string() + ", " +
+            color.string() + ")")
     end
 
 class _CustomClassMapProperty is Property1[MyLittlePony]

--- a/examples/runtime_info/main.pony
+++ b/examples/runtime_info/main.pony
@@ -50,22 +50,22 @@ actor Stat
       ActorStats.system_messages_processed_counter(auth)
     var ampc =
       ActorStats.app_messages_processed_counter(auth)
-    env.out.print("Actor stats:"
-      + "\n  id: " + (digestof this).string()
-      + "\n  heap memory allocated: " + ha.string()
-      + "\n  heap memory used: " + hu.string()
-      + "\n  heap num allocated: " + hn.string()
-      + "\n  heap realloc counter: " + rc.string()
-      + "\n  heap alloc counter: " + ac.string()
-      + "\n  heap free counter: " + fc.string()
-      + "\n  heap gc counter: " + gc.string()
-      + "\n  system cpu: " + asc.string()
-      + "\n  app cpu: " + aac.string()
-      + "\n  garbage collection marking cpu: " + agmc.string()
-      + "\n  garbage collection sweeping cpu: " + agsc.string()
-      + "\n  messages sent counter: " + msc.string()
-      + "\n  system messages processed counter: " + smpc.string()
-      + "\n  app messages processed counter: " + ampc.string())
+    env.out.print("Actor stats:" +
+      "\n  id: " + (digestof this).string() +
+      "\n  heap memory allocated: " + ha.string() +
+      "\n  heap memory used: " + hu.string() +
+      "\n  heap num allocated: " + hn.string() +
+      "\n  heap realloc counter: " + rc.string() +
+      "\n  heap alloc counter: " + ac.string() +
+      "\n  heap free counter: " + fc.string() +
+      "\n  heap gc counter: " + gc.string() +
+      "\n  system cpu: " + asc.string() +
+      "\n  app cpu: " + aac.string() +
+      "\n  garbage collection marking cpu: " + agmc.string() +
+      "\n  garbage collection sweeping cpu: " + agsc.string() +
+      "\n  messages sent counter: " + msc.string() +
+      "\n  system messages processed counter: " + smpc.string() +
+      "\n  app messages processed counter: " + ampc.string())
 
   be print_scheduler_stats(env: Env) =>
     """
@@ -95,18 +95,18 @@ actor Stat
         ss_auth)
     var nim =
       SchedulerStats.num_inflight_messages(ss_auth)
-    env.out.print("Scheduler stats:"
-      + "\n  index: " + i.string()
-      + "\n  total memory allocated: " + ta.string()
-      + "\n  total memory used: " + tu.string()
-      + "\n  created actors counter: " + cac.string()
-      + "\n  destroyed actors counter: " + dac.string()
-      + "\n  actors app cpu: " + aac.string()
-      + "\n  actors gc marking cpu: " + agmc.string()
-      + "\n  actors gc sweeping cpu: " + agsc.string()
-      + "\n  actors system cpu: " + asc.string()
-      + "\n  scheduler msgs cpu: " + mc.string()
-      + "\n  scheduler misc cpu: " + msc.string()
-      + "\n  memory used inflight messages: " + mum.string()
-      + "\n  memory allocated influght messages: " + mam.string()
-      + "\n  number of inflight messages: " + nim.string())
+    env.out.print("Scheduler stats:" +
+      "\n  index: " + i.string() +
+      "\n  total memory allocated: " + ta.string() +
+      "\n  total memory used: " + tu.string() +
+      "\n  created actors counter: " + cac.string() +
+      "\n  destroyed actors counter: " + dac.string() +
+      "\n  actors app cpu: " + aac.string() +
+      "\n  actors gc marking cpu: " + agmc.string() +
+      "\n  actors gc sweeping cpu: " + agsc.string() +
+      "\n  actors system cpu: " + asc.string() +
+      "\n  scheduler msgs cpu: " + mc.string() +
+      "\n  scheduler misc cpu: " + msc.string() +
+      "\n  memory used inflight messages: " + mum.string() +
+      "\n  memory allocated influght messages: " + mam.string() +
+      "\n  number of inflight messages: " + nim.string())

--- a/examples/under_pressure/main.pony
+++ b/examples/under_pressure/main.pony
@@ -35,8 +35,8 @@ class SlowDown is TCPConnectionNotify
       "\tgetsockopt get_tcp_nodelay = %d\n".cstring(),
       conn.get_tcp_nodelay()._2)
     @printf(
-      ("\tgetsockopt set_tcp_nodelay(true) "
-        + "return value = %d\n")
+      ("\tgetsockopt set_tcp_nodelay(true) " +
+        "return value = %d\n")
         .cstring(),
       conn.set_tcp_nodelay(true))
     @printf(

--- a/examples/yield/main.pony
+++ b/examples/yield/main.pony
@@ -63,8 +63,8 @@ actor LonelyPony
     end
     let d = _sw.delta()
     _env.out.print(
-      "N: " + _m.string()
-        + ", Lonely: " + d.string())
+      "N: " + _m.string() +
+        ", Lonely: " + d.string())
 
 actor InterruptiblePony
   """
@@ -103,8 +103,8 @@ actor InterruptiblePony
       Debug.err("Ugah!")
       let d = _sw.delta()
       _env.out.print(
-        "N=" + _n.string()
-          + ", Interruptible: " + d.string())
+        "N=" + _n.string() +
+          ", Interruptible: " + d.string())
     else
       if _debug then
         _env.err.print("I: " + _n.string())
@@ -177,14 +177,14 @@ actor Main
               where short' = 'p', default' = false)
             OptionSpec.i64(
               "bench",
-              "Run an instrumented behaviour to "
-                + "guesstimate overhead of "
-                + "non/interruptive."
+              "Run an instrumented behaviour to " +
+                "guesstimate overhead of " +
+                "non/interruptive."
               where short' = 'b', default' = 0)
             OptionSpec.bool(
               "lonely",
-              "Run a non-interruptible behaviour "
-                + "with logic that runs forever."
+              "Run a non-interruptible behaviour " +
+                "with logic that runs forever."
               where short' = 'l', default' = false)
             OptionSpec.bool(
               "debug",

--- a/packages/collections/range.pony
+++ b/packages/collections/range.pony
@@ -82,8 +82,8 @@ class Range[A: (Real[A] val & Number) = USize] is Iterator[A]
       else
         (true, true, true)
       end
-    let progress = ((_min < _max) and (_inc > 0))
-                    or ((_min > _max) and (_inc < 0)) // false if any is NaN!
+    let progress = ((_min < _max) and (_inc > 0)) or
+                    ((_min > _max) and (_inc < 0)) // false if any is NaN!
     if progress and min_finite and inc_finite then
       _empty = false
       _infinite = not max_finite // ok to use not max_finite for max_infinite

--- a/packages/files/directory.pony
+++ b/packages/files/directory.pony
@@ -79,9 +79,9 @@ class Directory
     ifdef posix then
       _fd =
         @open(from.path.cstring(),
-          @ponyint_o_rdonly()
-            or @ponyint_o_directory()
-            or @ponyint_o_cloexec())
+          @ponyint_o_rdonly() or
+            @ponyint_o_directory() or
+            @ponyint_o_cloexec())
 
       if _fd == -1 then
         error
@@ -127,9 +127,9 @@ class Directory
           ifdef linux or bsd then
             let fd =
               @openat(fd', ".".cstring(),
-                @ponyint_o_rdonly()
-                  or @ponyint_o_directory()
-                  or @ponyint_o_cloexec())
+                @ponyint_o_rdonly() or
+                  @ponyint_o_directory() or
+                  @ponyint_o_cloexec())
             @fdopendir(fd)
           else
             @opendir(path'.cstring())
@@ -186,9 +186,9 @@ class Directory
     ifdef linux or bsd then
       let fd' =
         @openat(_fd, target.cstring(),
-          @ponyint_o_rdonly()
-            or @ponyint_o_directory()
-            or @ponyint_o_cloexec())
+          @ponyint_o_rdonly() or
+            @ponyint_o_directory() or
+            @ponyint_o_cloexec())
       _relative(path', fd')
     else
       recover create(path')? end
@@ -239,10 +239,10 @@ class Directory
     if it does exist.
     """
     if
-      not path.caps(FileCreate)
-        or not path.caps(FileRead)
-        or not path.caps(FileWrite)
-        or (_fd == -1)
+      not path.caps(FileCreate) or
+        not path.caps(FileRead) or
+        not path.caps(FileWrite) or
+        (_fd == -1)
     then
       error
     end
@@ -252,9 +252,9 @@ class Directory
     ifdef linux or bsd then
       let fd' =
         @openat(_fd, target.cstring(),
-          @ponyint_o_rdwr()
-            or @ponyint_o_creat()
-            or @ponyint_o_cloexec(),
+          @ponyint_o_rdwr() or
+            @ponyint_o_creat() or
+            @ponyint_o_cloexec(),
           I32(0x1B6))
       recover File._descriptor(fd', path')? end
     else
@@ -266,8 +266,8 @@ class Directory
     Open for read only, failing if it doesn't exist.
     """
     if
-      not path.caps(FileRead)
-        or (_fd == -1)
+      not path.caps(FileRead) or
+        (_fd == -1)
     then
       error
     end
@@ -321,9 +321,9 @@ class Directory
     Return a FileInfo for some path relative to this directory.
     """
     if
-      not path.caps(FileStat)
-        or not path.caps(FileLookup)
-        or (_fd == -1)
+      not path.caps(FileStat) or
+        not path.caps(FileLookup) or
+        (_fd == -1)
     then
       error
     end
@@ -341,9 +341,9 @@ class Directory
     Set the FileMode for some path relative to this directory.
     """
     if
-      not path.caps(FileChmod)
-        or not path.caps(FileLookup)
-        or (_fd == -1)
+      not path.caps(FileChmod) or
+        not path.caps(FileLookup) or
+        (_fd == -1)
     then
       return false
     end
@@ -365,9 +365,9 @@ class Directory
     Set the FileMode for some path relative to this directory.
     """
     if
-      not path.caps(FileChown)
-        or not path.caps(FileLookup)
-        or (_fd == -1)
+      not path.caps(FileChown) or
+        not path.caps(FileLookup) or
+        (_fd == -1)
     then
       return false
     end
@@ -401,9 +401,9 @@ class Directory
     values.
     """
     if
-      not path.caps(FileChown)
-        or not path.caps(FileLookup)
-        or (_fd == -1)
+      not path.caps(FileChown) or
+        not path.caps(FileLookup) or
+        (_fd == -1)
     then
       return false
     end
@@ -430,11 +430,11 @@ class Directory
     this directory.
     """
     if
-      not path.caps(FileLink)
-        or not path.caps(FileLookup)
-        or not path.caps(FileCreate)
-        or not source.caps(FileLink)
-        or (_fd == -1)
+      not path.caps(FileLink) or
+        not path.caps(FileLookup) or
+        not path.caps(FileCreate) or
+        not source.caps(FileLink) or
+        (_fd == -1)
     then
       return false
     end
@@ -457,9 +457,9 @@ class Directory
     well, recursively. Symlinks will be removed but not traversed.
     """
     if
-      not path.caps(FileLookup)
-        or not path.caps(FileRemove)
-        or (_fd == -1)
+      not path.caps(FileLookup) or
+        not path.caps(FileRemove) or
+        (_fd == -1)
     then
       return false
     end
@@ -496,12 +496,12 @@ class Directory
     relative to the `to` directory).
     """
     if
-      not path.caps(FileLookup)
-       or not path.caps(FileRename)
-       or not to.path.caps(FileLookup)
-       or not to.path.caps(FileCreate)
-       or (_fd == -1)
-       or (to._fd == -1)
+      not path.caps(FileLookup) or
+       not path.caps(FileRename) or
+       not to.path.caps(FileLookup) or
+       not to.path.caps(FileCreate) or
+       (_fd == -1) or
+       (to._fd == -1)
     then
       return false
     end

--- a/packages/files/path.pony
+++ b/packages/files/path.pony
@@ -281,8 +281,8 @@ primitive Path
     end
 
     if
-      ((to_i - to_0) == 2)
-        and (to_clean.compare_sub("..", 2, to_0) is Equal)
+      ((to_i - to_0) == 2) and
+        (to_clean.compare_sub("..", 2, to_0) is Equal)
     then
       error
     end
@@ -417,8 +417,8 @@ primitive Path
     try
       let c = path.at_offset(offset)?
 
-      (((c >= 'A') and (c <= 'Z')) or ((c >= 'a') and (c <= 'z')))
-        and (path.at_offset(offset + 1)? == ':')
+      (((c >= 'A') and (c <= 'Z')) or ((c >= 'a') and (c <= 'z'))) and
+        (path.at_offset(offset + 1)? == ':')
     else
       false
     end

--- a/packages/iregex/_i_regexp_parser.pony
+++ b/packages/iregex/_i_regexp_parser.pony
@@ -185,12 +185,12 @@ class _IRegexpParser
       elseif _is_escapable_metachar(c) then
         _advance(1)
         _Literal(c.u32())
-      elseif (c == 'd') or (c == 'D') or (c == 'w') or (c == 'W')
-        or (c == 's') or (c == 'S')
+      elseif (c == 'd') or (c == 'D') or (c == 'w') or (c == 'W') or
+        (c == 's') or (c == 'S')
       then
-        _fail("Multi-character escapes (\\d, \\w, \\s) are not part of I-Regexp"
-          + " (RFC 9485). Use explicit character classes instead"
-          + " (e.g., [0-9] for \\d, \\p{Nd} for Unicode digits).")
+        _fail("Multi-character escapes (\\d, \\w, \\s) are not part of I-Regexp" +
+          " (RFC 9485). Use explicit character classes instead" +
+          " (e.g., [0-9] for \\d, \\p{Nd} for Unicode digits).")
         error
       else
         _fail("Invalid escape sequence: \\" + String.from_array([c]))

--- a/packages/iregex/_test.pony
+++ b/packages/iregex/_test.pony
@@ -124,8 +124,8 @@ class \nodoc\ iso _IRegexpMatchSafetyProperty is Property1[(String, String)]
       re.is_match(input)
       re.search(input)
     | let e: IRegexpParseError =>
-      ph.fail("Generated pattern should be valid: " + pattern
-        + " — " + e.string())
+      ph.fail("Generated pattern should be valid: " + pattern +
+        " — " + e.string())
     end
 
 class \nodoc\ iso _IRegexpIsMatchImpliesSearchProperty
@@ -159,10 +159,10 @@ class \nodoc\ iso _IRegexpLiteralRoundtripProperty is Property1[String]
     // Escape metacharacters to make a literal pattern
     let buf = String(sample.size() * 2)
     for byte in sample.values() do
-      if (byte == '(') or (byte == ')') or (byte == '*') or (byte == '+')
-        or (byte == '.') or (byte == '?') or (byte == '[') or (byte == '\\')
-        or (byte == ']') or (byte == '^') or (byte == '{') or (byte == '|')
-        or (byte == '}')
+      if (byte == '(') or (byte == ')') or (byte == '*') or (byte == '+') or
+        (byte == '.') or (byte == '?') or (byte == '[') or (byte == '\\') or
+        (byte == ']') or (byte == '^') or (byte == '{') or (byte == '|') or
+        (byte == '}')
       then
         buf.push('\\')
       end
@@ -194,8 +194,8 @@ class \nodoc\ iso _IRegexpSearchSubstringProperty
       let regexp_found = re.search(input)
       let string_found = input.contains(pattern)
       ph.assert_eq[Bool](string_found, regexp_found,
-        "Literal search should agree with String.contains for pattern: '"
-          + pattern + "' in input")
+        "Literal search should agree with String.contains for pattern: '" +
+          pattern + "' in input")
     | let _: IRegexpParseError =>
       ph.fail("ASCII letter pattern should always be valid: " + pattern)
     end

--- a/packages/itertools/iter.pony
+++ b/packages/itertools/iter.pony
@@ -998,10 +998,10 @@ class Iter[A] is Iterator[A]
         let _i4: Iterator[D] = i4
 
         fun ref has_next(): Bool =>
-          _i1.has_next()
-            and _i2.has_next()
-            and _i3.has_next()
-            and _i4.has_next()
+          _i1.has_next() and
+            _i2.has_next() and
+            _i3.has_next() and
+            _i4.has_next()
 
         fun ref next(): (A, B, C, D) ? =>
           (_i1.next()?, _i2.next()?, _i3.next()?, _i4.next()?)
@@ -1029,11 +1029,11 @@ class Iter[A] is Iterator[A]
         let _i5: Iterator[E] = i5
 
         fun ref has_next(): Bool =>
-          _i1.has_next()
-            and _i2.has_next()
-            and _i3.has_next()
-            and _i4.has_next()
-            and _i5.has_next()
+          _i1.has_next() and
+            _i2.has_next() and
+            _i3.has_next() and
+            _i4.has_next() and
+            _i5.has_next()
 
         fun ref next(): (A, B, C, D, E) ? =>
           (_i1.next()?, _i2.next()?, _i3.next()?, _i4.next()?, _i5.next()?)

--- a/packages/json/_json_path_parser.pony
+++ b/packages/json/_json_path_parser.pony
@@ -363,8 +363,8 @@ class ref _JsonPathParser
         | let s: _SearchExpr => _NotExpr(s)
         else
           _fail(
-            "Cannot negate value-returning function"
-            + " — only match() and search() can be negated")
+            "Cannot negate value-returning function" +
+            " — only match() and search() can be negated")
           error
         end
       else
@@ -394,8 +394,8 @@ class ref _JsonPathParser
         _skip_whitespace()
         if not _looking_at_comparison_op() then
           _fail(
-            "Value-returning function requires a comparison operator"
-            + " (e.g., length(@.a) > 3)")
+            "Value-returning function requires a comparison operator" +
+            " (e.g., length(@.a) > 3)")
           error
         end
         let op = _parse_comparison_op()?

--- a/packages/json/_json_scan.pony
+++ b/packages/json/_json_scan.pony
@@ -181,8 +181,8 @@ primitive _NumberParse
     // exponent part
     var has_exp = false
     var exp: I64 = 0
-    if (i < n)
-      and (try (s(i)? == 'e') or (s(i)? == 'E') else false end)
+    if (i < n) and
+      (try (s(i)? == 'e') or (s(i)? == 'E') else false end)
     then
       has_exp = true
       i = i + 1

--- a/packages/json/_stream_test.pony
+++ b/packages/json/_stream_test.pony
@@ -153,8 +153,8 @@ class \nodoc\ iso _TestStreamSplitInvariance is UnitTest
         h.assert_eq[String](whole, _StreamHelp.render(vs)
           where msg = "mismatch at chunk size " + n.string())
       | let e: JsonParseError =>
-        h.fail("split parse failed at chunk size " + n.string()
-          + ": " + e.string())
+        h.fail("split parse failed at chunk size " + n.string() +
+          ": " + e.string())
       end
     end
 
@@ -820,8 +820,8 @@ class \nodoc\ iso _StreamSplitInvariantProperty is Property1[String]
         | let vs: Array[JsonValue] =>
           ph.assert_eq[String val](whole, _StreamHelp.render(vs))
         | let e: JsonParseError =>
-          ph.fail("split at " + n.string() + " failed on " + doc + ": "
-            + e.string())
+          ph.fail("split at " + n.string() + " failed on " + doc + ": " +
+            e.string())
         end
       end
     | let e: JsonParseError =>

--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -165,9 +165,9 @@ primitive \nodoc\ _JsonValueStringGen
     let f = numerator.f64() / denom.f64()
     let s: String val = f.string()
     if
-      (not s.contains("."))
-        and (not s.contains("e"))
-        and (not s.contains("E"))
+      (not s.contains(".")) and
+        (not s.contains("e")) and
+        (not s.contains("E"))
     then
       s + ".0"
     else
@@ -1932,9 +1932,9 @@ class \nodoc\ iso _FunctionMatchImpliesSearchProperty
         let search_results = sp.query(doc)
         // Every match result must also be a search result
         ph.assert_true(match_results.size() <= search_results.size(),
-          "match returned " + match_results.size().string()
-          + " but search returned " + search_results.size().string()
-          + " for pattern '" + pattern + "'")
+          "match returned " + match_results.size().string() +
+          " but search returned " + search_results.size().string() +
+          " for pattern '" + pattern + "'")
       end
     | let _: JsonParseError => None
     end

--- a/packages/json/json_token_parser.pony
+++ b/packages/json/json_token_parser.pony
@@ -153,8 +153,8 @@ class ref JsonTokenParser
       if _error_message != "" then
         _error_message
       else
-        "Invalid JSON at byte offset " + _offset.string()
-          + ", line " + _line.string()
+        "Invalid JSON at byte offset " + _offset.string() +
+          ", line " + _line.string()
       end
     end
 
@@ -546,8 +546,8 @@ class ref JsonTokenParser
     end
 
   fun _is_number_byte(c: U8): Bool =>
-    ((c >= '0') and (c <= '9')) or (c == '-') or (c == '+') or (c == '.')
-      or (c == 'e') or (c == 'E')
+    ((c >= '0') and (c <= '9')) or (c == '-') or (c == '+') or (c == '.') or
+      (c == 'e') or (c == 'E')
 
   // --- token emission and failure -----------------------------------------
 

--- a/packages/net/net_address.pony
+++ b/packages/net/net_address.pony
@@ -118,19 +118,19 @@ class val NetAddress is Equatable[NetAddress]
       recover String.from_cstring(consume serv) end)
 
   fun eq(that: NetAddress box): Bool =>
-      (this._family == that._family)
-      and (this._port == that._port)
-      and (host_eq(that))
-      and (this._scope == that._scope)
+      (this._family == that._family) and
+      (this._port == that._port) and
+      (host_eq(that)) and
+      (this._scope == that._scope)
 
   fun host_eq(that: NetAddress box): Bool =>
     if ip4() then
       this._addr == that._addr
     else
-      (this._addr1 == that._addr1)
-        and (this._addr2 == that._addr2)
-        and (this._addr3 == that._addr3)
-        and (this._addr4 == that._addr4)
+      (this._addr1 == that._addr1) and
+        (this._addr2 == that._addr2) and
+        (this._addr3 == that._addr3) and
+        (this._addr4 == that._addr4)
     end
 
   fun length() : U8 =>

--- a/packages/net/tcp_connection.pony
+++ b/packages/net/tcp_connection.pony
@@ -630,8 +630,8 @@ actor TCPConnection is AsioEventNotify
         // Skip if this event also carried a readable (handled below), reads are
         // muted, or the peer has closed. (kqueue arms read and write on separate
         // one-shots, so it never loses the read arm and this is an inert no-op.)
-        if _writeable and not AsioEvent.readable(flags) and _connected
-          and not _readable and not _muted and not _shutdown_peer
+        if _writeable and not AsioEvent.readable(flags) and _connected and
+          not _readable and not _muted and not _shutdown_peer
         then
           @pony_asio_event_resubscribe_read(_event)
         end
@@ -834,8 +834,8 @@ actor TCPConnection is AsioEventNotify
 
           // check if we should yield to let another actor run
           if (not _notify.received(this, consume data,
-            received_called))
-            or (received_called >= _max_received_called)
+            received_called)) or
+            (received_called >= _max_received_called)
           then
             _read_again()
             _reading = false

--- a/packages/pony_check/ascii_range.pony
+++ b/packages/pony_check/ascii_range.pony
@@ -22,10 +22,10 @@ primitive ASCIILetters
 
 primitive ASCIIPrintable
   fun apply(): String =>
-    ASCIIDigits()
-      + ASCIILetters()
-      + ASCIIPunctuation()
-      + ASCIIWhiteSpace()
+    ASCIIDigits() +
+      ASCIILetters() +
+      ASCIIPunctuation() +
+      ASCIIWhiteSpace()
 
 primitive ASCIINonPrintable
   fun apply(): String =>

--- a/packages/pony_check/property_helper.pony
+++ b/packages/pony_check/property_helper.pony
@@ -164,16 +164,16 @@ class val PropertyHelper
     Assert that the 2 given expressions resolve to the same instance.
     """
     if expect isnt actual then
-      _fail(_fmt_msg(loc, "Assert is failed. " + msg
-        + " Expected (" + (digestof expect).string() + ") is ("
-        + (digestof actual).string() + ")"))
+      _fail(_fmt_msg(loc, "Assert is failed. " + msg +
+        " Expected (" + (digestof expect).string() + ") is (" +
+        (digestof actual).string() + ")"))
       return false
     end
 
     _runner.log(
-      _fmt_msg(loc, "Assert is passed. " + msg
-        + " Got (" + (digestof expect).string() + ") is ("
-        + (digestof actual).string() + ")"),
+      _fmt_msg(loc, "Assert is passed. " + msg +
+        " Got (" + (digestof expect).string() + ") is (" +
+        (digestof actual).string() + ")"),
       true)
     true
 
@@ -188,16 +188,16 @@ class val PropertyHelper
     Assert that the 2 given expressions resolve to different instances.
     """
     if not_expect is actual then
-      _fail(_fmt_msg(loc, "Assert isn't failed. " + msg
-        + " Expected (" + (digestof not_expect).string() + ") isnt ("
-        + (digestof actual).string() + ")"))
+      _fail(_fmt_msg(loc, "Assert isn't failed. " + msg +
+        " Expected (" + (digestof not_expect).string() + ") isnt (" +
+        (digestof actual).string() + ")"))
       return false
     end
 
     _runner.log(
-      _fmt_msg(loc, "Assert isn't passed. " + msg
-        + " Got (" + (digestof not_expect).string() + ") isnt ("
-        + (digestof actual).string() + ")"),
+      _fmt_msg(loc, "Assert isn't passed. " + msg +
+        " Got (" + (digestof not_expect).string() + ") isnt (" +
+        (digestof actual).string() + ")"),
       true)
     true
 
@@ -212,13 +212,13 @@ class val PropertyHelper
     Assert that the 2 given expressions are equal.
     """
     if expect != actual then
-      _fail(_fmt_msg(loc,  "Assert eq failed. " + msg
-        + " Expected (" + expect.string() + ") == (" + actual.string() + ")"))
+      _fail(_fmt_msg(loc,  "Assert eq failed. " + msg +
+        " Expected (" + expect.string() + ") == (" + actual.string() + ")"))
       return false
     end
 
-    _runner.log(_fmt_msg(loc, "Assert eq passed. " + msg
-      + " Got (" + expect.string() + ") == (" + actual.string() + ")"),
+    _runner.log(_fmt_msg(loc, "Assert eq passed. " + msg +
+      " Got (" + expect.string() + ") == (" + actual.string() + ")"),
       true)
     true
 
@@ -233,15 +233,15 @@ class val PropertyHelper
     Assert that the 2 given expressions are not equal.
     """
     if not_expect == actual then
-      _fail(_fmt_msg(loc, "Assert ne failed. " + msg
-        + " Expected (" + not_expect.string() + ") != (" + actual.string()
-        + ")"))
+      _fail(_fmt_msg(loc, "Assert ne failed. " + msg +
+        " Expected (" + not_expect.string() + ") != (" + actual.string() +
+        ")"))
       return false
     end
 
     _runner.log(
-      _fmt_msg(loc, "Assert ne passed. " + msg
-        + " Got (" + not_expect.string() + ") != (" + actual.string() + ")"),
+      _fmt_msg(loc, "Assert ne passed. " + msg +
+        " Got (" + not_expect.string() + ") != (" + actual.string() + ")"),
       true)
     true
 
@@ -276,14 +276,14 @@ class val PropertyHelper
     end
 
     if not ok then
-      _fail(_fmt_msg(loc, "Assert EQ failed. " + msg + " Expected ("
-        + _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")"))
+      _fail(_fmt_msg(loc, "Assert EQ failed. " + msg + " Expected (" +
+        _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")"))
       return false
     end
 
     _runner.log(
-      _fmt_msg(loc, "Assert EQ passed. " + msg + " Got ("
-        + _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")"),
+      _fmt_msg(loc, "Assert EQ passed. " + msg + " Got (" +
+        _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")"),
       true)
     true
 
@@ -324,11 +324,11 @@ class val PropertyHelper
 
       if (extra.size() != 0) or (missing.size() != 0) then
         _fail(
-          _fmt_msg(loc, "Assert EQ_UNORDERED failed. " + msg
-            + " Expected (" + _print_array[A](expect) + ") == ("
-            + _print_array[A](actual) + "):"
-            + "\nMissing: " + _print_array[box->A](missing)
-            + "\nExtra: " + _print_array[box->A](extra)
+          _fmt_msg(loc, "Assert EQ_UNORDERED failed. " + msg +
+            " Expected (" + _print_array[A](expect) + ") == (" +
+            _print_array[A](actual) + "):" +
+            "\nMissing: " + _print_array[box->A](missing) +
+            "\nExtra: " + _print_array[box->A](extra)
           )
         )
         return false
@@ -336,13 +336,13 @@ class val PropertyHelper
       _runner.log(
         _fmt_msg(
           loc,
-          "Assert EQ_UNORDERED passed. "
-          + msg
-          + " Got ("
-          + _print_array[A](expect)
-          + ") == ("
-          + _print_array[A](actual)
-          + ")"
+          "Assert EQ_UNORDERED passed. " +
+          msg +
+          " Got (" +
+          _print_array[A](expect) +
+          ") == (" +
+          _print_array[A](actual) +
+          ")"
         ),
         true
       )

--- a/packages/pony_check/property_runner.pony
+++ b/packages/pony_check/property_runner.pony
@@ -396,11 +396,11 @@ actor PropertyRunner[T]
     and signal failure to the `PropertyResultNotify`.
     """
     _notify.fail(
-      "Property errored for sample "
-        + sample_repr
-        + " (after "
-        + shrink_rounds.string()
-        + " shrinks)"
+      "Property errored for sample " +
+        sample_repr +
+        " (after " +
+        shrink_rounds.string() +
+        " shrinks)"
     )
 
   fun _report_failed(sample_repr: String,
@@ -410,11 +410,11 @@ actor PropertyRunner[T]
     Report a failed property and signal failure to the `PropertyResultNotify`.
     """
     _notify.fail(
-      "Property failed for sample "
-        + sample_repr
-        + " (after "
-        + shrink_rounds.string()
-        + " shrinks)"
+      "Property failed for sample " +
+        sample_repr +
+        " (after " +
+        shrink_rounds.string() +
+        " shrinks)"
     )
 
 

--- a/packages/pony_test/pony_test.pony
+++ b/packages/pony_test/pony_test.pony
@@ -410,9 +410,9 @@ actor PonyTest
     try
       if not _no_prog then
         _env.out.print(
-          _started.string() + " test" + _plural(_started)
-            + " started, " + _finished.string() + " complete: "
-            + _records(id)?.name + " started")
+          _started.string() + " test" + _plural(_started) +
+            " started, " + _finished.string() + " complete: " +
+            _records(id)?.name + " started")
       end
     end
 
@@ -429,9 +429,9 @@ actor PonyTest
 
       if not _no_prog then
         _env.out.print(
-          _started.string() + " test" + _plural(_started)
-            + " started, " + _finished.string() + " complete: "
-            + _records(id)?.name + " complete")
+          _started.string() + " test" + _plural(_started) +
+            " started, " + _finished.string() + " complete: " +
+            _records(id)?.name + " complete")
       end
     end
 
@@ -532,17 +532,17 @@ actor PonyTest
         _env.out.print("  " + exe_name + " [options]")
         _env.out.print("")
         _env.out.print("Options:")
-        _env.out.print("  --exclude=prefix  - Don't run tests whose names "
-          + "start with the given prefix.")
-        _env.out.print("  --only=prefix     - Only run tests whose names "
-          + "start with the given prefix.")
+        _env.out.print("  --exclude=prefix  - Don't run tests whose names " +
+          "start with the given prefix.")
+        _env.out.print("  --only=prefix     - Only run tests whose names " +
+          "start with the given prefix.")
         _env.out.print("  --verbose         - Show all test output.")
         _env.out.print("  --sequential      - Run tests sequentially.")
         _env.out.print("  --noprog          - Do not print progress messages.")
         _env.out.print("  --list            - List but do not run tests.")
         _env.out.print("  --label=label     - Only run tests with given label")
-        _env.out.print("  --shuffle[=seed]  - Run tests in a random order, "
-          + "optionally specifying a U64 seed.")
+        _env.out.print("  --shuffle[=seed]  - Run tests in a random order, " +
+          "optionally specifying a U64 seed.")
         _do_nothing = true
         return
       end
@@ -567,10 +567,10 @@ actor PonyTest
 
     // Next we print the pass / fail stats.
     _env.out.print("----")
-    _env.out.print("---- " + _records.size().string() + " test"
-      + _plural(_records.size()) + " ran.")
-    _env.out.print(_Color.green() + "---- Passed: " + pass_count.string()
-      + _Color.reset())
+    _env.out.print("---- " + _records.size().string() + " test" +
+      _plural(_records.size()) + " ran.")
+    _env.out.print(_Color.green() + "---- Passed: " + pass_count.string() +
+      _Color.reset())
 
     if fail_count == 0 then
       // Success, nothing failed.
@@ -578,8 +578,8 @@ actor PonyTest
     end
 
     // Not everything passed.
-    _env.out.print(_Color.red() + "**** FAILED: " + fail_count.string()
-      + " test" + _plural(fail_count) + ", listed below:" + _Color.reset())
+    _env.out.print(_Color.red() + "**** FAILED: " + fail_count.string() +
+      " test" + _plural(fail_count) + ", listed below:" + _Color.reset())
 
     // Finally print our list of failed tests.
     for rec in _records.values() do

--- a/packages/pony_test/test_helper.pony
+++ b/packages/pony_test/test_helper.pony
@@ -138,16 +138,16 @@ class val TestHelper
     Check that the 2 given expressions resolve to the same instance
     """
     if expect isnt actual then
-      fail(_format_loc(loc) + "Assert " + check + " failed. " + msg
-        + " Expected (" + (digestof expect).string() + ") is ("
-        + (digestof actual).string() + ")")
+      fail(_format_loc(loc) + "Assert " + check + " failed. " + msg +
+        " Expected (" + (digestof expect).string() + ") is (" +
+        (digestof actual).string() + ")")
       return false
     end
 
     log(
-      _format_loc(loc) + "Assert " + check + " passed. " + msg
-        + " Got (" + (digestof expect).string() + ") is ("
-        + (digestof actual).string() + ")",
+      _format_loc(loc) + "Assert " + check + " passed. " + msg +
+        " Got (" + (digestof expect).string() + ") is (" +
+        (digestof actual).string() + ")",
       true)
     true
 
@@ -167,13 +167,13 @@ class val TestHelper
     Check that the 2 given expressions are equal.
     """
     if expect != actual then
-      fail(_format_loc(loc) + "Assert " + check + " failed. " + msg
-        + " Expected (" + expect.string() + ") == (" + actual.string() + ")")
+      fail(_format_loc(loc) + "Assert " + check + " failed. " + msg +
+        " Expected (" + expect.string() + ") == (" + actual.string() + ")")
       return false
     end
 
-    log(_format_loc(loc) + "Assert " + check + " passed. " + msg
-      + " Got (" + expect.string() + ") == (" + actual.string() + ")", true)
+    log(_format_loc(loc) + "Assert " + check + " passed. " + msg +
+      " Got (" + expect.string() + ") == (" + actual.string() + ")", true)
     true
 
   fun assert_isnt[A](
@@ -200,16 +200,16 @@ class val TestHelper
     Check that the 2 given expressions resolve to different instances.
     """
     if not_expect is actual then
-      fail(_format_loc(loc) + "Assert " + check + " failed. " + msg
-        + " Expected (" + (digestof not_expect).string() + ") isnt ("
-        + (digestof actual).string() + ")")
+      fail(_format_loc(loc) + "Assert " + check + " failed. " + msg +
+        " Expected (" + (digestof not_expect).string() + ") isnt (" +
+        (digestof actual).string() + ")")
       return false
     end
 
     log(
-      _format_loc(loc) + "Assert " + check + " passed. " + msg
-        + " Got (" + (digestof not_expect).string() + ") isnt ("
-        + (digestof actual).string() + ")",
+      _format_loc(loc) + "Assert " + check + " passed. " + msg +
+        " Got (" + (digestof not_expect).string() + ") isnt (" +
+        (digestof actual).string() + ")",
       true)
     true
 
@@ -229,15 +229,15 @@ class val TestHelper
     Check that the 2 given expressions are not equal.
     """
     if not_expect == actual then
-      fail(_format_loc(loc) + "Assert " + check + " failed. " + msg
-        + " Expected (" + not_expect.string() + ") != (" + actual.string()
-        + ")")
+      fail(_format_loc(loc) + "Assert " + check + " failed. " + msg +
+        " Expected (" + not_expect.string() + ") != (" + actual.string() +
+        ")")
       return false
     end
 
     log(
-      _format_loc(loc) + "Assert " + check + " passed. " + msg
-        + " Got (" + not_expect.string() + ") != (" + actual.string() + ")",
+      _format_loc(loc) + "Assert " + check + " passed. " + msg +
+        " Got (" + not_expect.string() + ") != (" + actual.string() + ")",
       true)
     true
 
@@ -283,14 +283,14 @@ class val TestHelper
     end
 
     if not ok then
-      fail(_format_loc(loc) + "Assert EQ failed. " + msg + " Expected ("
-        + _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")")
+      fail(_format_loc(loc) + "Assert EQ failed. " + msg + " Expected (" +
+        _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")")
       return false
     end
 
     log(
-      _format_loc(loc) + "Assert EQ passed. " + msg + " Got ("
-        + _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")",
+      _format_loc(loc) + "Assert EQ passed. " + msg + " Got (" +
+        _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")",
       true)
     true
 
@@ -342,16 +342,16 @@ class val TestHelper
 
       if (extra.size() != 0) or (missing.size() != 0) then
         fail(
-          _format_loc(loc) + "Assert EQ_UNORDERED failed. " + msg
-            + " Expected (" + _print_array[A](expect) + ") == ("
-            + _print_array[A](actual) + "):"
-            + "\nMissing: " + _print_array[box->A](missing)
-            + "\nExtra: " + _print_array[box->A](extra))
+          _format_loc(loc) + "Assert EQ_UNORDERED failed. " + msg +
+            " Expected (" + _print_array[A](expect) + ") == (" +
+            _print_array[A](actual) + "):" +
+            "\nMissing: " + _print_array[box->A](missing) +
+            "\nExtra: " + _print_array[box->A](extra))
         return false
       end
       log(
-        _format_loc(loc) + "Assert EQ_UNORDERED passed. " + msg + " Got ("
-          + _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")",
+        _format_loc(loc) + "Assert EQ_UNORDERED passed. " + msg + " Got (" +
+          _print_array[A](expect) + ") == (" + _print_array[A](actual) + ")",
         true)
       true
     else

--- a/packages/process/_process.pony
+++ b/packages/process/_process.pony
@@ -232,8 +232,8 @@ class _ProcessPosix is _Process
         @kill(pid, Sig.kill())
         var wstatus: I32 = 0
         while
-          (@waitpid(pid, addressof wstatus, 0) < 0)
-            and (@pony_os_errno() == _EINTR())
+          (@waitpid(pid, addressof wstatus, 0) < 0) and
+            (@pony_os_errno() == _EINTR())
         do
           None
         end
@@ -473,8 +473,8 @@ class _ProcessWindows is _Process
               | let wdir_str: String => wdir_str
               | None => "?"
               end
-            ProcessError(ChdirError, "Failed to change directory to "
-              + wdirpath)
+            ProcessError(ChdirError, "Failed to change directory to " +
+              wdirpath)
           else
             let message = String.from_cstring(error_message)
             ProcessError(ForkError, recover message.clone() end)

--- a/packages/process/_test.pony
+++ b/packages/process/_test.pony
@@ -672,8 +672,8 @@ class \nodoc\ _TestChdir is UnitTest
     let file_auth = FileAuth(h.env.root)
 
     let parent = Path.dir(Path.cwd())
-    let notifier: ProcessNotify iso = _ProcessClient(parent.size()
-      + (ifdef windows then 2 else 1 end), "", 0, h)
+    let notifier: ProcessNotify iso = _ProcessClient(parent.size() +
+      (ifdef windows then 2 else 1 end), "", 0, h)
 
     let path = FilePath(file_auth, _PwdPath())
     let args: Array[String] val = _PwdArgs()
@@ -1006,8 +1006,8 @@ class \nodoc\ _ProcessClient is ProcessNotify
       if actual.error_type is expected.error_type then
         _h.complete(true)
       else
-        _h.fail("Expected '" + expected.string() + "'; actual was '"
-          + actual.string() + "'")
+        _h.fail("Expected '" + expected.string() + "'; actual was '" +
+          actual.string() + "'")
       end
     else
       _h.fail(actual.string())
@@ -1315,8 +1315,8 @@ class \nodoc\ _ExpectDisposeClient is ProcessNotify
     if s == _expected then
       _h.complete(true)
     else
-      _h.fail("expected dispose(" + _expected.string() + "), got "
-        + s.string())
+      _h.fail("expected dispose(" + _expected.string() + "), got " +
+        s.string())
       _h.complete(false)
     end
 
@@ -1340,8 +1340,8 @@ class \nodoc\ _ExpectFailedClient is ProcessNotify
     if e.error_type is _expected then
       _h.complete(true)
     else
-      _h.fail("expected failed(" + _expected.string() + "), got "
-        + e.error_type.string())
+      _h.fail("expected failed(" + _expected.string() + "), got " +
+        e.error_type.string())
       _h.complete(false)
     end
 
@@ -1395,8 +1395,8 @@ class \nodoc\ iso _TestExitReportsExactlyOnce is UnitTest
     pm._test_trigger_exit()
     pm._test_trigger_exit()
     _Spy.settle_then_check(h, pm, recorder, {(r: _SpyResults): (Bool, String) =>
-      ((r.disposes == 1) and r.last_is(Exited(3)) and (not r.kill_after_reap)
-        and (not r.backpressure_applied),
+      ((r.disposes == 1) and r.last_is(Exited(3)) and (not r.kill_after_reap) and
+        (not r.backpressure_applied),
        "expected exactly one dispose of Exited(3), no kill after reap")
     })
     h.long_test(5_000_000_000)
@@ -1512,8 +1512,8 @@ class \nodoc\ iso _TestNoKillAfterReap is UnitTest
     pm._test_trigger_exit()
     pm.dispose()
     _Spy.settle_then_check(h, pm, recorder, {(r: _SpyResults): (Bool, String) =>
-      ((r.kills == 0) and (not r.kill_after_reap) and (r.disposes == 1)
-        and r.last_is(Exited(7)),
+      ((r.kills == 0) and (not r.kill_after_reap) and (r.disposes == 1) and
+        r.last_is(Exited(7)),
        "expected no kill after reap and exactly one dispose")
     })
     h.long_test(5_000_000_000)
@@ -1668,8 +1668,8 @@ actor \nodoc\ _FdLeakDriver
         // small margin for descriptors other packages' tests open while this
         // one runs in the same test binary.
         _h.assert_true(final_count <= (_baseline + 30),
-          "open fd count grew from " + _baseline.string() + " to "
-            + final_count.string() + " over " + _total.string() + " starts")
+          "open fd count grew from " + _baseline.string() + " to " +
+            final_count.string() + " over " + _total.string() + " starts")
         _h.complete(true)
       | None =>
         _h.fail("could not read /proc/self/fd")
@@ -1735,8 +1735,8 @@ class \nodoc\ _FailAndExitClient is ProcessNotify
     if err.error_type is _expected then
       _failed_fired = true
     else
-      _h.fail("expected " + _expected.string() + ", got "
-        + err.error_type.string())
+      _h.fail("expected " + _expected.string() + ", got " +
+        err.error_type.string())
       _h.complete(false)
     end
 
@@ -1751,7 +1751,7 @@ class \nodoc\ _FailAndExitClient is ProcessNotify
     match child_exit_status
     | Exited(_EXOSERR()) => _h.complete(true)
     else
-      _h.fail("expected Exited(" + _EXOSERR().string() + "), got "
-        + child_exit_status.string())
+      _h.fail("expected Exited(" + _EXOSERR().string() + "), got " +
+        child_exit_status.string())
       _h.complete(false)
     end

--- a/packages/process/process_monitor.pony
+++ b/packages/process/process_monitor.pony
@@ -37,16 +37,16 @@ primitive StartProcess
     // We need permission to execute and the file itself needs to be an
     // executable.
     if not path.caps(FileExec) then
-      return ProcessError(CapError, path.path
-        + " is not an executable or we do not have execute capability.")
+      return ProcessError(CapError, path.path +
+        " is not an executable or we do not have execute capability.")
     end
 
     let is_file = try FileInfo(path)?.file else false end
     if not is_file then
       // Unable to stat the path given, so it may not exist or may be a
       // directory.
-      return ProcessError(ExecutableNotFound, path.path
-        + " does not exist or is a directory.")
+      return ProcessError(ExecutableNotFound, path.path +
+        " does not exist or is a directory.")
     end
 
     // On Linux, exit detection uses a pidfd, which needs kernel >= 5.3. Probe

--- a/packages/signals/handleable_signal.pony
+++ b/packages/signals/handleable_signal.pony
@@ -45,27 +45,27 @@ primitive HandleableSignalValidator is Validator[U32]
 
   fun _is_handleable(sig: U32): Bool =>
     ifdef bsd or osx then
-      (sig == Sig.hup()) or (sig == Sig.int()) or (sig == Sig.quit())
-        or (sig == Sig.emt()) or (sig == Sig.pipe()) or (sig == Sig.alrm())
-        or (sig == Sig.term()) or (sig == Sig.urg()) or (sig == Sig.tstp())
-        or (sig == Sig.cont()) or (sig == Sig.chld()) or (sig == Sig.ttin())
-        or (sig == Sig.ttou()) or (sig == Sig.io()) or (sig == Sig.xcpu())
-        or (sig == Sig.xfsz()) or (sig == Sig.vtalrm()) or (sig == Sig.prof())
-        or (sig == Sig.winch()) or (sig == Sig.info()) or (sig == Sig.usr1())
-        or (sig == Sig.sys())
-        or _usr2_handleable(sig)
-        or _is_rt(sig)
+      (sig == Sig.hup()) or (sig == Sig.int()) or (sig == Sig.quit()) or
+        (sig == Sig.emt()) or (sig == Sig.pipe()) or (sig == Sig.alrm()) or
+        (sig == Sig.term()) or (sig == Sig.urg()) or (sig == Sig.tstp()) or
+        (sig == Sig.cont()) or (sig == Sig.chld()) or (sig == Sig.ttin()) or
+        (sig == Sig.ttou()) or (sig == Sig.io()) or (sig == Sig.xcpu()) or
+        (sig == Sig.xfsz()) or (sig == Sig.vtalrm()) or (sig == Sig.prof()) or
+        (sig == Sig.winch()) or (sig == Sig.info()) or (sig == Sig.usr1()) or
+        (sig == Sig.sys()) or
+        _usr2_handleable(sig) or
+        _is_rt(sig)
     elseif linux then
-      (sig == Sig.hup()) or (sig == Sig.int()) or (sig == Sig.quit())
-        or (sig == Sig.pipe()) or (sig == Sig.alrm()) or (sig == Sig.term())
-        or (sig == Sig.urg()) or (sig == Sig.stkflt()) or (sig == Sig.tstp())
-        or (sig == Sig.cont()) or (sig == Sig.chld()) or (sig == Sig.ttin())
-        or (sig == Sig.ttou()) or (sig == Sig.io()) or (sig == Sig.xcpu())
-        or (sig == Sig.xfsz()) or (sig == Sig.vtalrm()) or (sig == Sig.prof())
-        or (sig == Sig.winch()) or (sig == Sig.pwr()) or (sig == Sig.usr1())
-        or (sig == Sig.sys())
-        or _usr2_handleable(sig)
-        or _is_rt(sig)
+      (sig == Sig.hup()) or (sig == Sig.int()) or (sig == Sig.quit()) or
+        (sig == Sig.pipe()) or (sig == Sig.alrm()) or (sig == Sig.term()) or
+        (sig == Sig.urg()) or (sig == Sig.stkflt()) or (sig == Sig.tstp()) or
+        (sig == Sig.cont()) or (sig == Sig.chld()) or (sig == Sig.ttin()) or
+        (sig == Sig.ttou()) or (sig == Sig.io()) or (sig == Sig.xcpu()) or
+        (sig == Sig.xfsz()) or (sig == Sig.vtalrm()) or (sig == Sig.prof()) or
+        (sig == Sig.winch()) or (sig == Sig.pwr()) or (sig == Sig.usr1()) or
+        (sig == Sig.sys()) or
+        _usr2_handleable(sig) or
+        _is_rt(sig)
     elseif windows then
       // Only SIGINT and SIGTERM can be meaningfully handled through the
       // ASIO mechanism on Windows; the other signals the CRT knows

--- a/packages/term/_test.pony
+++ b/packages/term/_test.pony
@@ -98,9 +98,9 @@ class \nodoc\ _RecordNotify is ANSINotify
     _expected = expected
 
   fun _mods(ctrl: Bool, alt: Bool, shift: Bool): String =>
-    (if ctrl then "1" else "0" end)
-      + (if alt then "1" else "0" end)
-      + (if shift then "1" else "0" end)
+    (if ctrl then "1" else "0" end) +
+      (if alt then "1" else "0" end) +
+      (if shift then "1" else "0" end)
 
   fun ref apply(term: ANSITerm ref, input: U8) =>
     _got.push("byte " + input.string())

--- a/packages/time/timer.pony
+++ b/packages/time/timer.pony
@@ -121,7 +121,7 @@ class Timer
     Converts a wall-clock adjusted system time to absolute expiration time
     """
     let wall_now = Time.now()
-    Time.nanos()
-      + (((wall._1 * 1000000000) + wall._2)
-      - ((wall_now._1 * 1000000000) + wall_now._2)).u64()
+    Time.nanos() +
+      (((wall._1 * 1000000000) + wall._2) -
+      ((wall_now._1 * 1000000000) + wall_now._2)).u64()
 

--- a/test/full-program-runner/_build_process_notify.pony
+++ b/test/full-program-runner/_build_process_notify.pony
@@ -33,8 +33,8 @@ class iso _BuildProcessNotify is ProcessNotify
         if exited.exit_code() == 0 then
           _tester.building_succeeded()
         else
-          _tester.building_failed("exited with code "
-            + exited.exit_code().string())
+          _tester.building_failed("exited with code " +
+            exited.exit_code().string())
         end
       | let signaled: Signaled =>
         _tester.building_failed("signal " + signaled.signal().string())

--- a/test/full-program-runner/_colors.pony
+++ b/test/full-program-runner/_colors.pony
@@ -5,9 +5,9 @@ primitive _Colors
   fun none(): String => "\x1b[0m"
 
   fun info(msg: String, double: Bool = false): String =>
-    green()
-      + (if double then "[==========] " else "[----------] " end)
-      + none() + msg
+    green() +
+      (if double then "[==========] " else "[----------] " end) +
+      none() + msg
 
   fun warn(msg: String): String =>
     yellow() + "[----------] " + none() + msg

--- a/test/full-program-runner/_coordinator.pony
+++ b/test/full-program-runner/_coordinator.pony
@@ -151,8 +151,8 @@ actor _Coordinator is _TesterNotify
         _env.out.print(_Colors.pass(num_succeeded.string() + " test(s)."))
       end
       if num_failed > 0 then
-        _env.out.print(_Colors.fail(num_failed.string()
-          + " test(s), listed below:"))
+        _env.out.print(_Colors.fail(num_failed.string() +
+          " test(s), listed below:"))
         for (name, succeeded') in _success.pairs() do
           if not succeeded' then
             _env.out.print(_Colors.fail(name))

--- a/test/full-program-runner/_test_definitions.pony
+++ b/test/full-program-runner/_test_definitions.pony
@@ -106,8 +106,8 @@ class _TestDefinitions
 
     let fp = FilePath(auth, path)
     if not fp.exists() then
-      _err.print(_Colors.red() + path + ": path does not exist"
-        + _Colors.none())
+      _err.print(_Colors.red() + path + ": path does not exist" +
+        _Colors.none())
       return
     end
 
@@ -115,8 +115,8 @@ class _TestDefinitions
       try
         FileInfo(fp)?
       else
-        _err.print(_Colors.red() + path + ": unable to get file info"
-          + _Colors.none())
+        _err.print(_Colors.red() + path + ": unable to get file info" +
+          _Colors.none())
         return
       end
 
@@ -129,8 +129,8 @@ class _TestDefinitions
       try
         Directory(fp)?
       else
-        _err.print(_Colors.red() + path + ": unable to open directory"
-          + _Colors.none())
+        _err.print(_Colors.red() + path + ": unable to open directory" +
+          _Colors.none())
         return
       end
 
@@ -138,8 +138,8 @@ class _TestDefinitions
       try
         dir.entries()?
       else
-        _err.print(_Colors.red() + path + ": unable to get entries"
-          + _Colors.none())
+        _err.print(_Colors.red() + path + ": unable to get entries" +
+          _Colors.none())
         return
       end
 
@@ -155,11 +155,11 @@ class _TestDefinitions
     end
 
     if broken.size() > 0 then
-      _err.print(_Colors.red() + broken.size().string()
-        + " test(s) could not be configured; failing the run:" + _Colors.none())
+      _err.print(_Colors.red() + broken.size().string() +
+        " test(s) could not be configured; failing the run:" + _Colors.none())
       for bt in broken.values() do
-        _err.print(_Colors.red() + "  " + bt.name + ": " + bt.reason
-          + _Colors.none())
+        _err.print(_Colors.red() + "  " + bt.name + ": " + bt.reason +
+          _Colors.none())
       end
       return
     end

--- a/test/full-program-runner/_tester.pony
+++ b/test/full-program-runner/_tester.pony
@@ -272,8 +272,8 @@ actor _Tester
               if in_quote then
                 cur_arg.append(fragment)
                 if fragment(fragment.size() - 1)? == '"' then
-                  if (cur_arg(0)? == '"')
-                    and (cur_arg(cur_arg.size() - 1)? == '"')
+                  if (cur_arg(0)? == '"') and
+                    (cur_arg(cur_arg.size() - 1)? == '"')
                   then
                     let quoted: String val = cur_arg.clone()
                     ifdef windows then
@@ -369,9 +369,9 @@ actor _Tester
       if exit_code' == _definition.expected_exit_code then
         _shutdown_succeeded()
       else
-        _shutdown_failed("expected exit code "
-          + _definition.expected_exit_code.string() + "; actual was "
-          + exit_code'.string())
+        _shutdown_failed("expected exit code " +
+          _definition.expected_exit_code.string() + "; actual was " +
+          exit_code'.string())
       end
     end
 
@@ -382,8 +382,8 @@ actor _Tester
 
   be timeout() =>
     if (_stage is _Building) or (_stage is _Testing) then
-      _shutdown_failed("timed out after " + _options.timeout_s.string()
-        + " seconds")
+      _shutdown_failed("timed out after " + _options.timeout_s.string() +
+        " seconds")
     end
 
   be stdin_delay_over() =>
@@ -406,8 +406,8 @@ actor _Tester
       _end_ms = Time.millis()
       _notify.print(
         _definition.name,
-        _Colors.ok(_definition.name + " ("
-          + (_end_ms - _start_ms).string() + " ms)"))
+        _Colors.ok(_definition.name + " (" +
+          (_end_ms - _start_ms).string() + " ms)"))
       _timers.cancel(_timer)
       _cancel_stdin_timer()
       _stage = _Succeeded
@@ -420,8 +420,8 @@ actor _Tester
 
       _notify.print(
         _definition.name,
-        _Colors.fail(_definition.name + " ("
-          + (_end_ms - _start_ms).string() + " ms): " + msg))
+        _Colors.fail(_definition.name + " (" +
+          (_end_ms - _start_ms).string() + " ms): " + msg))
 
       match _build_process
       | let process: ProcessMonitor =>
@@ -452,12 +452,12 @@ actor _Tester
     if _out_buf.size() > 0 then
       _notify.print(
         _definition.name,
-        _definition.name + ": STDOUT:\n"
-          + recover val _out_buf.clone() end)
+        _definition.name + ": STDOUT:\n" +
+          recover val _out_buf.clone() end)
     end
     if _err_buf.size() > 0 then
       _notify.print(
         _definition.name,
-        _definition.name + ": STDERR\n"
-          + recover val _err_buf.clone() end)
+        _definition.name + ": STDERR\n" +
+          recover val _err_buf.clone() end)
     end

--- a/test/rt-stress/generative/main.pony
+++ b/test/rt-stress/generative/main.pony
@@ -232,10 +232,10 @@ actor Coordinator
 
     // Synchronous print so the result survives even though we do not force an
     // exit: env.out.print is async and could be lost if a later exit raced it.
-    let line = "RECEIVED=" + _total_received.string()
-      + " SENT=" + total_sent.string()
-      + " EXPECTED=" + expected.string()
-      + " ORDER_SIG=" + _sig.string() + "\n"
+    let line = "RECEIVED=" + _total_received.string() +
+      " SENT=" + total_sent.string() +
+      " EXPECTED=" + expected.string() +
+      " ORDER_SIG=" + _sig.string() + "\n"
     @printf("%s".cstring(), line.cstring())
 
     // On success: return and let the program reach natural
@@ -250,9 +250,9 @@ actor Coordinator
     // fast once a bug is detected rather than risk
     // quiescing a broken run.
     if not conserved then
-      let diag = "CONSERVATION FAILURE: received=" + _total_received.string()
-        + " sent=" + total_sent.string()
-        + " expected=" + expected.string() + "\n"
+      let diag = "CONSERVATION FAILURE: received=" + _total_received.string() +
+        " sent=" + total_sent.string() +
+        " expected=" + expected.string() + "\n"
       @fprintf(@pony_os_stderr(), "%s".cstring(), diag.cstring())
       @exit(I32(1))
     end
@@ -520,9 +520,9 @@ actor CyclicCollector
       // Synchronous print so the result survives natural quiescence (no SENT --
       // the garbage workers cannot be polled for a send tally; see module
       // docs).
-      let line = "RECEIVED=" + _received.string()
-        + " EXPECTED=" + _expected.string()
-        + " ORDER_SIG=" + _sig.string() + "\n"
+      let line = "RECEIVED=" + _received.string() +
+        " EXPECTED=" + _expected.string() +
+        " ORDER_SIG=" + _sig.string() + "\n"
       @printf("%s".cstring(), line.cstring())
     elseif _received > _expected then
       _Fatal("late/duplicate completion (received > expected)")
@@ -735,19 +735,19 @@ actor Consumer
 
     // Synchronous print so the result survives natural quiescence
     // (env.out.print is async and could be lost if a later exit raced it).
-    let line = "RECEIVED=" + _received.string()
-      + " SENT=" + _total_sent.string()
-      + " EXPECTED=" + _expected.string()
-      + " ORDER_SIG=" + _sig.string() + "\n"
+    let line = "RECEIVED=" + _received.string() +
+      " SENT=" + _total_sent.string() +
+      " EXPECTED=" + _expected.string() +
+      " ORDER_SIG=" + _sig.string() + "\n"
     @printf("%s".cstring(), line.cstring())
 
     // On success: return and let the program reach natural quiescence (no
     // forced exit), same as the mesh/cyclic. Only a conservation FAILURE forces
     // a non-zero exit: fail fast once a bug is detected.
     if not conserved then
-      let diag = "CONSERVATION FAILURE: received=" + _received.string()
-        + " sent=" + _total_sent.string()
-        + " expected=" + _expected.string() + "\n"
+      let diag = "CONSERVATION FAILURE: received=" + _received.string() +
+        " sent=" + _total_sent.string() +
+        " expected=" + _expected.string() + "\n"
       @fprintf(@pony_os_stderr(), "%s".cstring(), diag.cstring())
       @exit(I32(1))
     end
@@ -993,19 +993,19 @@ actor Dispatcher
 
     // Synchronous print so the result survives natural quiescence
     // (env.out.print is async and could be lost if a later exit raced it).
-    let line = "RECEIVED=" + _total_received.string()
-      + " SENT=" + total_sent.string()
-      + " EXPECTED=" + expected.string()
-      + " ORDER_SIG=" + _sig.string() + "\n"
+    let line = "RECEIVED=" + _total_received.string() +
+      " SENT=" + total_sent.string() +
+      " EXPECTED=" + expected.string() +
+      " ORDER_SIG=" + _sig.string() + "\n"
     @printf("%s".cstring(), line.cstring())
 
     // On success: return and let the program reach natural quiescence (no
     // forced exit), same as the other workloads. Only a conservation FAILURE
     // forces a non-zero exit: fail fast once a bug is detected.
     if not conserved then
-      let diag = "CONSERVATION FAILURE: received=" + _total_received.string()
-        + " sent=" + total_sent.string()
-        + " expected=" + expected.string() + "\n"
+      let diag = "CONSERVATION FAILURE: received=" + _total_received.string() +
+        " sent=" + total_sent.string() +
+        " expected=" + expected.string() + "\n"
       @fprintf(@pony_os_stderr(), "%s".cstring(), diag.cstring())
       @exit(I32(1))
     end
@@ -1220,19 +1220,19 @@ actor Referrer
 
     // Synchronous print so the result survives natural quiescence
     // (env.out.print is async and could be lost if a later exit raced it).
-    let line = "RECEIVED=" + _total_received.string()
-      + " SENT=" + total_sent.string()
-      + " EXPECTED=" + expected.string()
-      + " ORDER_SIG=" + _sig.string() + "\n"
+    let line = "RECEIVED=" + _total_received.string() +
+      " SENT=" + total_sent.string() +
+      " EXPECTED=" + expected.string() +
+      " ORDER_SIG=" + _sig.string() + "\n"
     @printf("%s".cstring(), line.cstring())
 
     // On success: return and let the program reach natural quiescence (no
     // forced exit), same as the other workloads. Only a conservation FAILURE
     // forces a non-zero exit: fail fast once a bug is detected.
     if not conserved then
-      let diag = "CONSERVATION FAILURE: received=" + _total_received.string()
-        + " sent=" + total_sent.string()
-        + " expected=" + expected.string() + "\n"
+      let diag = "CONSERVATION FAILURE: received=" + _total_received.string() +
+        " sent=" + total_sent.string() +
+        " expected=" + expected.string() + "\n"
       @fprintf(@pony_os_stderr(), "%s".cstring(), diag.cstring())
       @exit(I32(1))
     end
@@ -1400,9 +1400,9 @@ primitive _Cli
   fun spec(): CommandSpec ? =>
     CommandSpec.leaf(
       "generative",
-      "Generative runtime stress workload"
-        + " (driven by the orchestrate_*.py"
-        + " harnesses)",
+      "Generative runtime stress workload" +
+        " (driven by the orchestrate_*.py" +
+        " harnesses)",
       [
         OptionSpec.u64(
           "seed",
@@ -1410,73 +1410,73 @@ primitive _Cli
           where default' = 1)
         OptionSpec.string(
           "workload",
-          "workload kind: mesh | cyclic"
-            + " | backpressure | iso | actorref"
+          "workload kind: mesh | cyclic" +
+            " | backpressure | iso | actorref"
           where default' = "mesh")
         OptionSpec.u64(
           "pingers",
-          "mesh/iso/actorref only"
-            + " (ignored otherwise):"
-            + " number of mesh actors (>= 1)"
+          "mesh/iso/actorref only" +
+            " (ignored otherwise):" +
+            " number of mesh actors (>= 1)"
           where default' = 8)
         OptionSpec.u64(
           "generations",
-          "cyclic only (ignored otherwise):"
-            + " garbage-group generations"
-            + " (>= 1)"
+          "cyclic only (ignored otherwise):" +
+            " garbage-group generations" +
+            " (>= 1)"
           where default' = 1)
         OptionSpec.u64(
           "group",
-          "cyclic only (ignored otherwise):"
-            + " actors per garbage group"
-            + " (>= 2)"
+          "cyclic only (ignored otherwise):" +
+            " actors per garbage group" +
+            " (>= 2)"
           where default' = 2)
         OptionSpec.u64(
           "producers",
-          "backpressure only"
-            + " (ignored otherwise):"
-            + " flooding producers (>= 1)"
+          "backpressure only" +
+            " (ignored otherwise):" +
+            " flooding producers (>= 1)"
           where default' = 64)
         OptionSpec.u64(
           "messages",
-          "backpressure only"
-            + " (ignored otherwise):"
-            + " work msgs per producer (>= 1)"
+          "backpressure only" +
+            " (ignored otherwise):" +
+            " work msgs per producer (>= 1)"
           where default' = 1000)
         OptionSpec.u64(
           "apply-every",
-          "backpressure only"
-            + " (ignored otherwise):"
-            + " received msgs between"
-            + " apply/release toggles (>= 1)"
+          "backpressure only" +
+            " (ignored otherwise):" +
+            " received msgs between" +
+            " apply/release toggles (>= 1)"
           where default' = 200)
         OptionSpec.u64(
           "node-size",
-          "iso only (ignored otherwise):"
-            + " bytes per graph node array"
-            + " (>= 1)"
+          "iso only (ignored otherwise):" +
+            " bytes per graph node array" +
+            " (>= 1)"
           where default' = 64)
         OptionSpec.u64(
           "node-depth",
-          "iso only (ignored otherwise):"
-            + " graph nesting levels (>= 1)"
+          "iso only (ignored otherwise):" +
+            " graph nesting levels (>= 1)"
           where default' = 2)
         OptionSpec.u64(
           "node-breadth",
-          "iso only (ignored otherwise):"
-            + " child nodes per graph node"
+          "iso only (ignored otherwise):" +
+            " child nodes per graph node"
           where default' = 1)
         OptionSpec.u64(
           "chains",
-          "mesh/cyclic/iso/actorref only"
-            + " (ignored for backpressure):"
-            + " chains to inject (>= 1)"
+          "mesh/cyclic/iso/actorref only" +
+            " (ignored for backpressure):" +
+            " chains to inject (>= 1)"
           where default' = 8)
         OptionSpec.u64(
           "ttl",
-          "mesh/cyclic/iso/actorref only"
-            + " (ignored for backpressure):"
-            + " hops per chain"
+          "mesh/cyclic/iso/actorref only" +
+            " (ignored for backpressure):" +
+            " hops per chain"
           where default' = 16)
         OptionSpec.string(
           "payload",
@@ -1484,13 +1484,13 @@ primitive _Cli
           where default' = "string")
         OptionSpec.u64(
           "payload-size",
-          "string payload size in bytes"
-            + " (>= 1)"
+          "string payload size in bytes" +
+            " (>= 1)"
           where default' = 64)
         OptionSpec.string(
           "payload-mode",
-          "per-send payload allocation:"
-            + " forward | fresh"
+          "per-send payload allocation:" +
+            " forward | fresh"
           where default' = "forward")
       ])? .> add_help()?
 
@@ -1563,9 +1563,9 @@ primitive _Cli
         if chains < 1 then return "--chains must be >= 1" end
         _ActorRef(pingers, chains, ttl)
       else
-        return "bad --workload (expected 'mesh',"
-          + " 'cyclic', 'backpressure', 'iso'"
-          + " or 'actorref')"
+        return "bad --workload (expected 'mesh'," +
+          " 'cyclic', 'backpressure', 'iso'" +
+          " or 'actorref')"
       end
 
     _Config(seed, payload_string, payload_size, payload_fresh, workload)
@@ -1583,8 +1583,8 @@ primitive _Fatal
   one -- so the stress run fails loudly with a location rather than passing.
   """
   fun apply(msg: String, loc: SourceLoc = __loc) =>
-    let line = "FATAL: " + msg + " (" + loc.file() + ":"
-      + loc.line().string() + ")\n"
+    let line = "FATAL: " + msg + " (" + loc.file() + ":" +
+      loc.line().string() + ")\n"
     @fprintf(@pony_os_stderr(), "%s".cstring(), line.cstring())
     @exit(I32(1))
 
@@ -1599,7 +1599,7 @@ primitive _Unreachable
   should be impossible, not one the harness is built to catch.
   """
   fun apply(msg: String, loc: SourceLoc = __loc) =>
-    let line = "UNREACHABLE: " + msg + " (" + loc.file() + ":"
-      + loc.line().string() + ")\n"
+    let line = "UNREACHABLE: " + msg + " (" + loc.file() + ":" +
+      loc.line().string() + ")\n"
     @fprintf(@pony_os_stderr(), "%s".cstring(), line.cstring())
     @exit(I32(1))

--- a/test/rt-stress/suspend-drain/main.pony
+++ b/test/rt-stress/suspend-drain/main.pony
@@ -393,13 +393,13 @@ actor Main
               where default' = 524288)
             OptionSpec.u64(
               "min-schedulers",
-              "The floor phase 2 must reach; "
-                + "run with --ponyminthreads 1"
+              "The floor phase 2 must reach; " +
+                "run with --ponyminthreads 1"
               where default' = 1)
             OptionSpec.f64(
               "reclaim-fraction",
-              "Payload fraction that must "
-                + "return in phase 3"
+              "Payload fraction that must " +
+                "return in phase 3"
               where default' = 0.5)
           ],
           [])?

--- a/test/rt-stress/tcp-swarm/main.pony
+++ b/test/rt-stress/tcp-swarm/main.pony
@@ -251,8 +251,8 @@ actor Spawner
     @fflush(@pony_os_stdout())
 
   fun ref _refill() =>
-    while (_inflight < _config.concurrency)
-      and (_spawned < _config.connections)
+    while (_inflight < _config.concurrency) and
+      (_spawned < _config.connections)
     do
       TCPConnection(
         _connect_auth,
@@ -269,9 +269,9 @@ actor Spawner
     _try_finish()
 
   fun ref _try_finish() =>
-    if (not _finished)
-      and (_spawned >= _config.connections)
-      and (_inflight == 0)
+    if (not _finished) and
+      (_spawned >= _config.connections) and
+      (_inflight == 0)
     then
       _finished = true
       // A final heartbeat with the true completed count
@@ -296,9 +296,9 @@ actor Spawner
     // %zu (size_t) is the portable format for USize;
     // %lu is 32-bit on Windows.
     let fmt =
-      ("RESULT connections=%zu spawned=%zu "
-        + "completed=%zu failed=%zu "
-        + "verified=%zu mismatched=%zu\n")
+      ("RESULT connections=%zu spawned=%zu " +
+        "completed=%zu failed=%zu " +
+        "verified=%zu mismatched=%zu\n")
     @printf(
       fmt.cstring(),
       _config.connections,
@@ -317,9 +317,9 @@ actor Spawner
       let truncated =
         (_completed - _verified) - _mismatched
       let fail_fmt =
-        ("FAIL: %zu of %zu connections did not "
-          + "verify (connect_failed=%zu "
-          + "truncated=%zu mismatched=%zu)\n")
+        ("FAIL: %zu of %zu connections did not " +
+          "verify (connect_failed=%zu " +
+          "truncated=%zu mismatched=%zu)\n")
       @printf(
         fail_fmt.cstring(),
         _config.connections - _verified,

--- a/test/rt-systematic/acquire-release-order-signature/main.pony
+++ b/test/rt-systematic/acquire-release-order-signature/main.pony
@@ -88,8 +88,8 @@ actor Collector
       // env.out.print is async and would be lost on @exit, and the forced exit
       // sidesteps the separate shutdown-hang symptom. The signature is fully
       // computed first, so the determinism result is unaffected.
-      let line = "RECEIVED=" + _received.string()
-        + " ORDER_SIG=" + _sig.string() + "\n"
+      let line = "RECEIVED=" + _received.string() +
+        " ORDER_SIG=" + _sig.string() + "\n"
       @printf("%s".cstring(), line.cstring())
       @exit(0)
     end

--- a/test/rt-systematic/cycle-collection-order-signature/main.pony
+++ b/test/rt-systematic/cycle-collection-order-signature/main.pony
@@ -163,8 +163,8 @@ actor Collector
       // env.out.print is async and would be lost on @exit, and the forced exit
       // sidesteps the separate shutdown-hang symptom. The signature is fully
       // computed first, so the determinism result is unaffected.
-      let line = "RECEIVED=" + _received.string()
-        + " ORDER_SIG=" + _sig.string() + "\n"
+      let line = "RECEIVED=" + _received.string() +
+        " ORDER_SIG=" + _sig.string() + "\n"
       @printf("%s".cstring(), line.cstring())
       @exit(0)
     end

--- a/test/rt-systematic/mute-order-signature/main.pony
+++ b/test/rt-systematic/mute-order-signature/main.pony
@@ -81,8 +81,8 @@ actor Collector
       // env.out.print is async and would be lost on @exit, and the forced exit
       // sidesteps the separate shutdown-hang symptom. The signature is fully
       // computed first, so the determinism result is unaffected.
-      let line = "RECEIVED=" + _received.string()
-        + " ORDER_SIG=" + _sig.string() + "\n"
+      let line = "RECEIVED=" + _received.string() +
+        " ORDER_SIG=" + _sig.string() + "\n"
       @printf("%s".cstring(), line.cstring())
       @exit(0)
     end

--- a/test/rt-systematic/order-signature/main.pony
+++ b/test/rt-systematic/order-signature/main.pony
@@ -66,8 +66,8 @@ actor Collector
       // sidesteps the separate shutdown-hang symptom under
       // systematic testing. The signature is fully computed
       // before we exit, so the determinism result is unaffected.
-      let line = "RECEIVED=" + _received.string()
-        + " ORDER_SIG=" + _sig.string() + "\n"
+      let line = "RECEIVED=" + _received.string() +
+        " ORDER_SIG=" + _sig.string() + "\n"
       @printf("%s".cstring(), line.cstring())
       @exit(0)
     end

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/_symtab.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/_symtab.pony
@@ -152,8 +152,8 @@ class ref SymbolTable
   fun debug(): String val =>
     var s = recover val String() end
     for (name, definition) in this.iter() do
-      s = s + name + ": "
-        + definition.debug() + ", "
+      s = s + name + ": " +
+        definition.debug() + ", "
     end
     s
 

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
@@ -408,9 +408,9 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
       else
         ""
       end
-    TokenIds.string(id()) + value
-      + " @ " + line().string()
-      + ":" + pos().string() + source_file'
+    TokenIds.string(id()) + value +
+      " @ " + line().string() +
+      ":" + pos().string() + source_file'
 
   fun string(): String iso^ =>
     """

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/compiler.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/compiler.pony
@@ -65,8 +65,8 @@ primitive Compiler
           else
             recover val
               [ Error.message(
-                "Compilation failed but libponyc "
-                + "produced no error messages.")]
+                "Compilation failed but libponyc " +
+                "produced no error messages.")]
             end
           end
         else

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/definition_resolver.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/definition_resolver.pony
@@ -123,8 +123,8 @@ primitive DefinitionResolver
           let rhs = lhs.sibling() as AST
           Assert(
             rhs.id() == TokenIds.tk_id(),
-            "RHS not an ID, but "
-              + rhs.id().string())?
+            "RHS not an ID, but " +
+              rhs.id().string())?
           let rhs_id =
             rhs.token_value() as String
           _find_in_type(lhs_type, rhs_id, [])?

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/position.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/position.pony
@@ -35,8 +35,8 @@ class val Position is (Comparable[Position] & Hashable & Stringable)
     (_line == other._line) and (_column == other._column)
 
   fun lt(other: box->Position): Bool =>
-    (_line < other._line)
-      or ((_line == other._line) and (_column < other._column))
+    (_line < other._line) or
+      ((_line == other._line) and (_column < other._column))
 
   fun hash(): USize =>
     _line.hash() xor _column.hash() // TODO: better hashing support for Pony

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/token.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/token.pony
@@ -538,10 +538,10 @@ primitive TokenIds
 
     Lambdas are not included. Maybe they should.
     """
-    (token_id == this.tk_class())
-      or (token_id == this.tk_actor())
-      or (token_id == this.tk_primitive())
-      or (token_id == this.tk_struct())
-      or (token_id == this.tk_interface())
-      or (token_id == this.tk_trait())
-      or (token_id == this.tk_object())
+    (token_id == this.tk_class()) or
+      (token_id == this.tk_actor()) or
+      (token_id == this.tk_primitive()) or
+      (token_id == this.tk_struct()) or
+      (token_id == this.tk_interface()) or
+      (token_id == this.tk_trait()) or
+      (token_id == this.tk_object())

--- a/tools/lib/ponylang/pony_compiler/tests/main.pony
+++ b/tools/lib/ponylang/pony_compiler/tests/main.pony
@@ -214,15 +214,15 @@ class \nodoc\ iso _PositionIndexFind is UnitTest
               h.assert_eq[String val](
                 TokenIds.string(expected_token_id),
                 TokenIds.string(ast.id()),
-                "Found wrong node at "
-                  + line.string() + ":"
-                  + column.string() + ": "
-                  + ast.debug())
+                "Found wrong node at " +
+                  line.string() + ":" +
+                  column.string() + ": " +
+                  ast.debug())
             | None =>
               h.fail(
-                "No AST node found at "
-                  + line.string() + ":"
-                  + column.string())
+                "No AST node found at " +
+                  line.string() + ":" +
+                  column.string())
               return
             end
 
@@ -340,18 +340,18 @@ class \nodoc\ _DefinitionTest is UnitTest
                 ast.definitions()
               if definitions.size() == 0 then
                 h.fail(
-                  "No definition for node: "
-                    + ast.debug())
+                  "No definition for node: " +
+                    ast.debug())
                 return
               end
               h.assert_eq[USize](
                 definitions.size(),
                 expected_def_positions.size(),
-                "Expected to find "
-                  + expected_def_positions
-                    .size().string()
-                  + " definitions, found: "
-                  + definitions.size().string())
+                "Expected to find " +
+                  expected_def_positions
+                    .size().string() +
+                  " definitions, found: " +
+                  definitions.size().string())
               let iter =
                 Iter[Position](
                   expected_def_positions.values())
@@ -362,8 +362,8 @@ class \nodoc\ _DefinitionTest is UnitTest
                 h.assert_eq[Position](
                   expected_def_pos,
                   definition.position(),
-                  "Definition at wrong position "
-                    + definition.debug())
+                  "Definition at wrong position " +
+                    definition.debug())
                 h.assert_eq[String val](
                   TokenIds.string(
                     expected_def_token_id),
@@ -372,8 +372,8 @@ class \nodoc\ _DefinitionTest is UnitTest
               end
             | None =>
               h.fail(
-                "No AST node found at "
-                  + ref_pos.string())
+                "No AST node found at " +
+                  ref_pos.string())
               return
             end
 
@@ -504,8 +504,8 @@ class \nodoc\ _CompileErrorTest is UnitTest
         "compile_errors_02",
         [
           ("main.pony", Position(5, 17),
-            "this parameter must be sendable"
-              + " (iso, val or tag)")
+            "this parameter must be sendable" +
+              " (iso, val or tag)")
         ])
       _ExpectedCompileErrors(
         "compile_errors_03",
@@ -515,8 +515,8 @@ class \nodoc\ _CompileErrorTest is UnitTest
           ("main.pony", Position(6, 5),
             "can't find declaration of 'foo'")
           ("main.pony", Position(6, 9),
-            "left side must be something"
-              + " that can be assigned to")
+            "left side must be something" +
+              " that can be assigned to")
         ])
       _ExpectedCompileErrors(
         "compile_errors_04",
@@ -550,17 +550,17 @@ class \nodoc\ _CompileErrorTest is UnitTest
         [pony_path] where limit = PassFinaliser)
       | let p: Program =>
         h.fail(
-          "Program successfully compiled,"
-            + " although we expected it to fail")
+          "Program successfully compiled," +
+            " although we expected it to fail")
       | let e: Array[Error] val =>
         h.assert_eq[USize](
           e.size(),
           expected_errs.expected_errors.size(),
-          "Expected "
-            + expected_errs
-              .expected_errors.size().string()
-            + " Errors, got "
-            + e.size().string())
+          "Expected " +
+            expected_errs
+              .expected_errors.size().string() +
+            " Errors, got " +
+            e.size().string())
         for i in Range(0, e.size()) do
           let err = e(i)?
           (let expected_file,
@@ -573,26 +573,26 @@ class \nodoc\ _CompileErrorTest is UnitTest
           h.assert_eq[String](
             Path.base(err.file as String),
             expected_file,
-            "Error file "
-              + (err.file as String)
-              + " does not match expected file "
-              + expected_file)
+            "Error file " +
+              (err.file as String) +
+              " does not match expected file " +
+              expected_file)
           h.assert_eq[Position](
             err.position,
             expected_position,
-            "Error position "
-              + err.position.string()
-              + " does not match expected "
-              + "position "
-              + expected_position.string())
+            "Error position " +
+              err.position.string() +
+              " does not match expected " +
+              "position " +
+              expected_position.string())
           h.assert_eq[String](
             err.msg,
             expected_message,
-            "Error message \""
-              + err.msg
-              + "\" doesn't match expected "
-              + "message \""
-              + expected_message + "\"")
+            "Error message \"" +
+              err.msg +
+              "\" doesn't match expected " +
+              "message \"" +
+              expected_message + "\"")
         end
       end
     end

--- a/tools/pony-doc/_assets.pony
+++ b/tools/pony-doc/_assets.pony
@@ -7,9 +7,9 @@ primitive _Assets
     """
     CSS for the ponylang MkDocs color scheme.
     """
-    "[data-md-color-scheme=\"ponylang\"] {\n"
-      + "  --md-typeset-a-color: var(--md-primary-fg-color);\n"
-      + "}"
+    "[data-md-color-scheme=\"ponylang\"] {\n" +
+      "  --md-typeset-a-color: var(--md-primary-fg-color);\n" +
+      "}"
 
   fun logo(): Array[U8] val =>
     """

--- a/tools/pony-doc/extractor.pony
+++ b/tools/pony-doc/extractor.pony
@@ -374,8 +374,8 @@ primitive Extractor
         result.push(_TypeExtractor(child, package_map))
       end
       // If provides has no children but is itself a type, extract it
-      if (result.size() == 0)
-        and (provides_node.id() != ast.TokenIds.tk_provides())
+      if (result.size() == 0) and
+        (provides_node.id() != ast.TokenIds.tk_provides())
       then
         result.push(_TypeExtractor(provides_node, package_map))
       end
@@ -494,8 +494,8 @@ primitive Extractor
 
       // Cap — only for fun and new (not be)
       let cap: (String | None) =
-        if (method_ast.id() == ast.TokenIds.tk_fun())
-          or (method_ast.id() == ast.TokenIds.tk_new())
+        if (method_ast.id() == ast.TokenIds.tk_fun()) or
+          (method_ast.id() == ast.TokenIds.tk_new())
         then
           _TypeExtractor.get_cap(method_ast(0)?)
         else
@@ -509,8 +509,8 @@ primitive Extractor
 
       // Return type — only for fun and new
       let return_type: (DocType | None) =
-        if (method_ast.id() == ast.TokenIds.tk_fun())
-          or (method_ast.id() == ast.TokenIds.tk_new())
+        if (method_ast.id() == ast.TokenIds.tk_fun()) or
+          (method_ast.id() == ast.TokenIds.tk_new())
         then
           let ret_node = method_ast(4)?
           if ret_node.id() != ast.TokenIds.tk_none() then
@@ -630,8 +630,8 @@ primitive Extractor
       try
         var j = i
         while (j > 0) and
-          (NameSort.compare(entities(j)?.name, entities(j - 1)?.name)
-            is Less)
+          (NameSort.compare(
+            entities(j)?.name, entities(j - 1)?.name) is Less)
         do
           let tmp = entities(j)?
           entities(j)? = entities(j - 1)?

--- a/tools/pony-doc/main.pony
+++ b/tools/pony-doc/main.pony
@@ -94,8 +94,8 @@ actor Main
       try
         MkDocsBackend.generate(doc_program, output_fp, include_private)?
         env.out.print(
-          "Documentation generated in "
-            + output_dir_path + "/" + doc_program.name + "-docs/")
+          "Documentation generated in " +
+            output_dir_path + "/" + doc_program.name + "-docs/")
       else
         env.err.print("error: failed to write documentation output")
         env.exitcode(1)

--- a/tools/pony-doc/mk_docs_backend.pony
+++ b/tools/pony-doc/mk_docs_backend.pony
@@ -135,8 +135,8 @@ primitive MkDocsBackend is Backend
           _write_source_page(src_dir, sanitized_pkg, sf)?
 
           source_entries.push(
-            "  - " + sf.filename + " : \""
-              + _source_doc_path(sanitized_pkg, sf.filename) + "\" \n")
+            "  - " + sf.filename + " : \"" +
+              _source_doc_path(sanitized_pkg, sf.filename) + "\" \n")
         end
       end
     end

--- a/tools/pony-doc/test/_test_type_renderer.pony
+++ b/tools/pony-doc/test/_test_type_renderer.pony
@@ -549,8 +549,8 @@ class \nodoc\ _TestRenderProvides is UnitTest
         "\n",
         doc.MkDocsLinkFormat,
         false),
-      "* [Stringable](builtin-Stringable.md)"
-        + "\n* [Hashable](collections-Hashable.md)\n")
+      "* [Stringable](builtin-Stringable.md)" +
+        "\n* [Hashable](collections-Hashable.md)\n")
 
     // Without links
     h.assert_eq[String](

--- a/tools/pony-doc/type_renderer.pony
+++ b/tools/pony-doc/type_renderer.pony
@@ -158,8 +158,8 @@ primitive TypeRenderer
 
     match format
     | let f: LinkFormat if
-        (not n.is_anonymous)
-          and (include_private or (not n.is_private))
+        (not n.is_anonymous) and
+          (include_private or (not n.is_private))
     =>
       result.append(f.link(n.name, n.tqfn))
       // Type args with format-specific brackets and links

--- a/tools/pony-lint/_ast_dispatcher.pony
+++ b/tools/pony-lint/_ast_dispatcher.pony
@@ -17,8 +17,8 @@ class ref _MaxLineVisitor is ast.ASTVisitor
     // Empty TK_MEMBERS has a parser-assigned position beyond the entity's
     // actual content (at the start of the next entity). Skip it so it
     // doesn't inflate end_line.
-    if (node.id() == ast.TokenIds.tk_members())
-      and (node.num_children() == 0)
+    if (node.id() == ast.TokenIds.tk_members()) and
+      (node.num_children() == 0)
     then
       return ast.Continue
     end
@@ -117,8 +117,8 @@ class ref _ASTDispatcher is ast.ASTVisitor
     let token_id = node.id()
 
     // Collect entity info for file-naming and blank-lines
-    if ast.TokenIds.is_entity(token_id)
-      or (token_id == ast.TokenIds.tk_type())
+    if ast.TokenIds.is_entity(token_id) or
+      (token_id == ast.TokenIds.tk_type())
     then
       try
         let name_node = node(0)?

--- a/tools/pony-lint/acronym_casing.pony
+++ b/tools/pony-lint/acronym_casing.pony
@@ -37,8 +37,8 @@ primitive AcronymCasing is ASTRule
           return recover val
             [ Diagnostic(
               id(),
-              "acronym '" + acronym + "' in '" + name
-                + "' should be fully uppercased",
+              "acronym '" + acronym + "' in '" + name +
+                "' should be fully uppercased",
               source.rel_path,
               name_node.line(),
               name_node.pos())]

--- a/tools/pony-lint/array_literal_format.pony
+++ b/tools/pony-lint/array_literal_format.pony
@@ -51,8 +51,8 @@ primitive ArrayLiteralFormat is ASTRule
       if not _is_first_nonws(line_text, open_col) then
         diags.push(Diagnostic(
           id(),
-          "opening '[' of multiline array must be the first"
-            + " non-whitespace on its line",
+          "opening '[' of multiline array must be the first" +
+            " non-whitespace on its line",
           source.rel_path,
           open_line,
           open_col))

--- a/tools/pony-lint/blank_lines.pony
+++ b/tools/pony-lint/blank_lines.pony
@@ -209,14 +209,14 @@ primitive BlankLines is ASTRule
     None
 
   fun _is_field(token_id: ast.TokenId): Bool =>
-    (token_id == ast.TokenIds.tk_flet())
-      or (token_id == ast.TokenIds.tk_fvar())
-      or (token_id == ast.TokenIds.tk_embed())
+    (token_id == ast.TokenIds.tk_flet()) or
+      (token_id == ast.TokenIds.tk_fvar()) or
+      (token_id == ast.TokenIds.tk_embed())
 
   fun _is_method(token_id: ast.TokenId): Bool =>
-    (token_id == ast.TokenIds.tk_fun())
-      or (token_id == ast.TokenIds.tk_new())
-      or (token_id == ast.TokenIds.tk_be())
+    (token_id == ast.TokenIds.tk_fun()) or
+      (token_id == ast.TokenIds.tk_new()) or
+      (token_id == ast.TokenIds.tk_be())
 
   fun _max_line(node: ast.AST box): USize =>
     """

--- a/tools/pony-lint/call_argument_format.pony
+++ b/tools/pony-lint/call_argument_format.pony
@@ -25,8 +25,8 @@ primitive CallArgumentFormat is ASTRule
   fun category(): String val => "style"
 
   fun description(): String val =>
-    "multiline call argument formatting"
-      + " (argument layout and placement)"
+    "multiline call argument formatting" +
+      " (argument layout and placement)"
 
   fun default_status(): RuleStatus => RuleOn
 
@@ -93,8 +93,8 @@ primitive CallArgumentFormat is ASTRule
       if arg_line == open_line then
         diags.push(Diagnostic(
           id(),
-          "in a multiline call, arguments should start"
-            + " on the line after '('",
+          "in a multiline call, arguments should start" +
+            " on the line after '('",
           source.rel_path,
           open_line,
           open_col))
@@ -107,8 +107,8 @@ primitive CallArgumentFormat is ASTRule
     if (distinct != 1) and (distinct != arg_lines.size()) then
       diags.push(Diagnostic(
         id(),
-        "multiline call arguments must all be on one line"
-          + " or each on its own line",
+        "multiline call arguments must all be on one line" +
+          " or each on its own line",
         source.rel_path,
         open_line,
         open_col))

--- a/tools/pony-lint/comment_spacing.pony
+++ b/tools/pony-lint/comment_spacing.pony
@@ -55,8 +55,8 @@ primitive CommentSpacing is TextRule
     let size = line.size()
     while (i + 2) < size do
       try
-        if (line(i)? == '"') and (line(i + 1)? == '"')
-          and (line(i + 2)? == '"')
+        if (line(i)? == '"') and (line(i + 1)? == '"') and
+          (line(i + 2)? == '"')
         then
           count = count + 1
           i = i + 3

--- a/tools/pony-lint/config.pony
+++ b/tools/pony-lint/config.pony
@@ -263,8 +263,8 @@ primitive ConfigLoader
     if size > _max_config_size() then
       file.dispose()
       return ConfigError(
-        "config file too large (" + size.string() + " bytes, max "
-          + _max_config_size().string() + "): " + fp.path)
+        "config file too large (" + size.string() + " bytes, max " +
+          _max_config_size().string() + "): " + fp.path)
     end
     let content: String val = file.read_string(size)
     file.dispose()
@@ -314,8 +314,8 @@ primitive ConfigLoader
             result(key) = RuleOff
           else
             return ConfigError(
-              "invalid rule status '" + s + "' for '" + key
-                + "': must be \"on\" or \"off\"")
+              "invalid rule status '" + s + "' for '" + key +
+                "': must be \"on\" or \"off\"")
           end
         else
           return ConfigError(

--- a/tools/pony-lint/control_structure_alignment.pony
+++ b/tools/pony-lint/control_structure_alignment.pony
@@ -456,8 +456,8 @@ primitive ControlStructureAlignment is ASTRule
     """
     Diagnostic(
       id(),
-      "'" + keyword + "' should align with '" + opening
-        + "' keyword (column " + expected_col.string() + ")",
+      "'" + keyword + "' should align with '" + opening +
+        "' keyword (column " + expected_col.string() + ")",
       file,
       line,
       actual_col)
@@ -601,8 +601,8 @@ primitive ControlStructureAlignment is ASTRule
     while i < line.size() do
       try
         let ch = line(i)?
-        if (ch == ' ') or (ch == '\t') or (ch == '(') or (ch == '\\')
-          or (ch == '"')
+        if (ch == ' ') or (ch == '\t') or (ch == '(') or (ch == '\\') or
+          (ch == '"')
         then
           break
         end
@@ -682,10 +682,10 @@ primitive ControlStructureAlignment is ASTRule
       try
         let ch = line(i)?
         if (ch != ' ') and (ch != '\t') then
-          return (((i + 2) < line.size())
-            and (ch == '"')
-            and (line(i + 1)? == '"')
-            and (line(i + 2)? == '"'))
+          return (((i + 2) < line.size()) and
+            (ch == '"') and
+            (line(i + 1)? == '"') and
+            (line(i + 2)? == '"'))
         end
       end
       i = i + 1
@@ -696,16 +696,16 @@ primitive ControlStructureAlignment is ASTRule
     """
     Check if a character can appear in a Pony identifier.
     """
-    ((ch >= 'a') and (ch <= 'z'))
-      or ((ch >= 'A') and (ch <= 'Z'))
-      or ((ch >= '0') and (ch <= '9'))
-      or (ch == '_')
+    ((ch >= 'a') and (ch <= 'z')) or
+      ((ch >= 'A') and (ch <= 'Z')) or
+      ((ch >= '0') and (ch <= '9')) or
+      (ch == '_')
 
   fun _is_block_opener(word: String val): Bool =>
     """
     Check if a word is a keyword that opens a block terminated by `end`.
     """
-    (word == "if") or (word == "ifdef") or (word == "iftype")
-      or (word == "while") or (word == "for") or (word == "try")
-      or (word == "match") or (word == "repeat") or (word == "with")
-      or (word == "recover") or (word == "object")
+    (word == "if") or (word == "ifdef") or (word == "iftype") or
+      (word == "while") or (word == "for") or (word == "try") or
+      (word == "match") or (word == "repeat") or (word == "with") or
+      (word == "recover") or (word == "object")

--- a/tools/pony-lint/diagnostic.pony
+++ b/tools/pony-lint/diagnostic.pony
@@ -77,8 +77,8 @@ class val Diagnostic is (Comparable[Diagnostic] & Stringable)
     end
 
   fun eq(that: box->Diagnostic): Bool =>
-    (file == that.file) and (line == that.line) and (column == that.column)
-      and (rule_id == that.rule_id) and (message == that.message)
+    (file == that.file) and (line == that.line) and (column == that.column) and
+      (rule_id == that.rule_id) and (message == that.message)
 
   fun lt(that: box->Diagnostic): Bool =>
     if file != that.file then

--- a/tools/pony-lint/docstring_format.pony
+++ b/tools/pony-lint/docstring_format.pony
@@ -39,9 +39,9 @@ primitive DocstringFormat is ASTRule
     """
     let token_id = node.id()
     let is_method =
-      (token_id == ast.TokenIds.tk_fun())
-        or (token_id == ast.TokenIds.tk_new())
-        or (token_id == ast.TokenIds.tk_be())
+      (token_id == ast.TokenIds.tk_fun()) or
+        (token_id == ast.TokenIds.tk_new()) or
+        (token_id == ast.TokenIds.tk_be())
 
     // Skip \nodoc\-annotated nodes
     if node.has_annotation("nodoc") then
@@ -187,8 +187,8 @@ primitive DocstringFormat is ASTRule
     let size = line.size()
     while (i + 3) <= size do
       try
-        if (line(i)? == '"') and (line(i + 1)? == '"')
-          and (line(i + 2)? == '"')
+        if (line(i)? == '"') and (line(i + 1)? == '"') and
+          (line(i + 2)? == '"')
         then
           return i
         end
@@ -241,8 +241,8 @@ primitive DocstringFormat is ASTRule
     while i < size do
       try
         let ch = line(i)?
-        if (ch == '"') and ((i + 3) <= size)
-          and (line(i + 1)? == '"') and (line(i + 2)? == '"')
+        if (ch == '"') and ((i + 3) <= size) and
+          (line(i + 1)? == '"') and (line(i + 2)? == '"')
         then
           if found_quote then
             // Two sets of """ on one line

--- a/tools/pony-lint/docstring_leading_blank.pony
+++ b/tools/pony-lint/docstring_leading_blank.pony
@@ -39,9 +39,9 @@ primitive DocstringLeadingBlank is ASTRule
     """
     let token_id = node.id()
     let is_method =
-      (token_id == ast.TokenIds.tk_fun())
-        or (token_id == ast.TokenIds.tk_new())
-        or (token_id == ast.TokenIds.tk_be())
+      (token_id == ast.TokenIds.tk_fun()) or
+        (token_id == ast.TokenIds.tk_new()) or
+        (token_id == ast.TokenIds.tk_be())
 
     // Skip \nodoc\-annotated nodes
     if node.has_annotation("nodoc") then
@@ -153,8 +153,8 @@ primitive DocstringLeadingBlank is ASTRule
     while i < size do
       try
         let ch = line(i)?
-        if (ch == '"') and ((i + 3) <= size)
-          and (line(i + 1)? == '"') and (line(i + 2)? == '"')
+        if (ch == '"') and ((i + 3) <= size) and
+          (line(i + 1)? == '"') and (line(i + 2)? == '"')
         then
           if found_quote then return false end
           found_quote = true

--- a/tools/pony-lint/file_naming.pony
+++ b/tools/pony-lint/file_naming.pony
@@ -75,8 +75,9 @@ primitive FileNaming is ASTRule
       recover val
         [ Diagnostic(
           id(),
-          "file '" + _filename_stem(source.path) + ".pony' should be named '"
-            + expected + ".pony' (principal type: " + principal + ")",
+          "file '" + _filename_stem(source.path) +
+            ".pony' should be named '" +
+            expected + ".pony' (principal type: " + principal + ")",
           source.rel_path,
           1,
           1)]
@@ -103,8 +104,8 @@ primitive FileNaming is ASTRule
     var trait_name: (String val | None) = None
     var non_trait_count: USize = 0
     for (name, token_id, _, _) in entities.values() do
-      if (token_id == ast.TokenIds.tk_trait())
-        or (token_id == ast.TokenIds.tk_interface())
+      if (token_id == ast.TokenIds.tk_trait()) or
+        (token_id == ast.TokenIds.tk_interface())
       then
         trait_name = name
       else

--- a/tools/pony-lint/glob_match.pony
+++ b/tools/pony-lint/glob_match.pony
@@ -38,8 +38,8 @@ primitive GlobMatch
     end
 
     // Leading **/
-    if (plen >= 3) and _is_star(p, ps) and _is_star(p, ps + 1)
-      and _is_slash(p, ps + 2)
+    if (plen >= 3) and _is_star(p, ps) and _is_star(p, ps + 1) and
+      _is_slash(p, ps + 2)
     then
       let rest = ps + 3
       // Try rest against the whole text
@@ -56,8 +56,8 @@ primitive GlobMatch
     end
 
     // Trailing /**
-    if (plen >= 3) and _is_slash(p, pe - 3) and _is_star(p, pe - 2)
-      and _is_star(p, pe - 1)
+    if (plen >= 3) and _is_slash(p, pe - 3) and _is_star(p, pe - 2) and
+      _is_star(p, pe - 1)
     then
       let prefix_end = pe - 3
       // Try prefix against text up to each / boundary; /** requires at least
@@ -75,8 +75,8 @@ primitive GlobMatch
     // Middle /**/
     var search = ps
     while (search + 3) < pe do
-      if _is_slash(p, search) and _is_star(p, search + 1)
-        and _is_star(p, search + 2) and _is_slash(p, search + 3)
+      if _is_slash(p, search) and _is_star(p, search + 1) and
+        _is_star(p, search + 2) and _is_slash(p, search + 3)
       then
         let left_end = search
         let right_start = search + 4

--- a/tools/pony-lint/ignore_matcher.pony
+++ b/tools/pony-lint/ignore_matcher.pony
@@ -112,8 +112,8 @@ class ref IgnoreMatcher
     if size > _max_ignore_file_size() then
       file.dispose()
       _errors.push((
-        "ignore file too large (" + size.string() + " bytes, max "
-          + _max_ignore_file_size().string() + "): " + file_path,
+        "ignore file too large (" + size.string() + " bytes, max " +
+          _max_ignore_file_size().string() + "): " + file_path,
         file_path))
       return
     end
@@ -197,8 +197,8 @@ class ref IgnoreMatcher
     if abs_path.at(base_dir) then
       let blen = base_dir.size()
       // Exact match or path continues with a separator
-      (abs_path.size() == blen)
-        or (try Path.is_sep(abs_path(blen)?) else false end)
+      (abs_path.size() == blen) or
+        (try Path.is_sep(abs_path(blen)?) else false end)
     else
       false
     end

--- a/tools/pony-lint/indentation_size.pony
+++ b/tools/pony-lint/indentation_size.pony
@@ -71,8 +71,8 @@ primitive IndentationSize is TextRule
     let size = line.size()
     while (i + 2) < size do
       try
-        if (line(i)? == '"') and (line(i + 1)? == '"')
-          and (line(i + 2)? == '"')
+        if (line(i)? == '"') and (line(i + 1)? == '"') and
+          (line(i + 2)? == '"')
         then
           count = count + 1
           i = i + 3

--- a/tools/pony-lint/lambda_spacing.pony
+++ b/tools/pony-lint/lambda_spacing.pony
@@ -32,11 +32,11 @@ primitive LambdaSpacing is ASTRule
     """
     let token = node.id()
     let is_bare =
-      (token == ast.TokenIds.tk_barelambda())
-        or (token == ast.TokenIds.tk_barelambdatype())
+      (token == ast.TokenIds.tk_barelambda()) or
+        (token == ast.TokenIds.tk_barelambdatype())
     let is_type =
-      (token == ast.TokenIds.tk_lambdatype())
-        or (token == ast.TokenIds.tk_barelambdatype())
+      (token == ast.TokenIds.tk_lambdatype()) or
+        (token == ast.TokenIds.tk_barelambdatype())
 
     let op_line = node.line()
     let op_col = node.pos()

--- a/tools/pony-lint/line_length.pony
+++ b/tools/pony-lint/line_length.pony
@@ -111,8 +111,8 @@ primitive LineLength is ASTRule
         end
 
         if byte == ' ' then
-          if in_word and (word_start_cp <= 80)
-            and ((cp_pos - 1) > 80)
+          if in_word and (word_start_cp <= 80) and
+            ((cp_pos - 1) > 80)
           then
             return true
           end
@@ -129,8 +129,8 @@ primitive LineLength is ASTRule
       i = i + 1
     end
 
-    in_word and (word_count <= 2)
-      and (word_start_cp <= 80) and (cp_pos > 80)
+    in_word and (word_count <= 2) and
+      (word_start_cp <= 80) and (cp_pos > 80)
 
 class ref _StringLiteralVisitor is ast.ASTVisitor
   """
@@ -205,9 +205,9 @@ class ref _StringLiteralVisitor is ast.ASTVisitor
 
     // Method docstrings
     let is_method =
-      (parent_id == ast.TokenIds.tk_fun())
-        or (parent_id == ast.TokenIds.tk_new())
-        or (parent_id == ast.TokenIds.tk_be())
+      (parent_id == ast.TokenIds.tk_fun()) or
+        (parent_id == ast.TokenIds.tk_new()) or
+        (parent_id == ast.TokenIds.tk_be())
 
     // Abstract method docstring at child 7
     if is_method and (idx == 7) then
@@ -219,9 +219,9 @@ class ref _StringLiteralVisitor is ast.ASTVisitor
       match parent.parent()
       | let grandparent: ast.AST =>
         let gp_id = grandparent.id()
-        if (gp_id == ast.TokenIds.tk_fun())
-          or (gp_id == ast.TokenIds.tk_new())
-          or (gp_id == ast.TokenIds.tk_be())
+        if (gp_id == ast.TokenIds.tk_fun()) or
+          (gp_id == ast.TokenIds.tk_new()) or
+          (gp_id == ast.TokenIds.tk_be())
         then
           return true
         end
@@ -243,9 +243,9 @@ class ref _StringLiteralVisitor is ast.ASTVisitor
       let line_text = _source.lines(l - 1)?
       let byte_offset = col - 1
       if (byte_offset + 2) < line_text.size() then
-        (line_text(byte_offset)? == '"')
-          and (line_text(byte_offset + 1)? == '"')
-          and (line_text(byte_offset + 2)? == '"')
+        (line_text(byte_offset)? == '"') and
+          (line_text(byte_offset + 1)? == '"') and
+          (line_text(byte_offset + 2)? == '"')
       else
         false
       end

--- a/tools/pony-lint/linter.pony
+++ b/tools/pony-lint/linter.pony
@@ -255,8 +255,8 @@ class val Linter
           let pkg_prefix: String val = pkg.dir + sep
           let kids = Array[_PackageInfo val]
           for other in all_pkgs.values() do
-            if (other.dir != pkg.dir)
-              and other.dir.at(pkg_prefix)
+            if (other.dir != pkg.dir) and
+              other.dir.at(pkg_prefix)
             then
               kids.push(other)
               child_dirs.set(other.dir)
@@ -1100,8 +1100,8 @@ class ref _FileCollector is WalkHandler
             if _matcher.is_ignored(full, entry, info.directory) then
               dir_entries.delete(i)?
             else
-              if info.file
-                and entry.at(".pony", entry.size().isize() - 5)
+              if info.file and
+                entry.at(".pony", entry.size().isize() - 5)
               then
                 _files.push(full)
               end

--- a/tools/pony-lint/match_case_indent.pony
+++ b/tools/pony-lint/match_case_indent.pony
@@ -48,8 +48,8 @@ primitive MatchCaseIndent is ASTRule
                 if case_col != match_col then
                   result.push(Diagnostic(
                     id(),
-                    "'|' should align with 'match' keyword (column "
-                      + match_col.string() + ")",
+                    "'|' should align with 'match' keyword (column " +
+                      match_col.string() + ")",
                     source.rel_path,
                     case_node.line(),
                     case_col))

--- a/tools/pony-lint/member_naming.pony
+++ b/tools/pony-lint/member_naming.pony
@@ -38,9 +38,9 @@ primitive MemberNaming is ASTRule
     // Methods: name is child 1
     // Fields, params, locals: name is child 0
     let name_idx: USize =
-      if (token_id == ast.TokenIds.tk_fun())
-        or (token_id == ast.TokenIds.tk_new())
-        or (token_id == ast.TokenIds.tk_be())
+      if (token_id == ast.TokenIds.tk_fun()) or
+        (token_id == ast.TokenIds.tk_new()) or
+        (token_id == ast.TokenIds.tk_be())
       then
         1
       else

--- a/tools/pony-lint/method_declaration_format.pony
+++ b/tools/pony-lint/method_declaration_format.pony
@@ -19,8 +19,8 @@ primitive MethodDeclarationFormat is ASTRule
   fun category(): String val => "style"
 
   fun description(): String val =>
-    "multiline method declaration formatting"
-      + " (parameter layout, return type and '=>' alignment)"
+    "multiline method declaration formatting" +
+      " (parameter layout, return type and '=>' alignment)"
 
   fun default_status(): RuleStatus => RuleOn
 
@@ -64,8 +64,8 @@ primitive MethodDeclarationFormat is ASTRule
                 if param_l == prev_line then
                   diags.push(Diagnostic(
                     id(),
-                    "each parameter should be on its own line"
-                      + " in a multiline declaration",
+                    "each parameter should be on its own line" +
+                      " in a multiline declaration",
                     source.rel_path,
                     param_l,
                     param_node.pos()))
@@ -94,9 +94,9 @@ primitive MethodDeclarationFormat is ASTRule
               if actual_col != expected_col then
                 diags.push(Diagnostic(
                   id(),
-                  "':' should align at column "
-                    + expected_col.string()
-                    + " (indented from '" + keyword_name + "')",
+                  "':' should align at column " +
+                    expected_col.string() +
+                    " (indented from '" + keyword_name + "')",
                   source.rel_path,
                   ret_line,
                   actual_col))
@@ -125,9 +125,9 @@ primitive MethodDeclarationFormat is ASTRule
                 if actual_col != keyword_col then
                   diags.push(Diagnostic(
                     id(),
-                    "'=>' should align with '" + keyword_name
-                      + "' keyword (column "
-                      + keyword_col.string() + ")",
+                    "'=>' should align with '" + keyword_name +
+                      "' keyword (column " +
+                      keyword_col.string() + ")",
                     source.rel_path,
                     scan_line,
                     actual_col))

--- a/tools/pony-lint/operator_spacing.pony
+++ b/tools/pony-lint/operator_spacing.pony
@@ -2,17 +2,22 @@ use ast = "pony_compiler"
 
 primitive OperatorSpacing is ASTRule
   """
-  Checks whitespace around operators per the style guide.
+  Checks whitespace and placement of operators per the style guide.
 
-  Binary operators require a space before and after. The `not` keyword requires
-  a space after; before `not`, either a space or a non-alphanumeric character
-  (e.g., `(`) is acceptable. Unary minus must NOT have a space after.
+  Binary operators require a space before and after, and belong at the end of
+  a line when an expression spans multiple lines. A binary operator at the
+  start of a continuation line is an error. The `not` keyword requires a space
+  after; before `not`, either a space or a non-alphanumeric character (e.g.,
+  `(`) is acceptable. Unary minus must not have a space after; at the start of
+  a line, `- expr` with a space is flagged because the parser treats `-` there
+  as negation, not subtraction.
   """
   fun id(): String val => "style/operator-spacing"
   fun category(): String val => "style"
 
   fun description(): String val =>
-    "binary operators need surrounding spaces; no space after unary '-'"
+    "binary operators need surrounding spaces and belong at line end," +
+      " not line start; no space after unary '-'"
 
   fun default_status(): RuleStatus => RuleOn
 
@@ -56,8 +61,8 @@ primitive OperatorSpacing is ASTRule
     unary minus, `not`, or a binary operator.
     """
     let token = node.id()
-    if (token == ast.TokenIds.tk_unary_minus())
-      or (token == ast.TokenIds.tk_unary_minus_tilde())
+    if (token == ast.TokenIds.tk_unary_minus()) or
+      (token == ast.TokenIds.tk_unary_minus_tilde())
     then
       _check_unary_minus(node, source, token)
     elseif token == ast.TokenIds.tk_not() then
@@ -73,9 +78,9 @@ primitive OperatorSpacing is ASTRule
     : Array[Diagnostic val] val
   =>
     """
-    Binary operators require a space before and after. The "before" check is
-    skipped when the operator is the first non-whitespace on its line
-    (continuation line). The "after" check is skipped at end-of-line.
+    Binary operators require a space before and after. A binary operator at
+    the start of a continuation line is an error; it belongs at the end of
+    the previous line.
     """
     let op_line = node.line()
     let op_col = node.pos()
@@ -85,8 +90,19 @@ primitive OperatorSpacing is ASTRule
       let starts_line = _is_first_nonws(line_text, op_col)
       let symbol = _op_symbol(token)
 
-      // Check character before operator
-      if (not starts_line) and (op_col > 1) then
+      if starts_line then
+        return recover val
+          [ Diagnostic(
+            id(),
+            "'" + symbol +
+              "' at start of line; move to end of previous line",
+            source.rel_path,
+            op_line,
+            op_col)]
+        end
+      end
+
+      if op_col > 1 then
         try
           if line_text((op_col - 2).usize())? != ' ' then
             return recover val
@@ -133,7 +149,9 @@ primitive OperatorSpacing is ASTRule
     : Array[Diagnostic val] val
   =>
     """
-    Unary minus must NOT have a space after the operator (`-` or `-~`).
+    Unary minus must not have a space after the operator (`-` or `-~`).
+    At the start of a line, `- expr` with a space is flagged with a specific
+    message: the parser treats `-` there as negation, not subtraction.
     """
     let op_line = node.line()
     let op_col = node.pos()
@@ -143,13 +161,22 @@ primitive OperatorSpacing is ASTRule
       if token == ast.TokenIds.tk_unary_minus_tilde() then "-~" else "-" end
     try
       let line_text = source.lines(op_line - 1)?
+      let starts_line = _is_first_nonws(line_text, op_col)
       let after_idx = ((op_col - 1) + width).usize()
       try
         if line_text(after_idx)? == ' ' then
+          let msg =
+            if starts_line then
+              "'" + symbol +
+                "' at start of line is negation, not subtraction;" +
+                " move to end of previous line"
+            else
+              "no space after unary '" + symbol + "'"
+            end
           return recover val
             [ Diagnostic(
               id(),
-              "no space after unary '" + symbol + "'",
+              consume msg,
               source.rel_path,
               op_line,
               op_col)]
@@ -230,55 +257,55 @@ primitive OperatorSpacing is ASTRule
     """
     Check if a character is alphanumeric or underscore.
     """
-    ((ch >= 'a') and (ch <= 'z'))
-      or ((ch >= 'A') and (ch <= 'Z'))
-      or ((ch >= '0') and (ch <= '9'))
-      or (ch == '_')
+    ((ch >= 'a') and (ch <= 'z')) or
+      ((ch >= 'A') and (ch <= 'Z')) or
+      ((ch >= '0') and (ch <= '9')) or
+      (ch == '_')
 
   fun _op_width(token: ast.TokenId): USize =>
     """
     Return the character width of the operator token.
     """
-    if (token == ast.TokenIds.tk_plus())
-      or (token == ast.TokenIds.tk_minus())
-      or (token == ast.TokenIds.tk_multiply())
-      or (token == ast.TokenIds.tk_divide())
-      or (token == ast.TokenIds.tk_rem())
-      or (token == ast.TokenIds.tk_lt())
-      or (token == ast.TokenIds.tk_gt())
-      or (token == ast.TokenIds.tk_assign())
-      or (token == ast.TokenIds.tk_unary_minus())
+    if (token == ast.TokenIds.tk_plus()) or
+      (token == ast.TokenIds.tk_minus()) or
+      (token == ast.TokenIds.tk_multiply()) or
+      (token == ast.TokenIds.tk_divide()) or
+      (token == ast.TokenIds.tk_rem()) or
+      (token == ast.TokenIds.tk_lt()) or
+      (token == ast.TokenIds.tk_gt()) or
+      (token == ast.TokenIds.tk_assign()) or
+      (token == ast.TokenIds.tk_unary_minus())
     then
       1
-    elseif (token == ast.TokenIds.tk_plus_tilde())
-      or (token == ast.TokenIds.tk_minus_tilde())
-      or (token == ast.TokenIds.tk_multiply_tilde())
-      or (token == ast.TokenIds.tk_divide_tilde())
-      or (token == ast.TokenIds.tk_rem_tilde())
-      or (token == ast.TokenIds.tk_mod())
-      or (token == ast.TokenIds.tk_lshift())
-      or (token == ast.TokenIds.tk_rshift())
-      or (token == ast.TokenIds.tk_eq())
-      or (token == ast.TokenIds.tk_ne())
-      or (token == ast.TokenIds.tk_le())
-      or (token == ast.TokenIds.tk_ge())
-      or (token == ast.TokenIds.tk_or())
-      or (token == ast.TokenIds.tk_is())
-      or (token == ast.TokenIds.tk_lt_tilde())
-      or (token == ast.TokenIds.tk_gt_tilde())
-      or (token == ast.TokenIds.tk_unary_minus_tilde())
+    elseif (token == ast.TokenIds.tk_plus_tilde()) or
+      (token == ast.TokenIds.tk_minus_tilde()) or
+      (token == ast.TokenIds.tk_multiply_tilde()) or
+      (token == ast.TokenIds.tk_divide_tilde()) or
+      (token == ast.TokenIds.tk_rem_tilde()) or
+      (token == ast.TokenIds.tk_mod()) or
+      (token == ast.TokenIds.tk_lshift()) or
+      (token == ast.TokenIds.tk_rshift()) or
+      (token == ast.TokenIds.tk_eq()) or
+      (token == ast.TokenIds.tk_ne()) or
+      (token == ast.TokenIds.tk_le()) or
+      (token == ast.TokenIds.tk_ge()) or
+      (token == ast.TokenIds.tk_or()) or
+      (token == ast.TokenIds.tk_is()) or
+      (token == ast.TokenIds.tk_lt_tilde()) or
+      (token == ast.TokenIds.tk_gt_tilde()) or
+      (token == ast.TokenIds.tk_unary_minus_tilde())
     then
       2
-    elseif (token == ast.TokenIds.tk_mod_tilde())
-      or (token == ast.TokenIds.tk_lshift_tilde())
-      or (token == ast.TokenIds.tk_rshift_tilde())
-      or (token == ast.TokenIds.tk_eq_tilde())
-      or (token == ast.TokenIds.tk_ne_tilde())
-      or (token == ast.TokenIds.tk_le_tilde())
-      or (token == ast.TokenIds.tk_ge_tilde())
-      or (token == ast.TokenIds.tk_not())
-      or (token == ast.TokenIds.tk_and())
-      or (token == ast.TokenIds.tk_xor())
+    elseif (token == ast.TokenIds.tk_mod_tilde()) or
+      (token == ast.TokenIds.tk_lshift_tilde()) or
+      (token == ast.TokenIds.tk_rshift_tilde()) or
+      (token == ast.TokenIds.tk_eq_tilde()) or
+      (token == ast.TokenIds.tk_ne_tilde()) or
+      (token == ast.TokenIds.tk_le_tilde()) or
+      (token == ast.TokenIds.tk_ge_tilde()) or
+      (token == ast.TokenIds.tk_not()) or
+      (token == ast.TokenIds.tk_and()) or
+      (token == ast.TokenIds.tk_xor())
     then
       3
     elseif token == ast.TokenIds.tk_isnt() then

--- a/tools/pony-lint/public_docstring.pony
+++ b/tools/pony-lint/public_docstring.pony
@@ -48,9 +48,9 @@ primitive PublicDocstring is ASTRule
     """
     let token_id = node.id()
     let is_method =
-      (token_id == ast.TokenIds.tk_fun())
-        or (token_id == ast.TokenIds.tk_new())
-        or (token_id == ast.TokenIds.tk_be())
+      (token_id == ast.TokenIds.tk_fun()) or
+        (token_id == ast.TokenIds.tk_new()) or
+        (token_id == ast.TokenIds.tk_be())
 
     // Skip \nodoc\-annotated nodes — excluded from documentation
     if node.has_annotation("nodoc") then
@@ -108,8 +108,8 @@ primitive PublicDocstring is ASTRule
           end
         else
           // Entity types: skip Main actors
-          if (token_id == ast.TokenIds.tk_actor())
-            and (name == "Main")
+          if (token_id == ast.TokenIds.tk_actor()) and
+            (name == "Main")
           then
             return recover val Array[Diagnostic val] end
           end

--- a/tools/pony-lint/suppressions.pony
+++ b/tools/pony-lint/suppressions.pony
@@ -174,8 +174,8 @@ class val Suppressions
       for (target, start_line) in active_offs.pairs() do
         errs.push(Diagnostic(
           "lint/unclosed-suppression",
-          "suppression for '" + target + "' opened at line "
-            + start_line.string() + " was never closed",
+          "suppression for '" + target + "' opened at line " +
+            start_line.string() + " was never closed",
           source.rel_path,
           start_line,
           1))

--- a/tools/pony-lint/test/_test_blank_lines.pony
+++ b/tools/pony-lint/test/_test_blank_lines.pony
@@ -452,8 +452,8 @@ class \nodoc\ _TestMaxLineVisitor is ast.ASTVisitor
   new ref create(seed: USize) => max_line = seed
 
   fun ref visit(node: ast.AST box): ast.VisitResult =>
-    if (node.id() == ast.TokenIds.tk_members())
-      and (node.num_children() == 0)
+    if (node.id() == ast.TokenIds.tk_members()) and
+      (node.num_children() == 0)
     then
       return ast.Continue
     end
@@ -489,8 +489,8 @@ class \nodoc\ _TestEntityCollector is ast.ASTVisitor
 
   fun ref visit(node: ast.AST box): ast.VisitResult =>
     let token_id = node.id()
-    if ast.TokenIds.is_entity(token_id)
-      or (token_id == ast.TokenIds.tk_type())
+    if ast.TokenIds.is_entity(token_id) or
+      (token_id == ast.TokenIds.tk_type())
     then
       try
         let name_node = node(0)?

--- a/tools/pony-lint/test/_test_diagnostic.pony
+++ b/tools/pony-lint/test/_test_diagnostic.pony
@@ -13,8 +13,8 @@ class \nodoc\ _TestDiagnosticString is UnitTest
         10,
         81)
     let expected: String val =
-      "src/main.pony:10:81: error[style/line-length]: "
-        + "line exceeds 80 columns (95)"
+      "src/main.pony:10:81: error[style/line-length]: " +
+        "line exceeds 80 columns (95)"
     h.assert_eq[String](expected, d.string())
 
 class \nodoc\ _TestDiagnosticStringSpecialChars is UnitTest

--- a/tools/pony-lint/test/_test_explain.pony
+++ b/tools/pony-lint/test/_test_explain.pony
@@ -19,8 +19,8 @@ class \nodoc\ _TestExplainFormatEnabled is UnitTest
         "no spaces around '.'; '.>' spaced as infix operator"))
     h.assert_true(
       output.contains(
-        "https://www.ponylang.io/use/linting/rule-reference/"
-          + "#styledot-spacing"))
+        "https://www.ponylang.io/use/linting/rule-reference/" +
+          "#styledot-spacing"))
 
 class \nodoc\ _TestExplainFormatDisabled is UnitTest
   """Verify format output for a disabled-by-default rule."""

--- a/tools/pony-lint/test/_test_glob_match.pony
+++ b/tools/pony-lint/test/_test_glob_match.pony
@@ -194,8 +194,8 @@ class \nodoc\ _TestGlobMatchStarNoCrossSlashProperty is Property1[String]
     ph.assert_eq[Bool](
       expected,
       lint.GlobMatch.matches("*", arg1),
-      "* vs '" + arg1 + "': expected "
-        + if expected then "match" else "no match" end)
+      "* vs '" + arg1 + "': expected " +
+        if expected then "match" else "no match" end)
 
 class \nodoc\ _TestGlobMatchDoubleStarMatchesAllProperty is Property1[String]
   """** matches every string."""

--- a/tools/pony-lint/test/_test_operator_spacing.pony
+++ b/tools/pony-lint/test/_test_operator_spacing.pony
@@ -160,9 +160,11 @@ class \nodoc\ _TestOperatorSpacingUnaryMinusClean is UnitTest
       h.fail("compilation failed")
     end
 
-class \nodoc\ _TestOperatorSpacingUnaryMinusSpaceViolation is UnitTest
-  """Unary minus with space after is flagged."""
-  fun name(): String => "OperatorSpacing: '- a' flagged"
+class \nodoc\ _TestOperatorSpacingUnaryMinusStartOfLineViolation is UnitTest
+  """Unary minus with space at start of line gets negation-specific message."""
+  fun name(): String =>
+    "OperatorSpacing: '- a' at start of line flagged as negation"
+
   fun exclusion_group(): String => "ast-compile"
 
   fun apply(h: TestHelper) =>
@@ -171,6 +173,43 @@ class \nodoc\ _TestOperatorSpacingUnaryMinusSpaceViolation is UnitTest
       "  fun apply(): I32 =>\n" +
       "    let a: I32 = 5\n" +
       "    - a\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.OperatorSpacing)
+          h.assert_true(diags.size() > 0)
+          try
+            h.assert_true(
+              diags(0)?.message.contains("negation"))
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestOperatorSpacingUnaryMinusSpaceMidLine is UnitTest
+  """Unary minus with space mid-line gets the standard spacing message."""
+  fun name(): String =>
+    "OperatorSpacing: '(- a)' mid-line flagged"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun apply(): I32 =>\n" +
+      "    let a: I32 = 5\n" +
+      "    1 + (- a)\n"
     try
       (let program, let sf) = _ASTTestHelper.compile(h, source)?
       match program.package()
@@ -557,10 +596,10 @@ class \nodoc\ _TestOperatorSpacingStyleGuideExample is UnitTest
       h.fail("compilation failed")
     end
 
-class \nodoc\ _TestOperatorSpacingContinuationLineClean is UnitTest
-  """Operator at start of continuation line is clean (before-check exempt)."""
+class \nodoc\ _TestOperatorSpacingContinuationLineViolation is UnitTest
+  """Operator at start of continuation line is flagged."""
   fun name(): String =>
-    "OperatorSpacing: continuation line is clean"
+    "OperatorSpacing: continuation line flagged"
 
   fun exclusion_group(): String => "ast-compile"
 
@@ -570,6 +609,80 @@ class \nodoc\ _TestOperatorSpacingContinuationLineClean is UnitTest
       "  fun apply(x: U32, y: U32): U32 =>\n" +
       "    x\n" +
       "      + y\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.OperatorSpacing)
+          h.assert_true(diags.size() > 0)
+          try
+            h.assert_true(
+              diags(0)?.message.contains("start of line"))
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestOperatorSpacingKeywordContinuationViolation is UnitTest
+  """Keyword operator at start of continuation line is flagged."""
+  fun name(): String =>
+    "OperatorSpacing: keyword continuation flagged"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "primitive Foo\n" +
+      "  fun apply(x: Bool, y: Bool): Bool =>\n" +
+      "    x\n" +
+      "      and y\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.OperatorSpacing)
+          h.assert_true(diags.size() > 0)
+          try
+            h.assert_true(
+              diags(0)?.message.contains("start of line"))
+          else
+            h.fail("could not access diagnostic")
+          end
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
+class \nodoc\ _TestOperatorSpacingEndOfLineClean is UnitTest
+  """Operator at end of line with operand on next line is clean."""
+  fun name(): String =>
+    "OperatorSpacing: operator at end of line is clean"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "primitive Foo\n" +
+      "  fun apply(x: U32, y: U32): U32 =>\n" +
+      "    x +\n" +
+      "      y\n"
     try
       (let program, let sf) = _ASTTestHelper.compile(h, source)?
       match program.package()

--- a/tools/pony-lint/test/_test_suppression.pony
+++ b/tools/pony-lint/test/_test_suppression.pony
@@ -7,11 +7,11 @@ class \nodoc\ _TestSuppressionOffOn is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "line 1\n"
-      + "// pony-lint: off style/line-length\n"
-      + "line 3\n"
-      + "// pony-lint: on style/line-length\n"
-      + "line 5\n"
+      "line 1\n" +
+      "// pony-lint: off style/line-length\n" +
+      "line 3\n" +
+      "// pony-lint: on style/line-length\n" +
+      "line 5\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_false(sup.is_suppressed(1, "style/line-length"))
@@ -25,11 +25,11 @@ class \nodoc\ _TestSuppressionOffOnAll is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "line 1\n"
-      + "// pony-lint: off\n"
-      + "line 3\n"
-      + "// pony-lint: on\n"
-      + "line 5\n"
+      "line 1\n" +
+      "// pony-lint: off\n" +
+      "line 3\n" +
+      "// pony-lint: on\n" +
+      "line 5\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_false(sup.is_suppressed(1, "style/line-length"))
@@ -44,10 +44,10 @@ class \nodoc\ _TestSuppressionAllow is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "line 1\n"
-      + "// pony-lint: allow style/line-length\n"
-      + "line 3\n"
-      + "line 4\n"
+      "line 1\n" +
+      "// pony-lint: allow style/line-length\n" +
+      "line 3\n" +
+      "line 4\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_false(sup.is_suppressed(1, "style/line-length"))
@@ -61,9 +61,9 @@ class \nodoc\ _TestSuppressionCategory is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "// pony-lint: off style\n"
-      + "line 2\n"
-      + "// pony-lint: on style\n"
+      "// pony-lint: off style\n" +
+      "line 2\n" +
+      "// pony-lint: on style\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_true(sup.is_suppressed(2, "style/line-length"))
@@ -77,10 +77,10 @@ class \nodoc\ _TestSuppressionRuleOverridesCategory is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "// pony-lint: off style\n"
-      + "// pony-lint: on style/line-length\n"
-      + "line 3\n"
-      + "// pony-lint: on style\n"
+      "// pony-lint: off style\n" +
+      "// pony-lint: on style/line-length\n" +
+      "line 3\n" +
+      "// pony-lint: on style\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_false(sup.is_suppressed(3, "style/line-length"))
@@ -93,8 +93,8 @@ class \nodoc\ _TestSuppressionUnclosed is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "// pony-lint: off style/line-length\n"
-      + "line 2\n"
+      "// pony-lint: off style/line-length\n" +
+      "line 2\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_eq[USize](1, sup.errors().size())
@@ -111,9 +111,9 @@ class \nodoc\ _TestSuppressionDuplicateOff is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "// pony-lint: off style/line-length\n"
-      + "// pony-lint: off style/line-length\n"
-      + "// pony-lint: on style/line-length\n"
+      "// pony-lint: off style/line-length\n" +
+      "// pony-lint: off style/line-length\n" +
+      "// pony-lint: on style/line-length\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     var found_malformed = false
@@ -150,12 +150,12 @@ class \nodoc\ _TestSuppressionMagicCommentLines is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "line 1\n"
-      + "// pony-lint: off style\n"
-      + "line 3\n"
-      + "// pony-lint: on style\n"
-      + "// pony-lint: allow style/hard-tabs\n"
-      + "line 6\n"
+      "line 1\n" +
+      "// pony-lint: off style\n" +
+      "line 3\n" +
+      "// pony-lint: on style\n" +
+      "// pony-lint: allow style/hard-tabs\n" +
+      "line 6\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_true(sup.magic_comment_lines().contains(2))
@@ -171,9 +171,9 @@ class \nodoc\ _TestSuppressionLintNotSuppressible is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "// pony-lint: off\n"
-      + "line 2\n"
-      + "// pony-lint: on\n"
+      "// pony-lint: off\n" +
+      "line 2\n" +
+      "// pony-lint: on\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_false(sup.is_suppressed(2, "lint/unclosed-suppression"))
@@ -209,13 +209,13 @@ class \nodoc\ _TestSuppressionOverrideThenReSuppress is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "// pony-lint: off style\n"       // line 1
-        + "// pony-lint: on style/ll\n"  // line 2: override
-        + "code A\n"                     // line 3: ll NOT suppressed
-        + "// pony-lint: on style\n"     // line 4: end category off
-        + "// pony-lint: off style/ll\n" // line 5: explicit off
-        + "code B\n"                     // line 6: ll suppressed
-        + "// pony-lint: on style/ll\n"  // line 7: end
+      "// pony-lint: off style\n" +       // line 1
+        "// pony-lint: on style/ll\n" +  // line 2: override
+        "code A\n" +                     // line 3: ll NOT suppressed
+        "// pony-lint: on style\n" +     // line 4: end category off
+        "// pony-lint: off style/ll\n" + // line 5: explicit off
+        "code B\n" +                     // line 6: ll suppressed
+        "// pony-lint: on style/ll\n"    // line 7: end
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     // Line 3: style/ll overridden, not suppressed
@@ -233,10 +233,10 @@ class \nodoc\ _TestSuppressionCategoryOnOverridesWildcardOff is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "// pony-lint: off\n"               // line 1: suppress all
-        + "// pony-lint: on style\n"       // line 2: re-enable style
-        + "code\n"                         // line 3
-        + "// pony-lint: on\n"             // line 4: end
+      "// pony-lint: off\n" +               // line 1: suppress all
+        "// pony-lint: on style\n" +       // line 2: re-enable style
+        "code\n" +                         // line 3
+        "// pony-lint: on\n"               // line 4: end
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     // style rules re-enabled by category on
@@ -253,9 +253,9 @@ class \nodoc\ _TestSuppressionWildcardOnOverridesCategoryOff is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "// pony-lint: off style\n"          // line 1: suppress style
-        + "// pony-lint: on\n"             // line 2: re-enable all
-        + "code\n"                         // line 3
+      "// pony-lint: off style\n" +          // line 1: suppress style
+        "// pony-lint: on\n" +             // line 2: re-enable all
+        "code\n"                           // line 3
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_false(sup.is_suppressed(3, "style/line-length"))
@@ -290,9 +290,9 @@ class \nodoc\ _TestSuppressionDoubleSpaceInDirective is UnitTest
 
   fun apply(h: TestHelper) =>
     let content: String val =
-      "// pony-lint: off  style/line-length\n"
-        + "line 2\n"
-        + "// pony-lint: on style/line-length\n"
+      "// pony-lint: off  style/line-length\n" +
+        "line 2\n" +
+        "// pony-lint: on style/line-length\n"
     let sf = lint.SourceFile("/tmp/t.pony", content, "/tmp")
     let sup = lint.Suppressions(sf)
     h.assert_true(sup.is_suppressed(2, "style/line-length"))

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -377,7 +377,8 @@ actor \nodoc\ Main is TestList
     test(_TestOperatorSpacingSpaceOnlyBefore)
     test(_TestOperatorSpacingSpaceOnlyAfter)
     test(_TestOperatorSpacingUnaryMinusClean)
-    test(_TestOperatorSpacingUnaryMinusSpaceViolation)
+    test(_TestOperatorSpacingUnaryMinusStartOfLineViolation)
+    test(_TestOperatorSpacingUnaryMinusSpaceMidLine)
     test(_TestOperatorSpacingNotClean)
     test(_TestOperatorSpacingNotAfterParenClean)
     test(_TestOperatorSpacingNotNoSpaceAfter)
@@ -390,7 +391,9 @@ actor \nodoc\ Main is TestList
     test(_TestOperatorSpacingPartialModClean)
     test(_TestOperatorSpacingSaturatingClean)
     test(_TestOperatorSpacingStyleGuideExample)
-    test(_TestOperatorSpacingContinuationLineClean)
+    test(_TestOperatorSpacingContinuationLineViolation)
+    test(_TestOperatorSpacingKeywordContinuationViolation)
+    test(_TestOperatorSpacingEndOfLineClean)
 
     // LambdaSpacing tests
     test(_TestLambdaSpacingSingleLineClean)

--- a/tools/pony-lint/test_list_nodoc.pony
+++ b/tools/pony-lint/test_list_nodoc.pony
@@ -60,8 +60,8 @@ primitive TestListNodoc is ASTRule
         | "TestList" => return true
         end
       end
-    elseif (tk == ast.TokenIds.tk_provides())
-      or (tk == ast.TokenIds.tk_isecttype())
+    elseif (tk == ast.TokenIds.tk_provides()) or
+      (tk == ast.TokenIds.tk_isecttype())
     then
       var i: USize = 0
       while true do

--- a/tools/pony-lint/type_alias_format.pony
+++ b/tools/pony-lint/type_alias_format.pony
@@ -172,8 +172,8 @@ primitive TypeAliasFormat is ASTRule
     TK_ISECTTYPE.
     """
     let token = node.id()
-    if (token == ast.TokenIds.tk_uniontype())
-      or (token == ast.TokenIds.tk_isecttype())
+    if (token == ast.TokenIds.tk_uniontype()) or
+      (token == ast.TokenIds.tk_isecttype())
     then
       return true
     end
@@ -189,8 +189,8 @@ primitive TypeAliasFormat is ASTRule
     leaf type component.
     """
     let token = node.id()
-    if (token == ast.TokenIds.tk_uniontype())
-      or (token == ast.TokenIds.tk_isecttype())
+    if (token == ast.TokenIds.tk_uniontype()) or
+      (token == ast.TokenIds.tk_isecttype())
     then
       try
         return _leftmost_leaf(node(0)?)

--- a/tools/pony-lint/type_parameter_format.pony
+++ b/tools/pony-lint/type_parameter_format.pony
@@ -19,8 +19,8 @@ primitive TypeParameterFormat is ASTRule
   fun category(): String val => "style"
 
   fun description(): String val =>
-    "multiline type parameter formatting"
-      + " (bracket placement, layout, and 'is' alignment)"
+    "multiline type parameter formatting" +
+      " (bracket placement, layout, and 'is' alignment)"
 
   fun default_status(): RuleStatus => RuleOn
 
@@ -99,8 +99,8 @@ primitive TypeParameterFormat is ASTRule
             if tp_l == prev_line then
               diags.push(Diagnostic(
                 id(),
-                "each type parameter should be on its own line"
-                  + " in a multiline declaration",
+                "each type parameter should be on its own line" +
+                  " in a multiline declaration",
                 source.rel_path,
                 tp_l,
                 tp_node.pos()))
@@ -140,10 +140,10 @@ primitive TypeParameterFormat is ASTRule
                 if word_col != expected_col then
                   diags.push(Diagnostic(
                     id(),
-                    "'is' should align at column "
-                      + expected_col.string()
-                      + " (indented from '"
-                      + _keyword_name(token_id) + "')",
+                    "'is' should align at column " +
+                      expected_col.string() +
+                      " (indented from '" +
+                      _keyword_name(token_id) + "')",
                     source.rel_path,
                     prov_line,
                     word_col))
@@ -161,9 +161,9 @@ primitive TypeParameterFormat is ASTRule
     """
     Check if the token represents a method declaration.
     """
-    (token_id == ast.TokenIds.tk_fun())
-      or (token_id == ast.TokenIds.tk_new())
-      or (token_id == ast.TokenIds.tk_be())
+    (token_id == ast.TokenIds.tk_fun()) or
+      (token_id == ast.TokenIds.tk_new()) or
+      (token_id == ast.TokenIds.tk_be())
 
   fun _keyword_name(token_id: ast.TokenId): String val =>
     """

--- a/tools/pony-lsp/corral.pony
+++ b/tools/pony-lsp/corral.pony
@@ -106,10 +106,7 @@ primitive _Flattened
     String.from_array(consume path_name_arr)
 
   fun _is_alphanum(c: U8): Bool =>
-    (('0' <= c) and (c <= '9'))
-      or
-    (('A' <= c) and (c <= 'Z'))
-      or
-    (('a' <= c) and (c <= 'z'))
-      or
+    (('0' <= c) and (c <= '9')) or
+    (('A' <= c) and (c <= 'Z')) or
+    (('a' <= c) and (c <= 'z')) or
     (c == '_')

--- a/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_call_hierarchy_integration_tests.pony
@@ -177,8 +177,8 @@ primitive _CHierCheckItem
       ok
     else
       h.fail(
-        label + " missing or has wrong structure (expected: "
-          + exp.name + ")")
+        label + " missing or has wrong structure (expected: " +
+          exp.name + ")")
       false
     end
 

--- a/tools/pony-lsp/test/_references_integration_tests.pony
+++ b/tools/pony-lsp/test/_references_integration_tests.pony
@@ -596,8 +596,8 @@ class val _RefsChecker
             let sc = range("start")("character").as_i64()?
             let el = range("end")("line").as_i64()?
             let ec = range("end")("character").as_i64()?
-            if (file == exp_file) and (sl == exp_sl) and (sc == exp_sc)
-              and (el == exp_el) and (ec == exp_ec)
+            if (file == exp_file) and (sl == exp_sl) and (sc == exp_sc) and
+              (el == exp_el) and (ec == exp_ec)
             then
               found = true
               break

--- a/tools/pony-lsp/test/_rename_integration_tests.pony
+++ b/tools/pony-lsp/test/_rename_integration_tests.pony
@@ -685,8 +685,8 @@ class val _RenameChecker
     for (exp_file, exp_sl, exp_sc, exp_el, exp_ec) in _expected.values() do
       var found = false
       for (file, sl, sc, el, ec, new_text) in got.values() do
-        if (file == exp_file) and (sl == exp_sl) and (sc == exp_sc)
-          and (el == exp_el) and (ec == exp_ec) and (new_text == _new_name)
+        if (file == exp_file) and (sl == exp_sl) and (sc == exp_sc) and
+          (el == exp_el) and (ec == exp_ec) and (new_text == _new_name)
         then
           found = true
           break

--- a/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
+++ b/tools/pony-lsp/test/_type_hierarchy_integration_tests.pony
@@ -561,8 +561,8 @@ primitive _THierCheckItem
       ok
     else
       h.fail(
-        "item[" + i.string() + "] missing or has wrong structure"
-          + " (expected: " + exp.name + ")")
+        "item[" + i.string() + "] missing or has wrong structure" +
+          " (expected: " + exp.name + ")")
       false
     end
 

--- a/tools/pony-lsp/test/message_handler.pony
+++ b/tools/pony-lsp/test/message_handler.pony
@@ -151,9 +151,9 @@ actor TestHarness is Channel
     do_expect()
 
   fun ref do_expect(force: Bool = false) =>
-    if force
-      or (sent.size() >= this._after_sends)
-      or (logs.size() >= this._after_logs)
+    if force or
+      (sent.size() >= this._after_sends) or
+      (logs.size() >= this._after_logs)
     then
       if not this._expect_fun(h, this) then
         // print out some debug stuff

--- a/tools/pony-lsp/workspace/_resolve_ast_target.pony
+++ b/tools/pony-lsp/workspace/_resolve_ast_target.pony
@@ -15,9 +15,9 @@ primitive _ResolveASTTarget
     let nid = node.id()
 
     // Literals have no referenceable identity.
-    if (nid == TokenIds.tk_true()) or (nid == TokenIds.tk_false())
-      or (nid == TokenIds.tk_int()) or (nid == TokenIds.tk_float())
-      or (nid == TokenIds.tk_string())
+    if (nid == TokenIds.tk_true()) or (nid == TokenIds.tk_false()) or
+      (nid == TokenIds.tk_int()) or (nid == TokenIds.tk_float()) or
+      (nid == TokenIds.tk_string())
     then
       return None
     end

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -33,9 +33,9 @@ primitive DocumentHighlights
     """
     // Literals have no referenceable identity — do not highlight.
     let nid = node.id()
-    if (nid == TokenIds.tk_true()) or (nid == TokenIds.tk_false())
-      or (nid == TokenIds.tk_int()) or (nid == TokenIds.tk_float())
-      or (nid == TokenIds.tk_string())
+    if (nid == TokenIds.tk_true()) or (nid == TokenIds.tk_false()) or
+      (nid == TokenIds.tk_int()) or (nid == TokenIds.tk_float()) or
+      (nid == TokenIds.tk_string())
     then
       return Array[DocumentHighlight]
     end

--- a/tools/pony-lsp/workspace/inlay_hint.pony
+++ b/tools/pony-lsp/workspace/inlay_hint.pony
@@ -405,10 +405,10 @@ class ref _InlayHintCollector is ASTVisitor
     (iso, trn, ref, val, box, tag). Returns false for cap sets (#read,
     #any, etc.) and tk_none.
     """
-    (id == TokenIds.tk_iso()) or (id == TokenIds.tk_trn())
-      or (id == TokenIds.tk_ref()) or (id == TokenIds.tk_val())
-      or (id == TokenIds.tk_box()) or (id == TokenIds.tk_tag())
+    (id == TokenIds.tk_iso()) or (id == TokenIds.tk_trn()) or
+      (id == TokenIds.tk_ref()) or (id == TokenIds.tk_val()) or
+      (id == TokenIds.tk_box()) or (id == TokenIds.tk_tag())
 
   fun _is_ident_char(c: U8): Bool =>
-    ((c >= 'a') and (c <= 'z')) or ((c >= 'A') and (c <= 'Z'))
-      or ((c >= '0') and (c <= '9')) or (c == '_')
+    ((c >= 'a') and (c <= 'z')) or ((c >= 'A') and (c <= 'Z')) or
+      ((c >= '0') and (c <= '9')) or (c == '_')

--- a/tools/pony-lsp/workspace/selection_ranges.pony
+++ b/tools/pony-lsp/workspace/selection_ranges.pony
@@ -85,8 +85,8 @@ primitive SelectionRanges
         let sc = s.column()
         let el = e.line()
         let ec = e.column()
-        if (sl == last_sl) and (sc == last_sc)
-          and (el == last_el) and (ec == last_ec)
+        if (sl == last_sl) and (sc == last_sc) and
+          (el == last_el) and (ec == last_ec)
         then
           continue
         end

--- a/tools/pony-lsp/workspace/type_hierarchy.pony
+++ b/tools/pony-lsp/workspace/type_hierarchy.pony
@@ -195,8 +195,8 @@ primitive TypeHierarchy
     let nid = provides.id()
     if nid == TokenIds.tk_none() then
       None
-    elseif (nid == TokenIds.tk_provides())
-      or (nid == TokenIds.tk_isecttype()) then
+    elseif (nid == TokenIds.tk_provides()) or
+      (nid == TokenIds.tk_isecttype()) then
       for child in provides.children() do
         _append_provides_defs(child, result)
       end
@@ -243,8 +243,8 @@ class ref _SubtypeCollector is ASTVisitor
       end
       // Name prefilter: cheap identifier-only walk before the expensive
       // definitions() call inside _provides_defs.
-      if (_target_name.size() > 0)
-        and not TypeHierarchy._provides_mentions(provides_node, _target_name)
+      if (_target_name.size() > 0) and
+        not TypeHierarchy._provides_mentions(provides_node, _target_name)
       then
         return Continue
       end

--- a/tools/pony-lsp/workspace/workspace_manager.pony
+++ b/tools/pony-lsp/workspace/workspace_manager.pony
@@ -483,9 +483,9 @@ actor WorkspaceManager
       // the refined node's children for a cap keyword covering the cursor.
       for child in hover_node.children() do
         let child_id = child.id()
-        if (child_id == TokenIds.tk_iso()) or (child_id == TokenIds.tk_trn())
-          or (child_id == TokenIds.tk_ref()) or (child_id == TokenIds.tk_val())
-          or (child_id == TokenIds.tk_box()) or (child_id == TokenIds.tk_tag())
+        if (child_id == TokenIds.tk_iso()) or (child_id == TokenIds.tk_trn()) or
+          (child_id == TokenIds.tk_ref()) or (child_id == TokenIds.tk_val()) or
+          (child_id == TokenIds.tk_box()) or (child_id == TokenIds.tk_tag())
         then
           let cap_col = child.position().column()
           if (cursor_line == child.position().line()) and
@@ -1031,18 +1031,18 @@ actor WorkspaceManager
           end
         | None =>
           this._channel.log(
-            "[textDocument/diagnostic] No document state available for "
-            + document_path)
+            "[textDocument/diagnostic] No document state available for " +
+            document_path)
         end
       | None =>
         this._channel.log(
-          "[textDocument/diagnostic] No package state available for package: "
-          + package.path)
+          "[textDocument/diagnostic] No package state available for package: " +
+          package.path)
       end
     else
       this._channel.log(
-        "[textDocument/diagnostic] Unable to find workspace package for: "
-        + document_uri)
+        "[textDocument/diagnostic] Unable to find workspace package for: " +
+        document_uri)
     end
     this._channel.send(
       ResponseMessage.create(


### PR DESCRIPTION
`Timer.abs` has been computing the wrong expiration time since 2017. A formatting change moved a binary `-` to the start of a continuation line, where the parser treats it as unary negation — the target wall-clock time was silently discarded and the expiration wrapped to a value far in the future. Timers created with `Timer.abs` never fired.

The root cause is a language-level parsing behavior: `-` at the start of a line produces `TK_MINUS_NEW`, which the parser maps to unary negation, not binary subtraction. The fix moves `-` back to the end of the previous line, and the linter now enforces that convention for all binary operators to prevent the same class of bug. All existing operator continuations in `tools/` and `packages/` are reformatted.

### Parked

- **Timer.abs test coverage**: `_abs_expiration_time` calls `Time.nanos()` and `Time.now()` internally (not injectable), and `Timer` is `iso`, so there's no clean way to test the computation directly. The fix is verified by reading the expression. Worth discussing whether to add an integration-level timer test.
