### PR TITLE
Consolidate tools lint steps in PR CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -381,18 +381,12 @@ jobs:
         run: ctest --preset debug -R pony-lint-tests
       - name: Test pony-lsp
         run: ctest --preset debug -R pony-lsp-tests
-      - name: Lint pony-lint
-        run: cd build/debug && PONYPATH=../../tools/lib/ponylang/pony_compiler ./pony-lint ../../tools/pony-lint/
-      - name: Lint pony-doc
-        run: cd build/debug && PONYPATH=../../tools/lib/ponylang/pony_compiler ./pony-lint ../../tools/pony-doc/
-      - name: Lint pony-lsp
-        run: cd build/debug && PONYPATH=../../tools/lib/ponylang/pony_compiler ./pony-lint ../../tools/pony-lsp/
+      - name: Lint tools
+        run: cd build/debug && PONYPATH=../../tools/lib/ponylang/pony_compiler ./pony-lint ../../tools/
       - name: Lint examples
         run: cd build/debug && ./pony-lint ../../examples/
       - name: Lint test
         run: cd build/debug && ./pony-lint ../../test/
-      - name: Lint pony-compiler
-        run: cd build/debug && ./pony-lint ../../tools/lib/ponylang/pony_compiler/
       - name: Lint packages
         run: cd build/debug && ./pony-lint ../../packages/
 


### PR DESCRIPTION
pony-lint handles recursive directory discovery, so a single invocation on `tools/` replaces the four separate runs (pony-lint, pony-doc, pony-lsp, pony-compiler). The `PONYPATH` for `pony_compiler` is still needed — the three tools that depend on it can't resolve it without it — but one step covers all four former targets.