### PR TITLE
Add weekly CI coverage for --runtimebc

### DIFF
--- a/.ci-scripts/linux-runtimebc-smoke.sh
+++ b/.ci-scripts/linux-runtimebc-smoke.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Runtime-bitcode smoke test for the weekly-checks job. Invoked from
+# .github/workflows/ponyc-weekly-checks.yml. Expects to run from the ponyc
+# source root, in a container that has already built libs.
+#
+# Exercises three things:
+#   1. PONY_RUNTIME_BITCODE=true produces libponyrt.bc (the llvm-link step).
+#   2. A Pony program compiled with --runtimebc links and runs.
+#   3. The stdlib test suite compiled with --runtimebc passes.
+set -eu
+
+# Build ponyc with the bitcode runtime. Remove any prior cmake build dir so the
+# configure is clean; the prebuilt LLVM in build/libs is a separate dir and is
+# untouched.
+rm -rf build/build_release
+cmake --preset release -DPONY_RUNTIME_BITCODE=true
+cmake --build --preset release
+
+# Verify the bitcode file was produced.
+if [ ! -f build/release/libponyrt.bc ]; then
+  echo "FAIL: PONY_RUNTIME_BITCODE=true did not produce libponyrt.bc"
+  exit 1
+fi
+echo "libponyrt.bc built: $(wc -c < build/release/libponyrt.bc) bytes"
+
+ponyc=build/release/ponyc
+
+# Compile and run a trivial program with --runtimebc.
+smoke=/tmp/runtimebc-smoke
+rm -rf "$smoke"
+mkdir -p "$smoke"
+cat > "$smoke/main.pony" <<'PONY'
+actor Main
+  new create(env: Env) =>
+    env.out.print("runtimebc smoke ok")
+PONY
+
+PONYPATH="$PWD/packages" "$ponyc" --runtimebc -b runtimebc-smoke -o "$smoke" "$smoke"
+out_text=$("$smoke/runtimebc-smoke")
+echo "$out_text"
+echo "$out_text" | grep -q "runtimebc smoke ok"
+
+# Compile and run the stdlib test suite with --runtimebc.
+PONYPATH=build/release "$ponyc" --runtimebc --pic -b stdlib-runtimebc -o build/release packages/stdlib
+build/release/stdlib-runtimebc --sequential
+
+echo "runtimebc smoke test passed"

--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -246,6 +246,51 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  runtimebc:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: ubuntu-latest
+
+    # PONY_RUNTIME_BITCODE builds every libponyrt .c file to LLVM bitcode and
+    # links them into libponyrt.bc with llvm-link. ponyc --runtimebc then merges
+    # that bitcode into the program's IR before optimisation, enabling cross-module
+    # interprocedural optimisation between Pony code and the runtime ("super LTO").
+    # Clang-only; incompatible with use=dtrace.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260425
+
+    name: runtimebc
+    container:
+      image: ${{ matrix.image }}
+      options: --user pony
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Build libs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIBS_IMAGE: ${{ matrix.image }}
+          LIBS_TAG: ${{ hashFiles('lib/CMakePresets.json', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/build-libs.cmake', 'lib/llvm/patches/*') }}
+        run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --branch-cache --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- cmake -DJOBS=4 -P lib/build-libs.cmake
+      - name: Runtime bitcode smoke test
+        run: sh .ci-scripts/linux-runtimebc-smoke.sh
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   systematic_testing_tests:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has-changes == 'true'


### PR DESCRIPTION
The `--runtimebc` flag and `PONY_RUNTIME_BITCODE` CMake option have no CI coverage. A weekly smoke test builds with the bitcode runtime, verifies `libponyrt.bc` is produced, compiles and runs a trivial program with `--runtimebc`, and compiles and runs the stdlib test suite with `--runtimebc`.

Closes #5864
