### PR TITLE
Report `match` pattern as unreachable when one type parameter would have to reify to two different types

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -49,7 +49,7 @@ main.pony:14:7: this pattern can never match
       ^
 ```
 
-Class, actor, and primitive patterns of this shape are now accepted; the match uses the fully reified type at runtime as it does for any other pattern. Trait and interface patterns still produce the same false error, as do a few less common shapes — union or intersection types appearing in a type argument, and two type parameters whose constraints only overlap through a common subtype. All are tracked as follow-up work.
+Class, actor, and primitive patterns of this shape are now accepted; the match uses the fully reified type at runtime as it does for any other pattern.
 
 ## Fix false "this pattern can never match" error for a type parameter inside a trait or interface type argument
 
@@ -86,5 +86,5 @@ main.pony:16:7: this pattern can never match
 
 Trait and interface patterns of this shape are now accepted when the operand's class nominally provides the pattern's trait or interface via `is`; the match uses the fully reified type at runtime as it does for any other pattern.
 
-A class that structurally satisfies an interface without declaring `is I` is not covered by this fix and still produces the same error — either add `is I[A]` on the class, or wait for a future release. The other shapes named in the earlier entity-side fix — union or intersection types appearing in a type argument, and two type parameters whose constraints only overlap through a common subtype — are also still tracked as follow-up work.
+A class that structurally satisfies an interface without declaring `is I` is not covered by this fix and still produces the same error — either add `is I[A]` on the class, or wait for a future release.
 

--- a/src/libponyc/type/matchtype.c
+++ b/src/libponyc/type/matchtype.c
@@ -8,6 +8,165 @@
 #include "viewpoint.h"
 #include "ponyassert.h"
 #include "alias.h"
+#include "../../libponyrt/mem/pool.h"
+
+// Substitution tracked across a single match_typeargs_pairwise walk. When
+// the same type parameter appears in more than one position of the two
+// typeargs lists being compared, every occurrence must reify to the same
+// type; without tracking, Pair[A, A] vs Pair[String, U8] would accept each
+// position independently even though no reification of A is both String
+// and U8.
+//
+// The typeparam_root(def) canonicalization keys each binding. The bound
+// type is a raw pointer into the AST tree being walked. When a recursive
+// call unfolds a type alias — typealias_unfold returns a freshly allocated
+// tree — subtrees of that unfolded tree may be bound; the tree therefore
+// has to outlive the walk, so subst_keep parks it on the substitution and
+// subst_free releases it at the end.
+typedef struct
+{
+  ast_t* def;
+  ast_t* type;
+} subst_entry_t;
+
+typedef struct
+{
+  subst_entry_t* entries;
+  size_t len;
+  size_t cap;
+  ast_t** keep;
+  size_t keep_len;
+  size_t keep_cap;
+} subst_t;
+
+static void subst_init(subst_t* s)
+{
+  s->entries = NULL;
+  s->len = 0;
+  s->cap = 0;
+  s->keep = NULL;
+  s->keep_len = 0;
+  s->keep_cap = 0;
+}
+
+static void subst_free(subst_t* s)
+{
+  if(s->entries != NULL)
+  {
+    ponyint_pool_free_size(s->cap * sizeof(subst_entry_t), s->entries);
+    s->entries = NULL;
+    s->len = 0;
+    s->cap = 0;
+  }
+
+  if(s->keep != NULL)
+  {
+    for(size_t i = 0; i < s->keep_len; i++)
+      ast_free_unattached(s->keep[i]);
+
+    ponyint_pool_free_size(s->keep_cap * sizeof(ast_t*), s->keep);
+    s->keep = NULL;
+    s->keep_len = 0;
+    s->keep_cap = 0;
+  }
+}
+
+static ast_t* subst_lookup(subst_t* s, ast_t* def)
+{
+  if(s == NULL)
+    return NULL;
+
+  for(size_t i = 0; i < s->len; i++)
+  {
+    if(s->entries[i].def == def)
+      return s->entries[i].type;
+  }
+
+  return NULL;
+}
+
+static void subst_bind(subst_t* s, ast_t* def, ast_t* type)
+{
+  if(s == NULL)
+    return;
+
+  // Invariant: callers look up first and only bind on a miss.
+  pony_assert(subst_lookup(s, def) == NULL);
+
+  if(s->len == s->cap)
+  {
+    size_t new_cap = (s->cap == 0) ? 4 : (s->cap * 2);
+    size_t old_size = s->cap * sizeof(subst_entry_t);
+    size_t new_size = new_cap * sizeof(subst_entry_t);
+    s->entries = (subst_entry_t*)ponyint_pool_realloc_size(old_size, new_size,
+      s->entries);
+    s->cap = new_cap;
+  }
+
+  s->entries[s->len].def = def;
+  s->entries[s->len].type = type;
+  s->len++;
+}
+
+static void subst_keep(subst_t* s, ast_t* ast)
+{
+  if(s == NULL)
+  {
+    ast_free_unattached(ast);
+    return;
+  }
+
+  if(s->keep_len == s->keep_cap)
+  {
+    size_t new_cap = (s->keep_cap == 0) ? 4 : (s->keep_cap * 2);
+    size_t old_size = s->keep_cap * sizeof(ast_t*);
+    size_t new_size = new_cap * sizeof(ast_t*);
+    s->keep = (ast_t**)ponyint_pool_realloc_size(old_size, new_size, s->keep);
+    s->keep_cap = new_cap;
+  }
+
+  s->keep[s->keep_len++] = ast;
+}
+
+// Save/restore checkpoint. Used by compound arm-covering to make each arm
+// attempt's bindings transient: one arm's bind must not leak to sibling
+// arms (which would spuriously reject `(P | A)` vs `(Q | A)`, where A can
+// reify to (P | Q)), and no arm's transient bind persists past the compound
+// branch. Restore truncates entries AND frees the extra keep trees; the
+// entries added since the checkpoint are the only references to those trees.
+typedef struct
+{
+  size_t entries_len;
+  size_t keep_len;
+} subst_checkpoint_t;
+
+static subst_checkpoint_t subst_save(subst_t* s)
+{
+  subst_checkpoint_t cp;
+
+  if(s == NULL)
+  {
+    cp.entries_len = 0;
+    cp.keep_len = 0;
+  } else {
+    cp.entries_len = s->len;
+    cp.keep_len = s->keep_len;
+  }
+
+  return cp;
+}
+
+static void subst_restore(subst_t* s, subst_checkpoint_t cp)
+{
+  if(s == NULL)
+    return;
+
+  for(size_t i = cp.keep_len; i < s->keep_len; i++)
+    ast_free_unattached(s->keep[i]);
+
+  s->keep_len = cp.keep_len;
+  s->len = cp.entries_len;
+}
 
 static matchtype_t is_x_match_x(ast_t* operand, ast_t* pattern,
   errorframe_t* errorf, bool report_reject, pass_opt_t* opt);
@@ -645,7 +804,8 @@ static bool typeparam_occurs_in(ast_t* tp_def, ast_t* other,
   return false;
 }
 
-static bool typeargs_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt);
+static bool typeargs_could_unify(subst_t* subst, ast_t* a, ast_t* b,
+  pass_opt_t* opt);
 
 // A concrete entity — class, primitive, actor, or struct — has no user-
 // visible subtype other than itself: Pony has no class-extends-class
@@ -730,14 +890,25 @@ static bool constraints_could_overlap(ast_t* a, ast_t* b, pass_opt_t* opt)
   return true;
 }
 
-// True if any arm of `compound` could unify with `other`.
-static bool any_arm_could_unify(ast_t* compound, ast_t* other,
+// True if any arm of `compound` could unify with `other`. Each arm attempt
+// snapshots subst on entry and restores on exit — bindings added by a
+// failed attempt must not leak to the next attempt, and bindings from a
+// successful attempt must not leak past the compound to the outer walk
+// (a bind of A→P from one arm attempt would then block a sibling arm from
+// binding A→Q that would otherwise succeed). Lookups still see outer
+// bindings, so a typeparam already bound by an earlier position is honored
+// inside the arm attempts.
+static bool any_arm_could_unify(subst_t* subst, ast_t* compound, ast_t* other,
   pass_opt_t* opt)
 {
   ast_t* arm = ast_child(compound);
   while(arm != NULL)
   {
-    if(typeargs_could_unify(arm, other, opt))
+    subst_checkpoint_t cp = subst_save(subst);
+    bool r = typeargs_could_unify(subst, arm, other, opt);
+    subst_restore(subst, cp);
+
+    if(r)
       return true;
 
     arm = ast_sibling(arm);
@@ -746,14 +917,21 @@ static bool any_arm_could_unify(ast_t* compound, ast_t* other,
   return false;
 }
 
-// True if every arm of `compound` could unify with `other`.
-static bool every_arm_could_unify(ast_t* compound, ast_t* other,
+// True if every arm of `compound` could unify with `other`. Same
+// snapshot/restore discipline as any_arm_could_unify — bindings from one
+// arm are transient. This is safe because compound-arm consistency is not
+// enforced across arms here; outer bindings are still visible via lookup.
+static bool every_arm_could_unify(subst_t* subst, ast_t* compound, ast_t* other,
   pass_opt_t* opt)
 {
   ast_t* arm = ast_child(compound);
   while(arm != NULL)
   {
-    if(!typeargs_could_unify(arm, other, opt))
+    subst_checkpoint_t cp = subst_save(subst);
+    bool r = typeargs_could_unify(subst, arm, other, opt);
+    subst_restore(subst, cp);
+
+    if(!r)
       return false;
 
     arm = ast_sibling(arm);
@@ -790,14 +968,18 @@ static bool other_is_subtype_of_every_arm(ast_t* compound, ast_t* other,
 // is handled by typeargs_could_unify's earlier branches, whose occurs
 // check would otherwise be bypassed.
 //
+// `subst` is looked up but effectively read-only through this branch:
+// any_arm_could_unify and every_arm_could_unify snapshot on each arm
+// attempt and restore on exit. Outer bindings from an earlier position
+// are honored inside arm attempts (so `Pair[A, (A | U8)]` vs
+// `Pair[String val, (I32 | U8)]` rejects — position 1 sees A bound to
+// String and no arm of the pattern matches). Bindings added inside an
+// arm attempt don't leak — required for `(P | A)` vs `(Q | A)` to accept,
+// which needs each arm to be tried with a fresh A.
+//
 // Rules:
 //   - Same kind (both union or both intersection): each arm on either side
-//     must have some arm on the other side that could unify. This is set-
-//     equality style: it does not enforce cross-arm consistency of a
-//     typeparam's reification, so `(P | A)` vs `(Q | A)` (same A on both
-//     sides) accepts even though no single reification of A satisfies
-//     both `(P | T) = (Q | T)`. Same over-approximation as
-//     `Pair[A, A]` vs `Pair[U8, U16]` in the same-def nominal recursion.
+//     must have some arm on the other side that could unify.
 //   - Mixed kinds (union vs intersection): any arm-vs-arm pair that could
 //     unify accepts. A common subtype of both sides supplies a valid
 //     reification.
@@ -808,7 +990,12 @@ static bool other_is_subtype_of_every_arm(ast_t* compound, ast_t* other,
 //     a subtype of every arm (so W inhabits the intersection). A
 //     typeparam arm accepts W iff W is admitted by the arm's constraint,
 //     which is_subtype_ignore_cap already models.
-static bool compound_types_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
+//
+// Residual gap: a typeparam bound inside a compound arm doesn't constrain
+// positions outside the compound. Fully closing that requires backtracking
+// across arm pairings, which is combinatorial.
+static bool compound_types_could_unify(subst_t* subst, ast_t* a, ast_t* b,
+  pass_opt_t* opt)
 {
   bool a_union = ast_id(a) == TK_UNIONTYPE;
   bool a_isect = ast_id(a) == TK_ISECTTYPE;
@@ -824,7 +1011,7 @@ static bool compound_types_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
     ast_t* arm = ast_child(a);
     while(arm != NULL)
     {
-      if(!any_arm_could_unify(b, arm, opt))
+      if(!any_arm_could_unify(subst, b, arm, opt))
         return false;
 
       arm = ast_sibling(arm);
@@ -833,7 +1020,7 @@ static bool compound_types_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
     arm = ast_child(b);
     while(arm != NULL)
     {
-      if(!any_arm_could_unify(a, arm, opt))
+      if(!any_arm_could_unify(subst, a, arm, opt))
         return false;
 
       arm = ast_sibling(arm);
@@ -847,7 +1034,7 @@ static bool compound_types_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
     ast_t* a_arm = ast_child(a);
     while(a_arm != NULL)
     {
-      if(any_arm_could_unify(b, a_arm, opt))
+      if(any_arm_could_unify(subst, b, a_arm, opt))
         return true;
 
       a_arm = ast_sibling(a_arm);
@@ -860,7 +1047,7 @@ static bool compound_types_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
   ast_t* other = a_compound ? b : a;
 
   if(ast_id(compound) == TK_UNIONTYPE)
-    return every_arm_could_unify(compound, other, opt);
+    return every_arm_could_unify(subst, compound, other, opt);
 
   return other_is_subtype_of_every_arm(compound, other, opt);
 }
@@ -874,6 +1061,12 @@ static bool compound_types_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
 // caps, so a compile-time cap check on the pair itself would spuriously
 // reject matches the runtime would accept.
 //
+// `subst` threads a substitution through the recursion so repeated
+// occurrences of the same type parameter across positions must reify to
+// the same type. Compound branches thread subst too, but each arm attempt
+// snapshots and restores it (see any_arm_could_unify) so within-compound
+// bindings are transient.
+//
 //   - eqtype pairs unify.
 //   - a bare type parameter unifies with anything the other side satisfies
 //     as a reification of the parameter's constraint (subtype, ignoring
@@ -881,10 +1074,16 @@ static bool compound_types_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
 //     parameter's def must not appear inside a generative constructor on
 //     the other side (occurs check): no reification satisfies A = f(A)
 //     without an infinite type. Occurrences in a union or intersection
-//     arm are not generative — A vs (A | U8) can unify.
-//   - two type parameters unify when their constraints share any common
-//     inhabitant (see constraints_could_overlap for the check and its
-//     over-approximation trade-offs).
+//     arm are not generative — A vs (A | U8) can unify. If the parameter
+//     is already bound in subst, the recorded binding must in turn unify
+//     with the other side; on a miss we record the binding.
+//   - two type parameters unify when either side is bound in subst and its
+//     binding unifies with the other side, or when neither side is bound
+//     and their constraints share any common inhabitant (see
+//     constraints_could_overlap for the check and its over-approximation
+//     trade-offs). The two-typeparam case doesn't add its own binding —
+//     that would require unifying two unification variables — but honors
+//     bindings recorded by earlier positions.
 //   - a union or intersection literal on either side (with neither side a
 //     bare type parameter) distributes over the arms (see
 //     compound_types_could_unify).
@@ -894,7 +1093,8 @@ static bool compound_types_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
 //     pair recursively unifies.
 //   - a type alias reference is unfolded and re-tried.
 //   - anything else does not unify.
-static bool typeargs_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
+static bool typeargs_could_unify(subst_t* subst, ast_t* a, ast_t* b,
+  pass_opt_t* opt)
 {
   if(is_eqtype(a, b, NULL, opt))
     return true;
@@ -905,9 +1105,9 @@ static bool typeargs_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
     if(unfolded == NULL)
       return false;
 
-    bool r = typeargs_could_unify(unfolded, b, opt);
+    bool r = typeargs_could_unify(subst, unfolded, b, opt);
     if(unfolded != a)
-      ast_free_unattached(unfolded);
+      subst_keep(subst, unfolded);
     return r;
   }
 
@@ -917,9 +1117,9 @@ static bool typeargs_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
     if(unfolded == NULL)
       return false;
 
-    bool r = typeargs_could_unify(a, unfolded, opt);
+    bool r = typeargs_could_unify(subst, a, unfolded, opt);
     if(unfolded != b)
-      ast_free_unattached(unfolded);
+      subst_keep(subst, unfolded);
     return r;
   }
 
@@ -928,6 +1128,21 @@ static bool typeargs_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
 
   if(a_tp && b_tp)
   {
+    ast_t* a_def = typeparam_root((ast_t*)ast_data(a));
+    ast_t* b_def = typeparam_root((ast_t*)ast_data(b));
+
+    // If either side is bound in subst, recurse through the binding — a
+    // later position that pairs an already-bound typeparam with another
+    // typeparam must check the bound value, not just constraint overlap.
+    ast_t* a_bound = subst_lookup(subst, a_def);
+    ast_t* b_bound = subst_lookup(subst, b_def);
+    if(a_bound != NULL && b_bound != NULL)
+      return typeargs_could_unify(subst, a_bound, b_bound, opt);
+    if(a_bound != NULL)
+      return typeargs_could_unify(subst, a_bound, b, opt);
+    if(b_bound != NULL)
+      return typeargs_could_unify(subst, a, b_bound, opt);
+
     ast_t* a_up = typeparam_upper(a);
     ast_t* b_up = typeparam_upper(b);
     bool r;
@@ -951,19 +1166,27 @@ static bool typeargs_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
     if(typeparam_occurs_in(tp_def, other, false))
       return false;
 
-    ast_t* upper = typeparam_upper(tp);
-    if(upper == NULL)
-      return true;
+    ast_t* bound = subst_lookup(subst, tp_def);
+    if(bound != NULL)
+      return typeargs_could_unify(subst, bound, other, opt);
 
-    bool r = is_subtype_ignore_cap(other, upper, NULL, opt);
-    ast_free_unattached(upper);
-    return r;
+    ast_t* upper = typeparam_upper(tp);
+    if(upper != NULL)
+    {
+      bool ok = is_subtype_ignore_cap(other, upper, NULL, opt);
+      ast_free_unattached(upper);
+      if(!ok)
+        return false;
+    }
+
+    subst_bind(subst, tp_def, other);
+    return true;
   }
 
   if((ast_id(a) == TK_UNIONTYPE) || (ast_id(a) == TK_ISECTTYPE)
     || (ast_id(b) == TK_UNIONTYPE) || (ast_id(b) == TK_ISECTTYPE))
   {
-    return compound_types_could_unify(a, b, opt);
+    return compound_types_could_unify(subst, a, b, opt);
   }
 
   if((ast_id(a) == TK_NOMINAL) && (ast_id(b) == TK_NOMINAL))
@@ -982,7 +1205,7 @@ static bool typeargs_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
 
     while((a_arg != NULL) && (b_arg != NULL))
     {
-      if(!typeargs_could_unify(a_arg, b_arg, opt))
+      if(!typeargs_could_unify(subst, a_arg, b_arg, opt))
         return false;
 
       a_arg = ast_sibling(a_arg);
@@ -999,7 +1222,7 @@ static bool typeargs_could_unify(ast_t* a, ast_t* b, pass_opt_t* opt)
 
     while((a_elem != NULL) && (b_elem != NULL))
     {
-      if(!typeargs_could_unify(a_elem, b_elem, opt))
+      if(!typeargs_could_unify(subst, a_elem, b_elem, opt))
         return false;
 
       a_elem = ast_sibling(a_elem);
@@ -1033,6 +1256,8 @@ static matchtype_t match_typeargs_pairwise(ast_t* o_typeargs, ast_t* p_typeargs,
   ast_t* p_arg = ast_child(p_typeargs);
 
   matchtype_t ok = MATCHTYPE_ACCEPT;
+  subst_t subst;
+  subst_init(&subst);
 
   while((o_arg != NULL) && (p_arg != NULL))
   {
@@ -1044,13 +1269,16 @@ static matchtype_t match_typeargs_pairwise(ast_t* o_typeargs, ast_t* p_typeargs,
       pair = MATCHTYPE_REJECT;
     else if(struct_pattern)
       pair = MATCHTYPE_DENY_NODESC;
-    else if(typeargs_could_unify(o_arg, p_arg, opt))
+    else if(typeargs_could_unify(&subst, o_arg, p_arg, opt))
       pair = MATCHTYPE_ACCEPT;
     else
       pair = MATCHTYPE_REJECT;
 
     if(pair == MATCHTYPE_DENY_NODESC)
+    {
+      subst_free(&subst);
       return MATCHTYPE_DENY_NODESC;
+    }
 
     if((pair == MATCHTYPE_REJECT) && (ok == MATCHTYPE_ACCEPT))
       ok = MATCHTYPE_REJECT;
@@ -1059,6 +1287,7 @@ static matchtype_t match_typeargs_pairwise(ast_t* o_typeargs, ast_t* p_typeargs,
     p_arg = ast_sibling(p_arg);
   }
 
+  subst_free(&subst);
   return ok;
 }
 

--- a/test/libponyc/matchtype.cc
+++ b/test/libponyc/matchtype.cc
@@ -2087,3 +2087,536 @@ TEST_F(MatchTypeTest, TypeParamInTypeArgTupleOccurs)
   ASSERT_EQ(MATCHTYPE_REJECT,
     is_matchtype(type_of("c1_a"), type_of("c1_tuple_wrap_a"), NULL, &opt));
 }
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionRepeatedParam)
+{
+  // The same type parameter appearing in more than one typearg position
+  // must reify to the same type at every occurrence. `Pair[A, A]` vs
+  // `Pair[String val, U8]` has no reification of A that is both String and
+  // U8, so match_typeargs_pairwise must reject.
+  //
+  // The consistent-both-concrete case `Pair[A, A]` vs `Pair[String, String]`
+  // must still accept — A = String satisfies both positions.
+  const char* src =
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (p_aa: Pair[A, A],\n"
+    "     p_string_u8: Pair[String val, U8],\n"
+    "     p_string_string: Pair[String val, String val])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_aa"), type_of("p_string_u8"), NULL, &opt));
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_string_u8"), type_of("p_aa"), NULL, &opt));
+
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("p_aa"), type_of("p_string_string"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionDistinctParams)
+{
+  // Distinct type parameters bind independently. `Pair[A, B]` vs
+  // `Pair[String val, U8]` must still accept: A can reify to String and B
+  // to U8; the consistency check only fires for repeated occurrences of
+  // the same def.
+  const char* src =
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share, B: Any #share]\n"
+    "    (p_ab: Pair[A, B],\n"
+    "     p_string_u8: Pair[String val, U8])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("p_ab"), type_of("p_string_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionNested)
+{
+  // Substitution threads through nested nominal recursion:
+  // `Cell[Pair[A, A]]` vs `Cell[Pair[String val, U8]]` recurses into the
+  // outer Cell's typearg, which is itself Pair[..] vs Pair[..], and the
+  // inner walk must reject the mismatched pair.
+  const char* src =
+    "class val Cell[X: Any #share]\n"
+    "  let value: X\n"
+    "  new val create(v: X) => value = v\n"
+
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (cell_pair_aa: Cell[Pair[A, A]],\n"
+    "     cell_pair_string_u8: Cell[Pair[String val, U8]])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("cell_pair_aa"),
+      type_of("cell_pair_string_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionMixedPosition)
+{
+  // Repeated typeparam on the operand paired against a mix of concrete and
+  // typeparam on the pattern side. `Pair[A, A]` vs `Pair[String val, B]`:
+  // position 0 binds A = String; position 1 pairs A against B (two-typeparam
+  // branch, over-approximates without consulting subst). The pair still
+  // accepts because a consistent reification exists — A = B = String —
+  // even though the current algorithm doesn't check it.
+  const char* src =
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share, B: Any #share]\n"
+    "    (p_aa: Pair[A, A],\n"
+    "     p_string_b: Pair[String val, B])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("p_aa"), type_of("p_string_b"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionAlias)
+{
+  // Type alias in a typearg position exercises typealias_unfold, which
+  // returns a freshly allocated tree. The unfolded tree may contribute a
+  // subtree to subst; subst_keep must hold it alive across positions or a
+  // later position's lookup would dereference freed memory.
+  //
+  // `Pair[A, A]` vs `Pair[StringAlias, U8]` (with StringAlias = String val)
+  // must reject: after unfolding StringAlias the pattern is effectively
+  // Pair[String val, U8], and the reported shape's rejection applies.
+  const char* src =
+    "type StringAlias is String val\n"
+
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (p_aa: Pair[A, A],\n"
+    "     p_alias_u8: Pair[StringAlias, U8])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_aa"), type_of("p_alias_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionRepeatedCompoundArg)
+{
+  // Repeated typeparam paired against a repeated compound arg. `Pair[A, A]`
+  // vs `Pair[(U8 | I32), (U8 | I32)]`: position 0 enters the one-typeparam
+  // branch (typeparam checks come before the compound branch) and binds A
+  // to the union; position 1 looks up A and recurses on the two identical
+  // unions, which is_eqtype accepts. Whole pair accepts because
+  // A = (U8 | I32) is a consistent reification.
+  const char* src =
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (p_aa: Pair[A, A],\n"
+    "     p_union_union: Pair[(U8 | I32), (U8 | I32)])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("p_aa"), type_of("p_union_union"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest,
+  TypeParamInTypeArgConsistentSubstitutionConstrainedTypeParam)
+{
+  // Constrained typeparam repeated across positions. A is constrained to
+  // (U8 | String val); position 0 binds A = U8, position 1 recurses with
+  // the bound U8 against String — is_eqtype false, nominal-nominal
+  // different-def rejects. Whole pair rejects.
+  const char* src =
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: (U8 | String val)]\n"
+    "    (p_aa: Pair[A, A],\n"
+    "     p_u8_string: Pair[U8, String val])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_aa"), type_of("p_u8_string"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionTraitPath)
+{
+  // Same-shape consistency for the trait/interface path
+  // (provides_could_match_pattern → match_typeargs_pairwise). Cons[A]
+  // provides T[A, A]; the pattern T[String val, U8] can never be reached
+  // from a Cons[A] operand because no reification of A is both String and
+  // U8.
+  const char* src =
+    "trait val T[A: Any #share, B: Any #share]\n"
+    "  fun first(): A\n"
+    "  fun second(): B\n"
+
+    "class val Cons[A: Any #share] is T[A, A]\n"
+    "  let _v: A\n"
+    "  new val create(v: A) => _v = v\n"
+    "  fun first(): A => _v\n"
+    "  fun second(): A => _v\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (cons_a: Cons[A],\n"
+    "     t_string_u8: T[String val, U8] val)";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("cons_a"), type_of("t_string_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionInterfacePath)
+{
+  // Interface-path parallel to the TraitPath test above. Cons[A] provides
+  // an interface I that carries T[A, A]; the pattern I[String val, U8]
+  // has no reification of A that is both String and U8.
+  const char* src =
+    "interface val I[A: Any #share, B: Any #share]\n"
+    "  fun first(): A\n"
+    "  fun second(): B\n"
+
+    "class val Cons[A: Any #share] is I[A, A]\n"
+    "  let _v: A\n"
+    "  new val create(v: A) => _v = v\n"
+    "  fun first(): A => _v\n"
+    "  fun second(): A => _v\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (cons_a: Cons[A],\n"
+    "     i_string_u8: I[String val, U8] val)";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("cons_a"), type_of("i_string_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionTupleElement)
+{
+  // Substitution threads through the tuple recursion path in
+  // typeargs_could_unify. `Cell[(A, A)]` vs `Cell[(String val, U8)]`
+  // reaches the tuple branch during the outer Cell's typearg walk, and the
+  // tuple's second element rejects because A is already bound to String.
+  const char* src =
+    "class val Cell[X: Any #share]\n"
+    "  let value: X\n"
+    "  new val create(v: X) => value = v\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (cell_tuple_aa: Cell[(A, A)],\n"
+    "     cell_tuple_string_u8: Cell[(String val, U8)])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("cell_tuple_aa"),
+      type_of("cell_tuple_string_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest,
+  TypeParamInTypeArgConsistentSubstitutionMultipleRepeatedParams)
+{
+  // Multiple distinct repeated typeparams live in subst simultaneously.
+  // Quad[A, A, B, B] vs Quad[String, U8, I32, I32]: A binds to String at
+  // position 0 and mismatches U8 at position 1, so the whole list rejects.
+  // A separate accept case swaps position 1 to String to prove B's binding
+  // is looked up independently of A's.
+  const char* src =
+    "class val Quad[A: Any #share, B: Any #share,\n"
+    "               C: Any #share, D: Any #share]\n"
+    "  let a: A\n"
+    "  let b: B\n"
+    "  let c: C\n"
+    "  let d: D\n"
+    "  new val create(a': A, b': B, c': C, d': D) =>\n"
+    "    a = a'; b = b'; c = c'; d = d'\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share, B: Any #share]\n"
+    "    (q_aabb: Quad[A, A, B, B],\n"
+    "     q_reject: Quad[String val, U8, I32, I32],\n"
+    "     q_accept: Quad[String val, String val, I32, I32])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("q_aabb"), type_of("q_reject"), NULL, &opt));
+
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("q_aabb"), type_of("q_accept"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgConsistentSubstitutionWithOccurs)
+{
+  // Occurs and consistent-substitution interact when a typeparam appears
+  // both bare in one position and inside a generative constructor in a
+  // later position that also carries a concrete on the other side.
+  //
+  // Pair[A, Wrap[A]] vs Pair[String val, Wrap[String val]] accepts:
+  // A = String satisfies both positions.
+  //
+  // Pair[A, Wrap[A]] vs Pair[String val, Wrap[U8]] rejects: A bound to
+  // String at position 0, then position 1's nominal-nominal recursion into
+  // Wrap's typearg finds A already bound to String, which does not unify
+  // with U8.
+  const char* src =
+    "class val Wrap[A: Any #share]\n"
+    "  let value: A\n"
+    "  new val create(v: A) => value = v\n"
+
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (p_a_wrap_a: Pair[A, Wrap[A] val],\n"
+    "     p_string_wrap_string: Pair[String val, Wrap[String val] val],\n"
+    "     p_string_wrap_u8: Pair[String val, Wrap[U8] val])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("p_a_wrap_a"),
+      type_of("p_string_wrap_string"), NULL, &opt));
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_a_wrap_a"),
+      type_of("p_string_wrap_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest,
+  TypeParamInTypeArgConsistentSubstitutionCompoundArg)
+{
+  // Compound (union / intersection) typearg position honors outer subst.
+  // `Pair[A, (A | U8)]` vs `Pair[String val, (I32 | U8)]` rejects: position
+  // 0 binds A = String, position 1's arm-covering finds no b-arm that
+  // matches a-arm A once A is bound (String ≠ I32, String ≠ U8).
+  //
+  // Intersection variant checks the same in every_arm_could_unify's path.
+  //
+  // Legit-accept `(P | A)` vs `(Q | A)` must still accept — the per-arm
+  // snapshot/restore in any_arm_could_unify keeps sibling arm attempts
+  // independent so A can bind to P and Q in separate attempts without
+  // conflict. That's covered by TypeParamInTypeArgUnionArmSameTypeParam.
+  const char* src =
+    "primitive P\n"
+
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (p_a_union_a_u8: Pair[A, (A | U8)],\n"
+    "     p_string_union_i32_u8: Pair[String val, (I32 | U8)],\n"
+    "     p_string_union_string_u8: Pair[String val, (String val | U8)],\n"
+    "     p_a_isect_a_any: Pair[A, (A & Any val)],\n"
+    "     p_string_isect_i32_any: Pair[String val, (I32 & Any val)])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_a_union_a_u8"),
+      type_of("p_string_union_i32_u8"), NULL, &opt));
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_string_union_i32_u8"),
+      type_of("p_a_union_a_u8"), NULL, &opt));
+
+  // A = String val makes (A | U8) = (String val | U8). Both positions
+  // reify consistently — accept.
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("p_a_union_a_u8"),
+      type_of("p_string_union_string_u8"), NULL, &opt));
+
+  // Intersection variant of the same shape.
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_a_isect_a_any"),
+      type_of("p_string_isect_i32_any"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest,
+  TypeParamInTypeArgConsistentSubstitutionCompoundArgNested)
+{
+  // Nested inside another nominal — the outer Cell recursion still
+  // threads subst into the inner Pair's typearg walk, so the same
+  // rejection fires at any depth.
+  const char* src =
+    "class val Cell[X: Any #share]\n"
+    "  let value: X\n"
+    "  new val create(v: X) => value = v\n"
+
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (cell_pair_a_union_a_u8:\n"
+    "       Cell[Pair[A, (A | U8)] val],\n"
+    "     cell_pair_string_union_i32_u8:\n"
+    "       Cell[Pair[String val, (I32 | U8)] val])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("cell_pair_a_union_a_u8"),
+      type_of("cell_pair_string_union_i32_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest,
+  TypeParamInTypeArgConsistentSubstitutionCompoundArgArmNominal)
+{
+  // Typeparam one nominal down inside a compound arm. Position 0 binds
+  // A = String; position 1's arm-covering tries Cell[A] vs Cell[I32],
+  // which recurses into the inner typearg and hits A already bound to
+  // String — String ≠ I32 → reject.
+  const char* src =
+    "class val Cell[X: Any #share]\n"
+    "  let value: X\n"
+    "  new val create(v: X) => value = v\n"
+
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (p_a_cell_a_u8:\n"
+    "       Pair[A, (Cell[A] val | U8)],\n"
+    "     p_string_cell_i32_u8:\n"
+    "       Pair[String val, (Cell[I32] val | U8)])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_a_cell_a_u8"),
+      type_of("p_string_cell_i32_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest,
+  TypeParamInTypeArgConsistentSubstitutionCompoundArgTraitPath)
+{
+  // Trait/interface path exercises the same subst threading via
+  // provides_could_match_pattern. Cons[A] provides T[A, (A | U8)]; the
+  // pattern T[String val, (I32 | U8)] requires A both String and (I32|U8)
+  // — impossible.
+  const char* src =
+    "trait val T[A: Any #share, B: Any #share]\n"
+    "  fun first(): A\n"
+    "  fun second(): B\n"
+
+    "class val Cons[A: Any #share] is T[A, (A | U8)]\n"
+    "  let _v: A\n"
+    "  new val create(v: A) => _v = v\n"
+    "  fun first(): A => _v\n"
+    "  fun second(): (A | U8) => _v\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (cons_a: Cons[A],\n"
+    "     t_string_union_i32_u8: T[String val, (I32 | U8)] val)";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("cons_a"),
+      type_of("t_string_union_i32_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest,
+  TypeParamInTypeArgConsistentSubstitutionTwoTypeParams)
+{
+  // Two-typeparam branch also consults subst. `Pair[A, A]` vs
+  // `Pair[String val, B]` where B: I32: position 0 binds A = String,
+  // position 1 pairs A (bound to String) against B (unbound); the
+  // recursive check on String val vs B falls to the one-typeparam branch
+  // and rejects because B's I32 constraint doesn't admit String.
+  //
+  // The legit-accept counterpart — `Pair[A, A]` vs `Pair[String, B]`
+  // where B: Any share — must still accept, because after A binds to
+  // String at position 0, position 1's B vs String recurse binds B =
+  // String successfully.
+  const char* src =
+    "class val Pair[A: Any #share, B: Any #share]\n"
+    "  let first: A\n"
+    "  let second: B\n"
+    "  new val create(a: A, b: B) => first = a; second = b\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share, B: I32, C: Any #share]\n"
+    "    (p_aa: Pair[A, A],\n"
+    "     p_string_b: Pair[String val, B],\n"
+    "     p_string_c: Pair[String val, C])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("p_aa"), type_of("p_string_b"), NULL, &opt));
+
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("p_aa"), type_of("p_string_c"), NULL, &opt));
+}


### PR DESCRIPTION
Closes #5862.

`match_typeargs_pairwise` threads a substitution through `typeargs_could_unify` so repeated occurrences of the same type parameter across positions must reify to the same type. Three branches of the helper had been checking each position independently:

- **Nominal and tuple recursion.** `Pair[A, A]` vs `Pair[String val, U8]` used to compile and fall through at runtime because each position accepted A independently. Position 1 now looks up A in the substitution recorded at position 0 and rejects.
- **Two-typeparam pairs.** `Pair[A, A]` vs `Pair[String val, B]` (with `B: I32`) had the same shape one recursion down — A bound to String at position 0, then paired against B at position 1 and accepted by constraint-overlap alone. The two-typeparam branch now consults the substitution before falling back to constraint overlap.
- **Compound (union / intersection) typearg positions.** `Pair[A, (A | U8)]` vs `Pair[String val, (I32 | U8)]`, its intersection variant, the nested-inside-`Cell` variant, and the trait-path variant all used to compile silently. `compound_types_could_unify` now threads the substitution; `any_arm_could_unify` and `every_arm_could_unify` snapshot on each arm attempt and restore on exit, so outer bindings from an earlier position are honored inside arm attempts but transient bindings added by one arm attempt never leak to a sibling. That per-attempt discipline is what keeps `(P | A)` vs `(Q | A)` accepting — A binds to P and Q in independent attempts without conflict.

Alias unfolding in `typeargs_could_unify` parks freshly allocated trees on the substitution's keepalive list so bindings that reference subtrees of an unfolded alias stay valid across positions.

The last cleanup: the accumulated unreleased entries for #5858 and #5861 listed trait/interface patterns and union/intersection typearg positions as still-open follow-up work. Both are since fixed by #5861 and #5866. The stale sentences are dropped.

Residual, documented in the code but not tested: a typeparam bound *inside* a compound arm doesn't constrain positions *outside* the compound. Fully closing that requires backtracking across arm-pairings, which is combinatorial and not what this PR takes on. Practical impact seems low — the shape needs a typeparam to appear only inside a compound arm on one side and elsewhere on the other — but if it turns up in real code the residual is worth revisiting.

Design: #5008
