### PR TITLE
Fix false "declaration appears after use" error with trait default method bodies

### DIFF
--- a/.release-notes/fix-trait-default-body-def-before-use.md
+++ b/.release-notes/fix-trait-default-body-def-before-use.md
@@ -1,0 +1,18 @@
+## Fix false "declaration appears after use" error with trait default method bodies
+
+When a type implemented multiple traits that declared the same method, and one of those traits provided a default body, the compiler could reject the program with a false "declaration of 'env' appears after use" error:
+
+```pony
+trait Concrete
+  fun hello(env: Env) =>
+    env.out.print("hello")
+
+trait Abstract1
+  fun hello(env: Env)
+
+actor Main is (Abstract1 & Concrete)
+  new create(env: Env) =>
+    hello(env)
+```
+
+Whether the compiler raised the error depended on the order the traits were declared in source. This has been fixed.

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -68,8 +68,17 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
 
     // lambda captures used before their declaration with their type
     // not defined are not legal
-    if(!def_before_use(opt, def, capture, name))
-      return false;
+    //
+    // After trait body adoption, the parameter definition and the body
+    // reference can originate from different traits, so their line numbers
+    // are not comparable.
+    if(ast_id(def) != TK_PARAM ||
+      ((opt->check.frame->method != NULL) &&
+       (ast_data(opt->check.frame->method) == opt->check.frame->type)))
+    {
+      if(!def_before_use(opt, def, capture, name))
+        return false;
+    }
 
     switch(ast_id(def))
     {
@@ -574,8 +583,16 @@ static bool capture_from_reference(pass_opt_t* opt, ast_t* ctx, ast_t* ast,
     return false;
   }
 
-  if(!def_before_use(opt, refdef, ctx, name))
-    return false;
+  // After trait body adoption, the parameter definition and the body
+  // reference can originate from different traits, so their line numbers
+  // are not comparable.
+  if(ast_id(refdef) != TK_PARAM ||
+    ((opt->check.frame->method != NULL) &&
+     (ast_data(opt->check.frame->method) == opt->check.frame->type)))
+  {
+    if(!def_before_use(opt, refdef, ctx, name))
+      return false;
+  }
 
   switch(ast_id(refdef))
   {

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -558,8 +558,15 @@ bool refer_reference(pass_opt_t* opt, ast_t** astp)
         return false;
       }
 
-      if(!def_before_use(opt, def, ast, name))
-        return false;
+      // After trait body adoption, the parameter definition and the body
+      // reference can originate from different traits, so their line numbers
+      // are not comparable.
+      if((opt->check.frame->method != NULL) &&
+        (ast_data(opt->check.frame->method) == opt->check.frame->type))
+      {
+        if(!def_before_use(opt, def, ast, name))
+          return false;
+      }
 
       if(!valid_reference(opt, ast, status))
         return false;

--- a/test/libponyc/lambda.cc
+++ b/test/libponyc/lambda.cc
@@ -619,3 +619,41 @@ TEST_F(LambdaTest, LambdaCaptureDefinedFieldOk)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(LambdaTest, TraitDefaultBodyWithExplicitLambdaCaptureParam)
+{
+  // From issue #5833 — explicit capture
+  const char* src =
+    "trait Concrete\n"
+      "fun hello(x: U32): U32 =>\n"
+        "let f = {()(x): U32 => x }\n"
+        "f()\n"
+
+    "trait Abstract1\n"
+      "fun hello(x: U32): U32\n"
+
+    "actor Main is (Abstract1 & Concrete)\n"
+      "new create(env: Env) =>\n"
+        "hello(42)";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(LambdaTest, TraitDefaultBodyWithImplicitLambdaCaptureParam)
+{
+  // From issue #5833 — implicit capture
+  const char* src =
+    "trait Concrete\n"
+      "fun hello(x: U32): U32 =>\n"
+        "let f = {(): U32 => x }\n"
+        "f()\n"
+
+    "trait Abstract1\n"
+      "fun hello(x: U32): U32\n"
+
+    "actor Main is (Abstract1 & Concrete)\n"
+      "new create(env: Env) =>\n"
+        "hello(42)";
+
+  TEST_COMPILE(src);
+}

--- a/test/libponyc/refer.cc
+++ b/test/libponyc/refer.cc
@@ -933,3 +933,22 @@ TEST_F(ReferTest, MemberAccessWithConsumeLhs)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(ReferTest, TraitDefaultBodyWithAbstractTraitParam)
+{
+  // From issue #5833
+  const char* src =
+    "trait Concrete\n"
+      "fun hello(env: Env) =>\n"
+        "env.out.print(\"hello\")\n"
+
+    "trait Abstract1\n"
+      "fun hello(env: Env)\n"
+
+    "actor Main is (Abstract1 & Concrete)\n"
+      "new create(env: Env) =>\n"
+        "hello(env)";
+
+  TEST_COMPILE(src);
+}
+


### PR DESCRIPTION
After trait body adoption, parameter definition nodes and body references can originate from different traits, making their source-line numbers incomparable. The `def_before_use` check compared those positions and fired a false error when the body-providing trait appeared before the abstract trait in source order.

The fix skips the check for `TK_PARAM` when the method body was adopted from a different trait (`ast_data(method) != frame->type`). The same guard is applied at all three call sites: `refer.c` (direct parameter references) and both `lambda.c` sites (explicit and implicit captured parameters).

Closes #5833
