### PR TITLE
Fix default type arguments failing to resolve with aliased use packages

### DIFF
--- a/.release-notes/fix-default-typearg-aliased-use.md
+++ b/.release-notes/fix-default-typearg-aliased-use.md
@@ -1,0 +1,16 @@
+## Fix default type arguments failing to resolve with aliased use packages
+
+When a generic type had a default type argument that named a type in its own package, using that generic from a consumer that imported the package with an alias (`use m = "pkg"`) failed with "can't find definition of" on the default type. The same code compiled when the package was imported without an alias. This bug was surfaced by lori 0.19.0, which introduced generic TCP types with default backend arguments.
+
+```pony
+// In package "tcp":
+trait tag Connection[T: Backend ref = RuntimeBackend]
+
+// In the consumer — failed before this fix:
+use tcp = "tcp"
+
+actor Main
+  let c: tcp.Connection = ...
+```
+
+Default type arguments now work correctly regardless of how the package is imported.

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -5,6 +5,25 @@
 #include "../pkg/package.h"
 #include "ponyassert.h"
 
+static bool resolve_default_typeargs(pass_opt_t* opt, ast_t* typeparams)
+{
+  for(ast_t* tp = ast_child(typeparams);
+    tp != NULL;
+    tp = ast_sibling(tp))
+  {
+    ast_t* defarg = ast_childidx(tp, 2);
+
+    if(ast_id(defarg) != TK_NONE)
+    {
+      if(ast_visit_scope(&defarg, NULL, pass_names, opt,
+        PASS_NAME_RESOLUTION) != AST_OK)
+        return false;
+    }
+  }
+
+  return true;
+}
+
 static bool names_typeargs(pass_opt_t* opt, ast_t* typeargs)
 {
   for(ast_t* typearg = ast_child(typeargs);
@@ -29,6 +48,9 @@ static bool names_typealias(pass_opt_t* opt, ast_t** astp, ast_t* def,
   // recursion through aliases is legal and checked later by
   // PASS_TYPEALIAS_RECURSION.
   AST_GET_CHILDREN(def, alias_id, typeparams, def_cap, provides);
+
+  if(!resolve_default_typeargs(opt, typeparams))
+    return false;
 
   if(!reify_defaults(typeparams, typeargs, true, opt))
     return false;
@@ -129,6 +151,9 @@ static bool names_type(pass_opt_t* opt, ast_t** astp, ast_t* def)
 
   // Store our definition for later use.
   ast_setdata(ast, def);
+
+  if(!resolve_default_typeargs(opt, typeparams))
+    return false;
 
   if(!reify_defaults(typeparams, typeargs, true, opt))
     return false;

--- a/test/full-program-tests/default-typearg-aliased-use/dep/base.pony
+++ b/test/full-program-tests/default-typearg-aliased-use/dep/base.pony
@@ -1,0 +1,2 @@
+trait Base
+  fun ref go()

--- a/test/full-program-tests/default-typearg-aliased-use/dep/gen.pony
+++ b/test/full-program-tests/default-typearg-aliased-use/dep/gen.pony
@@ -1,0 +1,2 @@
+trait tag Gen[T: Base ref = Impl]
+  fun tag hello(): None

--- a/test/full-program-tests/default-typearg-aliased-use/dep/impl.pony
+++ b/test/full-program-tests/default-typearg-aliased-use/dep/impl.pony
@@ -1,0 +1,3 @@
+class Impl is Base
+  new create() => None
+  fun ref go() => None

--- a/test/full-program-tests/default-typearg-aliased-use/main.pony
+++ b/test/full-program-tests/default-typearg-aliased-use/main.pony
@@ -1,0 +1,7 @@
+use d = "./dep"
+
+actor Main is d.Gen
+  new create(env: Env) =>
+    hello()
+
+  fun tag hello(): None => None


### PR DESCRIPTION
When a generic type had a default type argument naming a type in its own package, using that generic from a consumer with an aliased import (`use m = "pkg"`) failed with "can't find definition of" on the default type. The same code compiled with an unaliased import. This was surfaced by lori 0.19.0, which introduced generic TCP types with default backend arguments.

The cause: `reify_defaults` duplicates the default type argument node into the consumer's AST. The names pass then resolves it by walking up the consumer's parent chain, where only the alias is in scope — the bare type name isn't visible. With an unaliased import the type names are copied into the consumer's module scope, so the lookup succeeds.

The fix resolves default type arguments in their definition-site scope (via `ast_visit_scope` on the original nodes, before `reify_defaults` copies them). The resolved nodes carry their definition pointer through the duplication, and the names pass short-circuits on the copy.
