### PR TITLE
Fix stale version and git hash in local rebuilds

### DIFF
--- a/.release-notes/fix-stale-version-local-rebuilds.md
+++ b/.release-notes/fix-stale-version-local-rebuilds.md
@@ -1,0 +1,3 @@
+## Fix stale version and git hash in local rebuilds
+
+Rebuilding ponyc from the same checkout after pulling new commits showed the old version string and git hash until cmake was re-run from scratch. Installing that build wrote the stale version into the install, so `ponyc --version` reported the wrong version even after upgrading. CI builds were unaffected because they always configure fresh.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,11 +5,14 @@ project(Pony VERSION ${PONYC_PROJECT_VERSION} LANGUAGES C CXX)
 
 # Grab the PonyC version number from the "VERSION" source file. When building in
 # a git checkout, append the short commit sha; from a release tarball (no .git,
-# or git unavailable) use the bare version. The
-# git-success guard matters: without it a tarball build produces a trailing dash
-# ("0.66.0-"), which would put the install in lib/pony/0.66.0- instead of
-# lib/pony/0.66.0.
-if(NOT DEFINED PONYC_VERSION)
+# or git unavailable) use the bare version.
+#
+# This configure-time copy is used only for install paths (see
+# PONY_VERSIONED_DIR below) and the Windows active-version marker.
+if(DEFINED PONYC_VERSION)
+    set(_ponyc_version_overridden TRUE)
+else()
+    set(_ponyc_version_overridden FALSE)
     set(PONYC_VERSION "${PONYC_PROJECT_VERSION}")
     if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
         execute_process(
@@ -54,7 +57,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/PonyUses.cmake)
 #    (build/debug, build/release), so a capitalized "Release" would build into
 #    build/Release, which none of those lowercase paths point at.
 #  - The per-config compile flags and the PONY_BUILD_CONFIG / DEBUG / NDEBUG /
-#    PONY_VERSION_STR definitions are gated on $<CONFIG:Debug>/$<CONFIG:Release>.
+#    definitions are gated on $<CONFIG:Debug>/$<CONFIG:Release>.
 #    A name CMake doesn't recognize matches neither, so those definitions are
 #    dropped and the runtime fails to compile ("PONY_BUILD_CONFIG undeclared")
 #    partway through, far from the cause.
@@ -389,8 +392,7 @@ endfunction()
 # -lasan/-lubsan, Apple clang the clang_rt dylib by absolute path + -rpath (and
 # folds UBSan into ASan). Native Linux, FreeBSD, and macOS sanitizer builds
 # consume this (see genexe.cc); DragonFly/OpenBSD sanitizer builds are rejected
-# at configure time. The matching include dir is wired in below via
-# PONY_GENERATED_INCLUDE_NEEDED, and the splice lives in genexe.cc under
+# at configure time. The splice lives in genexe.cc under
 # #if defined(PONY_SANITIZER).
 if(PONY_SANITIZERS_ENABLED)
     _pony_capture_driver_link_fragment(
@@ -399,7 +401,6 @@ if(PONY_SANITIZERS_ENABLED)
         "sanitizer_link_args.h"
         "PONY_SANITIZER"
         "sanitizer")
-    set(PONY_GENERATED_INCLUDE_NEEDED TRUE)
 endif()
 
 # Coverage build with gcc: -fprofile-arcs instruments libponyrt's C objects with
@@ -428,7 +429,6 @@ if(PONY_USE_COVERAGE AND CMAKE_C_COMPILER_ID STREQUAL "GNU")
     # options only (unlike the sanitizer block's -fsanitize=, which the linker
     # genuinely needs).
     add_compile_options(-DPONY_COVERAGE)
-    set(PONY_GENERATED_INCLUDE_NEEDED TRUE)
 endif()
 
 if(DEFINED PONY_CPU AND NOT PONY_CPU STREQUAL "")
@@ -565,6 +565,30 @@ if(NOT PONY_CROSS_LIBPONYRT)
     endif()
 endif()
 
+# Build-time version header — recomputed on every build so the git hash and
+# VERSION file stay current without a manual reconfigure.  The generated
+# pony_version.h defines PONY_VERSION and PONY_VERSION_STR; source files that
+# need them include it directly.
+set(_version_header "${CMAKE_BINARY_DIR}/pony_generated/pony_version.h")
+set(_version_override "")
+if(_ponyc_version_overridden)
+    set(_version_override "${PONYC_VERSION}")
+endif()
+
+add_custom_target(pony_version ALL
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -DOUTPUT_FILE=${_version_header}
+        -DTEMPLATE_FILE=${CMAKE_SOURCE_DIR}/cmake/pony_version.h.in
+        -DLLVM_VERSION=${LLVM_VERSION}
+        -DCMAKE_C_COMPILER_ID=${CMAKE_C_COMPILER_ID}
+        -DCMAKE_C_COMPILER_VERSION=${CMAKE_C_COMPILER_VERSION}
+        -DCOMPILER_ARCH=${_compiler_arch}
+        -DOVERRIDE_VERSION=${_version_override}
+        -P ${CMAKE_SOURCE_DIR}/cmake/GenerateVersion.cmake
+    COMMENT "Refreshing pony_version.h"
+)
+
 # Required definitions.  We use these generators so that the defines are correct for both *nix (where the config applies at configuration time) and Windows (where the config applies at build time).
 add_compile_definitions(
     BUILD_COMPILER="${CMAKE_C_COMPILER_VERSION}"
@@ -580,11 +604,8 @@ add_compile_definitions(
     $<$<CONFIG:Debug>:PONY_BUILD_CONFIG="debug">
     $<$<CONFIG:Release>:PONY_BUILD_CONFIG="release">
     PONY_USE_BIGINT
-    PONY_VERSION="${PONYC_VERSION}"
     $<$<CONFIG:Debug>:DEBUG>
     $<$<CONFIG:Release>:NDEBUG>
-    $<$<CONFIG:Debug>:PONY_VERSION_STR="${PONYC_VERSION} [debug]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
-    $<$<CONFIG:Release>:PONY_VERSION_STR="${PONYC_VERSION} [release]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${_compiler_arch}">
     PONY_OSX_PLATFORM=${PONY_OSX_PLATFORM}
 )
 

--- a/cmake/GenerateVersion.cmake
+++ b/cmake/GenerateVersion.cmake
@@ -1,0 +1,33 @@
+# Build-time script: recompute the version string on every build so that the
+# git hash and VERSION file stay current without a manual reconfigure.
+#
+# Expected -D arguments (set by the custom target in the top-level CMakeLists):
+#   SOURCE_DIR         – path to the source tree (CMAKE_SOURCE_DIR)
+#   OUTPUT_FILE        – path to write the generated header to
+#   TEMPLATE_FILE      – path to pony_version.h.in
+#   LLVM_VERSION       – LLVM version string
+#   CMAKE_C_COMPILER_ID      – compiler family (GNU, Clang, …)
+#   CMAKE_C_COMPILER_VERSION – compiler version
+#   COMPILER_ARCH      – target architecture
+#   OVERRIDE_VERSION   – optional; when set, skip VERSION/git and use this
+
+if(DEFINED OVERRIDE_VERSION AND NOT OVERRIDE_VERSION STREQUAL "")
+    set(PONYC_VERSION "${OVERRIDE_VERSION}")
+else()
+    file(STRINGS "${SOURCE_DIR}/VERSION" PONYC_VERSION)
+
+    if(EXISTS "${SOURCE_DIR}/.git")
+        execute_process(
+            COMMAND git rev-parse --short HEAD
+            WORKING_DIRECTORY "${SOURCE_DIR}"
+            OUTPUT_VARIABLE _hash
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE _rc
+        )
+        if(_rc EQUAL 0 AND NOT _hash STREQUAL "")
+            set(PONYC_VERSION "${PONYC_VERSION}-${_hash}")
+        endif()
+    endif()
+endif()
+
+configure_file("${TEMPLATE_FILE}" "${OUTPUT_FILE}" @ONLY)

--- a/cmake/pony_version.h.in
+++ b/cmake/pony_version.h.in
@@ -1,0 +1,11 @@
+#ifndef PONY_VERSION_H
+#define PONY_VERSION_H
+
+#define PONY_VERSION "@PONYC_VERSION@"
+
+#define PONY_VERSION_STR \
+    PONY_VERSION " [" PONY_BUILD_CONFIG "]\n" \
+    "Compiled with: LLVM @LLVM_VERSION@ -- " \
+    "@CMAKE_C_COMPILER_ID@-@CMAKE_C_COMPILER_VERSION@-@COMPILER_ARCH@"
+
+#endif

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -107,16 +107,10 @@ target_compile_definitions(libponyc PRIVATE
 target_include_directories(libponyc
     PUBLIC ../common
     PRIVATE ../../build/libs/include
+    PRIVATE ${CMAKE_BINARY_DIR}/pony_generated
 )
 
-# In sanitizer builds (and gcc coverage builds), genexe.cc includes a generated
-# header from pony_generated/ (sanitizer_link_args.h / coverage_link_args.h —
-# the captured runtime link fragment; see the driver link-fragment capture in
-# the top-level CMakeLists.txt). PONY_GENERATED_INCLUDE_NEEDED is set there when
-# either capture runs, so both builds get the dir on the include path.
-if(PONY_GENERATED_INCLUDE_NEEDED)
-    target_include_directories(libponyc PRIVATE ${CMAKE_BINARY_DIR}/pony_generated)
-endif()
+add_dependencies(libponyc pony_version)
 
 if(${CMAKE_HOST_SYSTEM_NAME} MATCHES "Darwin")
     set(CMAKE_OSX_DEPLOYMENT_TARGET ${PONY_OSX_PLATFORM})

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -1,4 +1,5 @@
 #include "codegen.h"
+#include "pony_version.h"
 #include "genexe.h"
 #include "genprim.h"
 #include "genname.h"

--- a/src/libponyc/options/options.c
+++ b/src/libponyc/options/options.c
@@ -1,4 +1,5 @@
 #include "options.h"
+#include "pony_version.h"
 
 #include "../ponyc.h"
 #include "../ast/parserapi.h"

--- a/src/libponyrt/CMakeLists.txt
+++ b/src/libponyrt/CMakeLists.txt
@@ -164,7 +164,10 @@ endif()
 target_include_directories(libponyrt
     PUBLIC .
     PUBLIC ../common
+    PRIVATE ${CMAKE_BINARY_DIR}/pony_generated
 )
+
+add_dependencies(libponyrt pony_version)
 
 if (MSVC)
     # VirtualAlloc2, which mem/alloc.c calls, is not exported by kernel32.lib.
@@ -221,7 +224,7 @@ if(PONY_RUNTIME_BITCODE)
         #message("${libponyrt_SOURCE_DIR}/${_src_file} -> ${libponyrt_BINARY_DIR}/${_src_file}.bc")
         get_filename_component(_src_dir ${_src_file} DIRECTORY)
         add_custom_command(
-            COMMAND mkdir -p "${libponyrt_BINARY_DIR}/${_src_dir}" && ${CMAKE_C_COMPILER} $<IF:$<BOOL:${CMAKE_C_COMPILER_TARGET}>,--target=${CMAKE_C_COMPILER_TARGET},> -DBUILD_COMPILER="${CMAKE_C_COMPILER_VERSION}" -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DLLVM_BUILD_MODE=${PONY_LLVM_BUILD_MODE} -DLLVM_VERSION="${LLVM_VERSION}" -DPONY_COMPILER="${CMAKE_C_COMPILER}" -DPONY_ARCH="${CMAKE_SYSTEM_PROCESSOR}" -DPONY_BUILD_CONFIG="release" -DPONY_USE_BIGINT -DPONY_VERSION="${PONYC_VERSION}" -DPONY_VERSION_STR="${PONYC_VERSION} [release]\\nCompiled with: LLVM ${LLVM_VERSION} -- ${CMAKE_C_COMPILER_ID}-${CMAKE_C_COMPILER_VERSION}-${CMAKE_C_COMPILER_ARCHITECTURE_ID}" -pthread -fexceptions -Werror -Wconversion -Wno-sign-conversion -Wno-atomic-alignment -Wextra -Wall ${_c_flags} -I. -I../common -emit-llvm -o "${libponyrt_BINARY_DIR}/${_src_file}.bc" -c ${_src_file}
+            COMMAND mkdir -p "${libponyrt_BINARY_DIR}/${_src_dir}" && ${CMAKE_C_COMPILER} $<IF:$<BOOL:${CMAKE_C_COMPILER_TARGET}>,--target=${CMAKE_C_COMPILER_TARGET},> -DBUILD_COMPILER="${CMAKE_C_COMPILER_VERSION}" -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DLLVM_BUILD_MODE=${PONY_LLVM_BUILD_MODE} -DLLVM_VERSION="${LLVM_VERSION}" -DPONY_COMPILER="${CMAKE_C_COMPILER}" -DPONY_ARCH="${CMAKE_SYSTEM_PROCESSOR}" -DPONY_BUILD_CONFIG="release" -DPONY_USE_BIGINT -pthread -fexceptions -Werror -Wconversion -Wno-sign-conversion -Wno-atomic-alignment -Wextra -Wall ${_c_flags} -I. -I../common -I${CMAKE_BINARY_DIR}/pony_generated -emit-llvm -o "${libponyrt_BINARY_DIR}/${_src_file}.bc" -c ${_src_file}
             WORKING_DIRECTORY ${libponyrt_SOURCE_DIR}
             DEPENDS "${libponyrt_SOURCE_DIR}/${_src_file}"
             OUTPUT "${libponyrt_BINARY_DIR}/${_src_file}.bc"
@@ -237,6 +240,7 @@ if(PONY_RUNTIME_BITCODE)
         ${libponyrt_SOURCE_DIR}/../../build/libs/bin/llvm-link -o "${libponyrt_BINARY_DIR}/libponyrt.bc" ${_ll_bc_all}
         DEPENDS ${_ll_bc_all}
     )
+    add_dependencies(libponyrt_bc pony_version)
 
     add_custom_command(TARGET libponyrt_bc POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy ${libponyrt_BINARY_DIR}/libponyrt.bc ${PONY_OUTPUT_DIR}/

--- a/src/libponyrt/sched/start.c
+++ b/src/libponyrt/sched/start.c
@@ -1,5 +1,6 @@
 #define PONY_WANT_ATOMIC_DEFS
 
+#include "pony_version.h"
 #include "scheduler.h"
 #include "cpu.h"
 #include "../mem/heap.h"


### PR DESCRIPTION
The version string and git hash were computed at CMake configure time and cached. A rebuild after new commits or a VERSION bump kept showing the stale values until someone re-ran cmake. CI never hit this because it always configures from scratch.

A build-time custom target now regenerates `pony_version.h` on every build via `cmake/GenerateVersion.cmake`. `configure_file`'s copy-if-different means unchanged versions don't trigger recompilation. The three source files that need the version include the generated header directly.