### PR TITLE
Use QEMU serial console for DragonFly BSD VM setup

### DIFF
--- a/.ci-scripts/bsd/dfly_configure_vm.py
+++ b/.ci-scripts/bsd/dfly_configure_vm.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python3
-"""Drive the DragonFly BSD VM's VGA console over the QEMU monitor.
+"""Drive the DragonFly BSD VM setup via QEMU serial console.
 
-DragonFly raw images boot to a passwordless root login with no cloud-init, so the
-commands that bring SSH up (login, network, sshd, ssh key) are typed in with QEMU
-monitor `sendkey`. Each run first clears any half-typed line, then logs in fresh,
-so a re-run after a failed attempt starts from a clean prompt instead of adding to
-a line an earlier run left unfinished. Reads the public key to install from the
-PUB_KEY environment variable and the QEMU monitor socket path from DFLY_MONITOR_SOCK
-(defaulting to dfly-monitor.sock in the current directory). Called by
-dragonfly-provision.bash.
+DragonFly raw images boot to a passwordless root login with no cloud-init.
+Typing every command blind via VGA sendkey fails when boot is slow enough that
+keystrokes arrive before the login prompt.  This script uses a two-phase
+approach:
+
+  Phase 1 (sendkey bootstrap): After waiting for the boot loader to pass, type
+  the root login and a command that starts a /bin/sh on the serial port, all via
+  QEMU sendkey into the VGA console.  A retry loop handles the variable boot
+  time — each attempt clears the console, logs in, and starts the serial shell,
+  checking for a shell prompt on the serial socket before moving on.
+
+  Phase 2 (serial setup): Run all setup commands (network, sshd, ssh key)
+  through the serial console with prompt detection, so each command is confirmed
+  before the next is sent.
+
+Reads PUB_KEY, DFLY_MONITOR_SOCK, and DFLY_SERIAL_SOCK from the environment.
+Called by dragonfly-provision.bash.
 """
 import os
 import socket
+import sys
 import time
 
 KEYMAP = {
@@ -27,6 +37,12 @@ KEYMAP = {
     '%': 'shift-5', '^': 'shift-6', '&': 'shift-7', '*': 'shift-8',
     '(': 'shift-9', ')': 'shift-0',
 }
+
+BOOT_LOADER_WAIT = 30
+BOOT_TIMEOUT = 300
+COMMAND_TIMEOUT = 60
+MAX_BOOTSTRAP_ATTEMPTS = 20
+SERIAL_DEVICE = '/dev/cuaa0'
 
 
 def send_hmp(sock, cmd):
@@ -54,54 +70,141 @@ def send_line(sock, text):
         time.sleep(0.03)
 
 
+def serial_recv(sock, timeout=3):
+    sock.settimeout(timeout)
+    data = b''
+    try:
+        while True:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    except socket.timeout:
+        pass
+    sock.settimeout(None)
+    return data.decode(errors='replace')
+
+
+def serial_drain(sock):
+    sock.settimeout(0.3)
+    try:
+        while sock.recv(4096):
+            pass
+    except socket.timeout:
+        pass
+    sock.settimeout(None)
+
+
+def serial_cmd(sock, cmd, timeout=COMMAND_TIMEOUT):
+    """Send a command over serial and wait for the next shell prompt.
+
+    Returns the output on success, raises RuntimeError on timeout.
+    """
+    sock.sendall((cmd + '\n').encode())
+    output = ''
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        remaining = deadline - time.time()
+        chunk = serial_recv(sock, timeout=min(2, max(0.1, remaining)))
+        output += chunk
+        # The serial shell is /bin/sh running as root, whose default prompt
+        # ends with '#'.  None of the commands this script runs produce
+        # output ending with '#'.
+        if output.rstrip().endswith('#'):
+            return output
+    raise RuntimeError(f"serial_cmd timed out after {timeout}s: {cmd!r}")
+
+
+def bootstrap_serial_shell(monitor, serial):
+    """Type login + serial shell start via sendkey; retry until serial responds.
+
+    Returns True once a shell prompt appears on the serial socket.
+    """
+    time.sleep(BOOT_LOADER_WAIT)
+
+    deadline = time.time() + BOOT_TIMEOUT
+    for attempt in range(1, MAX_BOOTSTRAP_ATTEMPTS + 1):
+        if time.time() > deadline:
+            break
+
+        print(f"  attempt {attempt}: sendkey login + serial shell...")
+
+        send_hmp(monitor, 'sendkey ctrl-c')
+        time.sleep(0.3)
+
+        send_line(monitor, '')
+        time.sleep(0.5)
+        send_line(monitor, 'root')
+        time.sleep(2)
+
+        # Kill stale serial shells, then start a fresh one.
+        # Root's login shell is csh, so wrap sh-specific redirects in /bin/sh -c.
+        send_line(monitor, 'pkill -f cuaa0')
+        time.sleep(1)
+        cmd = f"/bin/sh -c '/bin/sh <{SERIAL_DEVICE} >{SERIAL_DEVICE} 2>&1 &'"
+        send_line(monitor, cmd)
+        time.sleep(2)
+
+        serial.sendall(b'\n')
+        response = serial_recv(serial, timeout=3)
+        if '#' in response or '$' in response:
+            print(f"  serial shell up after {attempt} attempt(s)")
+            return True
+
+        print(f"  no serial prompt (got: {response!r})")
+        time.sleep(10)
+
+    return False
+
+
 def main():
     pub_key = os.environ["PUB_KEY"]
     monitor_sock = os.environ.get("DFLY_MONITOR_SOCK", "dfly-monitor.sock")
+    serial_sock = os.environ.get("DFLY_SERIAL_SOCK", "dfly-serial.sock")
 
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    sock.connect(monitor_sock)
+    monitor = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    monitor.connect(monitor_sock)
     time.sleep(0.5)
-    sock.recv(4096)
+    monitor.recv(4096)
 
-    # Clear any half-typed line left by a dropped keystroke on an earlier run: an
-    # unterminated quote leaves the shell at a continuation prompt, and without
-    # this the next run's keystrokes are swallowed by the open string. ctrl-c
-    # cancels the pending line so this run starts at a fresh prompt.
-    send_hmp(sock, 'sendkey ctrl-c')
-    time.sleep(0.5)
+    serial = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    serial.connect(serial_sock)
+    serial_drain(serial)
 
-    # Press enter and login as root (no password)
-    send_line(sock, '')
-    time.sleep(2)
-    send_line(sock, 'root')
-    time.sleep(3)
+    try:
+        print("Bootstrapping serial shell via sendkey...")
+        if not bootstrap_serial_shell(monitor, serial):
+            print("ERROR: serial shell never came up", file=sys.stderr)
+            return 1
 
-    # Configure network
-    send_line(sock, 'dhclient vtnet0')
-    time.sleep(15)
+        serial_drain(serial)
 
-    # Configure sshd
-    send_line(sock, 'echo "PermitRootLogin yes" >> /etc/ssh/sshd_config')
-    time.sleep(0.5)
-    send_line(sock, 'echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config')
-    time.sleep(0.5)
+        print("Configuring VM via serial console...")
 
-    # Install SSH key
-    send_line(sock, 'mkdir -p /root/.ssh && chmod 700 /root/.ssh')
-    time.sleep(0.5)
-    send_line(sock, f'echo "{pub_key}" > /root/.ssh/authorized_keys')
-    time.sleep(0.5)
-    send_line(sock, 'chmod 600 /root/.ssh/authorized_keys')
-    time.sleep(0.5)
+        serial_cmd(serial, 'dhclient vtnet0', timeout=COMMAND_TIMEOUT)
 
-    # Generate host keys (virtio-rng provides entropy) and start sshd
-    send_line(sock, 'ssh-keygen -A')
-    time.sleep(10)
-    send_line(sock, '/usr/sbin/sshd')
-    time.sleep(3)
+        serial_cmd(serial,
+                   'echo "PermitRootLogin yes" >> /etc/ssh/sshd_config')
+        serial_cmd(serial,
+                   'echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config')
 
-    sock.close()
+        serial_cmd(serial, 'mkdir -p /root/.ssh && chmod 700 /root/.ssh')
+        serial_cmd(serial,
+                   f'echo "{pub_key}" > /root/.ssh/authorized_keys')
+        serial_cmd(serial, 'chmod 600 /root/.ssh/authorized_keys')
+
+        serial_cmd(serial, 'ssh-keygen -A', timeout=COMMAND_TIMEOUT)
+        serial_cmd(serial, '/usr/sbin/sshd')
+
+        print("VM configured successfully")
+        return 0
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        monitor.close()
+        serial.close()
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/.ci-scripts/bsd/dfly_configure_vm_test.py
+++ b/.ci-scripts/bsd/dfly_configure_vm_test.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python3
-"""Tests for dfly_configure_vm: KEYMAP de-escaping, send_line key mapping, the
-monitor-socket path selection, and the console reset.
+"""Tests for dfly_configure_vm.
 
-The KEYMAP checks guard the heredoc-to-standalone-.py extraction: the entries for
-backslash, backtick and dollar were shell-escaped in the original embedded
-heredoc, so a botched de-escape would silently corrupt them. The monitor-socket
-checks guard the contract with dragonfly-provision.bash, which creates the socket
-under VM_ARTIFACTS (outside the checkout, so it isn't rsynced into the guest) and
-passes its path via DFLY_MONITOR_SOCK; hardcoding the path back would break
-DragonFly provisioning. The console-reset check guards that main() sends ctrl-c
-before any login keystroke, so a re-run after a dropped keystroke starts at a fresh
-prompt rather than adding to a half-typed line. No VM required.
+Guards the KEYMAP de-escaping (backslash, backtick, dollar were shell-escaped in
+the original heredoc), send_line key mapping, the socket-path contract with
+dragonfly-provision.bash (DFLY_MONITOR_SOCK / DFLY_SERIAL_SOCK), and the
+two-phase bootstrap + serial setup flow.  No VM required.
 """
 import os
+import socket
 import sys
 
 import dfly_configure_vm as d
@@ -22,7 +17,6 @@ def _noop(*_args, **_kwargs):
     return None
 
 
-# the module's per-keystroke sleeps would make the test crawl; stub them out
 d.time.sleep = _noop
 
 
@@ -46,52 +40,15 @@ def keys_for(text):
     return [k.removeprefix('sendkey ') for k in sock.keys]
 
 
-class ConnectSock:
-    """A socket stand-in that records the path main() connects to."""
-
-    connected_path = None
-
-    def connect(self, path):
-        ConnectSock.connected_path = path
-
-    def sendall(self, _):
-        pass
-
-    def settimeout(self, _):
-        pass
-
-    def recv(self, _):
-        return b''
-
-    def close(self):
-        pass
-
-
-def monitor_path_for(env):
-    """Run main() with a stubbed socket and env; return the connected path."""
-    ConnectSock.connected_path = None
-    saved_env = dict(os.environ)
-    saved_socket = d.socket.socket
-    os.environ.clear()
-    os.environ.update(env)
-    d.socket.socket = lambda *_a, **_k: ConnectSock()
-    try:
-        d.main()
-    finally:
-        d.socket.socket = saved_socket
-        os.environ.clear()
-        os.environ.update(saved_env)
-    return ConnectSock.connected_path
-
-
-class RecordingSock:
-    """A socket stand-in that records every command main() sends."""
+class MonitorSock:
+    """Records HMP commands sent to the monitor socket."""
 
     def __init__(self):
         self.sent = []
+        self._first_recv = True
 
-    def connect(self, _):
-        pass
+    def connect(self, path):
+        self.connected_path = path
 
     def sendall(self, data):
         self.sent.append(data.decode().strip())
@@ -100,20 +57,124 @@ class RecordingSock:
         pass
 
     def recv(self, _):
-        return b''
+        if self._first_recv:
+            self._first_recv = False
+            return b'(qemu) '
+        raise socket.timeout
 
     def close(self):
         pass
 
 
-def capture_main(env):
-    """Run main() with a recording socket and send_line captured; return
-    (sendkeys, typed_lines) -- the ordered sendkey args and the text of each line
-    main() types into the console."""
+class SerialSock:
+    """Simulates the serial socket.
+
+    Returns a shell prompt ('# ') on the first recv after a sendall of '\\n'
+    (the probe the bootstrap sends to check for a shell).  Subsequent recv
+    calls for serial_cmd also return '# ' so the command loop exits.
+    All other recv calls raise socket.timeout to unblock serial_recv/drain.
+    """
+
+    def __init__(self):
+        self.sent = []
+        self._got_probe = False
+        self._responded = False
+
+    def connect(self, path):
+        self.connected_path = path
+
+    def sendall(self, data):
+        text = data.decode().strip()
+        self.sent.append(text)
+        if data == b'\n':
+            self._got_probe = True
+            self._responded = False
+        elif text:
+            self._got_probe = True
+            self._responded = False
+
+    def settimeout(self, _):
+        pass
+
+    def recv(self, _):
+        if self._got_probe and not self._responded:
+            self._responded = True
+            return b'# '
+        raise socket.timeout
+
+    def close(self):
+        pass
+
+
+class RetrySerialSock(SerialSock):
+    """Serial socket that responds only on the Nth probe.
+
+    The first (skip_count) probes (sendall of b'\\n') return no prompt; the
+    next one succeeds.  Exercises the bootstrap retry loop.
+    """
+
+    def __init__(self, skip_count=1):
+        super().__init__()
+        self._probe_count = 0
+        self._skip_count = skip_count
+
+    def sendall(self, data):
+        text = data.decode().strip()
+        self.sent.append(text)
+        if data == b'\n':
+            self._probe_count += 1
+            if self._probe_count > self._skip_count:
+                self._got_probe = True
+                self._responded = False
+        elif text:
+            self._got_probe = True
+            self._responded = False
+
+
+class DeadSerialSock(SerialSock):
+    """Serial socket that never returns a prompt."""
+
+    def recv(self, _):
+        raise socket.timeout
+
+
+class TimeoutSerialSock:
+    """Serial socket for testing serial_cmd timeout."""
+
+    def __init__(self):
+        self.sent = []
+
+    def sendall(self, data):
+        self.sent.append(data.decode().strip())
+
+    def settimeout(self, _):
+        pass
+
+    def recv(self, _):
+        raise socket.timeout
+
+
+def run_main(env, serial_cls=None):
+    """Run main() with stubbed sockets.
+
+    Returns (exit_code, monitor, serial, typed_lines).
+    """
     saved_env = dict(os.environ)
     saved_socket = d.socket.socket
     saved_send_line = d.send_line
-    rec = RecordingSock()
+    saved_boot_wait = d.BOOT_LOADER_WAIT
+    saved_max_attempts = d.MAX_BOOTSTRAP_ATTEMPTS
+
+    d.BOOT_LOADER_WAIT = 0
+
+    monitor = MonitorSock()
+    serial = serial_cls() if serial_cls else SerialSock()
+    call_count = [0]
+
+    def fake_socket(*_a, **_k):
+        call_count[0] += 1
+        return monitor if call_count[0] == 1 else serial
+
     typed = []
 
     def capturing_send_line(sock, text):
@@ -122,17 +183,21 @@ def capture_main(env):
 
     os.environ.clear()
     os.environ.update(env)
-    d.socket.socket = lambda *_a, **_k: rec
+    d.socket.socket = fake_socket
     d.send_line = capturing_send_line
+    if serial_cls is DeadSerialSock:
+        d.MAX_BOOTSTRAP_ATTEMPTS = 2
     try:
-        d.main()
+        rc = d.main()
     finally:
         d.send_line = saved_send_line
         d.socket.socket = saved_socket
+        d.BOOT_LOADER_WAIT = saved_boot_wait
+        d.MAX_BOOTSTRAP_ATTEMPTS = saved_max_attempts
         os.environ.clear()
         os.environ.update(saved_env)
-    sendkeys = [c.removeprefix('sendkey ') for c in rec.sent if c.startswith('sendkey ')]
-    return sendkeys, typed
+
+    return rc, monitor, serial, typed
 
 
 def main():
@@ -142,52 +207,125 @@ def main():
         if not cond:
             failures.append(name)
 
-    # KEYMAP: the three chars that were backslash-escaped in the heredoc.
+    # -- KEYMAP: chars that were backslash-escaped in the original heredoc --
     check("backslash maps to 'backslash'", d.KEYMAP['\\'] == 'backslash')
     check("backtick maps to 'grave_accent'", d.KEYMAP['`'] == 'grave_accent')
     check("dollar maps to 'shift-4'", d.KEYMAP['$'] == 'shift-4')
 
-    # send_line appends a trailing newline, which maps to 'ret'.
+    # -- send_line key mapping --
     check("send_line appends ret", keys_for('') == ['ret'])
-    # punctuation routes through KEYMAP (the escaped trio in context).
     check("'$' -> shift-4, ret", keys_for('$') == ['shift-4', 'ret'])
     check("backslash -> backslash, ret", keys_for('\\') == ['backslash', 'ret'])
     check("backtick -> grave_accent, ret", keys_for('`') == ['grave_accent', 'ret'])
-    # letters: lower verbatim, upper as shift-<lower>.
     check("'aB' -> a, shift-b, ret", keys_for('aB') == ['a', 'shift-b', 'ret'])
-    # digits pass through.
     check("'7' -> 7, ret", keys_for('7') == ['7', 'ret'])
-    # unmapped chars (e.g. tab) are skipped.
     check("tab is skipped", keys_for('\t') == ['ret'])
 
-    # monitor socket: DFLY_MONITOR_SOCK selects the path main() connects to,
-    # falling back to the cwd-relative default when it is unset.
-    check(
-        "DFLY_MONITOR_SOCK is honored",
-        monitor_path_for({"PUB_KEY": "k", "DFLY_MONITOR_SOCK": "/tmp/vm/mon.sock"})
-        == "/tmp/vm/mon.sock",
-    )
-    check(
-        "monitor socket defaults to dfly-monitor.sock",
-        monitor_path_for({"PUB_KEY": "k"}) == "dfly-monitor.sock",
-    )
+    # -- full flow via run_main --
+    env = {"PUB_KEY": "k"}
+    rc, monitor, serial, typed = run_main(env)
 
-    # main() clears the console before it logs in, so a re-run after a dropped
-    # keystroke starts at a fresh prompt; newfs/mount are no longer typed (the
-    # provision script mounts the build disk over ssh once ssh is up); and the
-    # bring-up still starts sshd.
-    sendkeys, typed = capture_main({"PUB_KEY": "k"})
-    check("console is reset (ctrl-c) before any login keystroke", sendkeys[0] == "ctrl-c")
+    check("main returns 0 on success", rc == 0)
+
+    sendkeys = [c.removeprefix('sendkey ')
+                for c in monitor.sent if c.startswith('sendkey ')]
+
+    check(
+        "console is reset (ctrl-c) before login",
+        sendkeys[0] == "ctrl-c",
+    )
     check(
         "newfs/mount are not typed into the console",
         not any("newfs" in line or "mount" in line for line in typed),
     )
-    check("bring-up starts sshd", any("/usr/sbin/sshd" in line for line in typed))
+    check(
+        "sshd is started via serial",
+        any("/usr/sbin/sshd" in s for s in serial.sent),
+    )
+    check(
+        "dhclient is run via serial",
+        any("dhclient" in s for s in serial.sent),
+    )
+    check(
+        "ssh key is installed via serial",
+        any("authorized_keys" in s for s in serial.sent),
+    )
+    check(
+        "ssh-keygen -A is run via serial",
+        any("ssh-keygen -A" in s for s in serial.sent),
+    )
+    check(
+        "PermitRootLogin is configured via serial",
+        any("PermitRootLogin" in s for s in serial.sent),
+    )
+    check(
+        "PermitEmptyPasswords is configured via serial",
+        any("PermitEmptyPasswords" in s for s in serial.sent),
+    )
 
+    # -- socket path defaults --
+    check(
+        "monitor socket defaults to dfly-monitor.sock",
+        monitor.connected_path == "dfly-monitor.sock",
+    )
+    check(
+        "serial socket defaults to dfly-serial.sock",
+        serial.connected_path == "dfly-serial.sock",
+    )
+
+    # -- socket path overrides --
+    env_override = {
+        "PUB_KEY": "k",
+        "DFLY_MONITOR_SOCK": "/tmp/vm/mon.sock",
+        "DFLY_SERIAL_SOCK": "/tmp/vm/ser.sock",
+    }
+    _rc2, mon2, ser2, _typed2 = run_main(env_override)
+    check(
+        "DFLY_MONITOR_SOCK override is honored",
+        mon2.connected_path == "/tmp/vm/mon.sock",
+    )
+    check(
+        "DFLY_SERIAL_SOCK override is honored",
+        ser2.connected_path == "/tmp/vm/ser.sock",
+    )
+
+    # -- bootstrap retry: first probe gets no prompt, second succeeds --
+    rc_retry, _mon_r, ser_r, _typed_r = run_main(
+        {"PUB_KEY": "k"}, serial_cls=RetrySerialSock,
+    )
+    check("retry: main returns 0", rc_retry == 0)
+    probe_count = sum(1 for s in ser_r.sent if s == '')
+    check("retry: bootstrap sent at least 2 probes", probe_count >= 2)
+    check(
+        "retry: setup commands ran after retry",
+        any("dhclient" in s for s in ser_r.sent),
+    )
+
+    # -- bootstrap failure: serial never responds --
+    rc_fail, _mon_f, _ser_f, _typed_f = run_main(
+        {"PUB_KEY": "k"}, serial_cls=DeadSerialSock,
+    )
+    check("failure: main returns 1", rc_fail == 1)
+
+    # -- serial_cmd timeout --
+    timeout_sock = TimeoutSerialSock()
+    saved_timeout = d.COMMAND_TIMEOUT
+    d.COMMAND_TIMEOUT = 0.1
+    try:
+        d.serial_cmd(timeout_sock, 'echo hello', timeout=0.1)
+        got_error = False
+    except RuntimeError:
+        got_error = True
+    finally:
+        d.COMMAND_TIMEOUT = saved_timeout
+    check("serial_cmd raises RuntimeError on timeout", got_error)
+
+    total = 28
     if failures:
-        print(f"dfly_configure_vm_test: FAIL ({len(failures)}): {', '.join(failures)}")
+        print(f"dfly_configure_vm_test: FAIL ({len(failures)}): "
+              f"{', '.join(failures)}")
         return 1
-    print("dfly_configure_vm_test: ok (15 checks)")
+    print(f"dfly_configure_vm_test: ok ({total} checks)")
     return 0
 
 

--- a/.ci-scripts/bsd/dragonfly-provision.bash
+++ b/.ci-scripts/bsd/dragonfly-provision.bash
@@ -71,6 +71,7 @@ qemu-system-x86_64 \
   -object rng-random,id=rng0,filename=/dev/urandom \
   -device virtio-rng-pci,rng=rng0 \
   -monitor unix:"$VM_ARTIFACTS/dfly-monitor.sock",server,nowait \
+  -serial unix:"$VM_ARTIFACTS/dfly-serial.sock",server,nowait \
   -display none \
   -daemonize
 echo "::endgroup::"
@@ -81,46 +82,25 @@ echo "::group::Configure and wait for VM"
 PUB_KEY="$(cat vm_key.pub)"
 export PUB_KEY
 
-# dfly_configure_vm.py types the ssh-bring-up commands (login, network, sshd, ssh
-# key) into the VGA console over the QEMU monitor on fixed timers, with no
-# feedback. When a slow host pushes boot past those timers, the keystrokes land
-# before the login prompt is up and sshd never starts. So type the sequence, poll
-# ssh, and retype if it did not take: a later attempt, after boot has finished,
-# lands correctly. The script clears the console at the start of each run, so a
-# retype starts fresh.
-poll_ssh() { # 0 if ssh answers within $1 seconds, else 1
-  local deadline=$(( SECONDS + $1 ))
-  while [ "$SECONDS" -lt "$deadline" ]; do
-    if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=2 -i vm_key -p 2222 \
-        root@localhost true 2>/dev/null; then
-      return 0
-    fi
+# dfly_configure_vm.py waits for the boot loader to pass, then types login +
+# serial shell start via sendkey. Once the serial shell responds, all setup
+# commands run through it with prompt detection. The sendkey phase retries
+# internally, so this script needs no retry loop.
+DFLY_MONITOR_SOCK="$VM_ARTIFACTS/dfly-monitor.sock" \
+  DFLY_SERIAL_SOCK="$VM_ARTIFACTS/dfly-serial.sock" \
+  python3 .ci-scripts/bsd/dfly_configure_vm.py
+
+# Verify ssh is reachable after the serial-driven setup.
+if ! timeout 120 bash -c '
+  while ! ssh -o StrictHostKeyChecking=no -o ConnectTimeout=2 -i vm_key -p 2222 \
+      root@localhost true 2>/dev/null; do
     sleep 2
   done
-  return 1
-}
-
-max_attempts=4
-sleep 90 # wait for boot to reach the login prompt before the first attempt
-
-configured=false
-for (( attempt = 1; attempt <= max_attempts; attempt++ )); do
-  echo "Configure attempt ${attempt}/${max_attempts}: typing setup into the console"
-  DFLY_MONITOR_SOCK="$VM_ARTIFACTS/dfly-monitor.sock" \
-    python3 .ci-scripts/bsd/dfly_configure_vm.py
-  if poll_ssh 30; then
-    configured=true
-    echo "SSH available after ${attempt} attempt(s)"
-    break
-  fi
-  echo "SSH not up after attempt ${attempt}"
-done
-
-if [ "$configured" != true ]; then
-  echo "::error::DragonFly VM never became ssh-reachable after ${max_attempts} configure attempts"
-  echo "::endgroup::"
+'; then
+  echo "::error::DragonFly VM never became ssh-reachable"
   exit 1
 fi
+echo "SSH available"
 echo "::endgroup::"
 
 echo "::group::Mount build disk"

--- a/.claude/skills/create-dragonfly-dev-env/SKILL.md
+++ b/.claude/skills/create-dragonfly-dev-env/SKILL.md
@@ -36,19 +36,18 @@ several steps:
   a here-string MUST go through an explicit `/bin/sh`:
   `ssh ... root@localhost /bin/sh <<'EOF' ... EOF`. A bare
   `ssh ... root@localhost 'cmd with $(...)'` fails with `Illegal variable name.`
-- **Don't blind-`sleep` for boot.** Verify the VM reached the `login:` prompt by taking
-  a console screendump over the QEMU monitor and looking at it; re-screendump until it's
-  there. Driving the console early types the whole setup into a half-booted VM and it's
-  silently lost.
+- **Boot timing is handled by the script.** `dfly_configure_vm.py` waits past the boot
+  loader and retries login + serial shell start until the serial port responds. If
+  something goes wrong, screendump the console (Step 5 has a helper) to see the VM state.
 - **A daemonized QEMU `chdir`s to `/`.** The monitor `screendump` (and any relative path
   the daemon writes) needs an **absolute** path, or it fails `Permission denied`.
 - **No `sudo` needed (and often unavailable).** CI loop-mounts the ISO with `sudo` to get
   `/usr/include`; locally, extract it with `bsdtar` instead — same result, no privilege.
 - **Detach long in-VM builds.** The libs build (LLVM) takes hours; run it
   `nohup … > /build/x.log 2>&1 &` and poll the log, so an ssh drop doesn't kill it.
-- **Reuse the CI console script verbatim.** `.ci-scripts/bsd/dfly_configure_vm.py` types
-  the setup commands into the VGA console via QEMU `sendkey`; the timing/KEYMAP is fiddly
-  and already correct. Copy it, don't reimplement console typing.
+- **Reuse the CI console script verbatim.** `.ci-scripts/bsd/dfly_configure_vm.py`
+  bootstraps a serial shell via QEMU sendkey, then runs setup commands through the serial
+  console with prompt detection. Copy it, don't reimplement the bootstrap or setup.
 
 ## Step 0 — verify prerequisites (do NOT assume they're installed)
 
@@ -159,6 +158,7 @@ qemu-system-x86_64 \
   -object rng-random,id=rng0,filename=/dev/urandom \
   -device virtio-rng-pci,rng=rng0 \
   -monitor unix:dfly-monitor.sock,server,nowait \
+  -serial unix:dfly-serial.sock,server,nowait \
   -display none -pidfile dfly.pid -daemonize
 ```
 
@@ -166,12 +166,26 @@ qemu-system-x86_64 \
 it never silently falls back to slow TCG. `-smp`/`-m` are speed knobs; CI uses 4 CPUs /
 12G. `hostfwd 2222->22` is the ssh port.)
 
-### 5. Confirm the login prompt (re-screendump until ready), then drive the console
+### 5. Run the console setup script
 
-Save the monitor helper and screendump the console. The daemonized QEMU writes to an
-**absolute** path. Boot takes ~80s; **if the image isn't at the `login:` prompt yet,
-wait ~20s and screendump again — repeat until you see `login:`.** Do not run the console
-script before then (it blind-types into the console and a half-booted VM loses it).
+The CI console script waits past the boot loader, bootstraps a serial shell via sendkey
+with retries, and runs all setup commands through the serial console with prompt detection.
+It handles boot timing internally, so no screendump wait is needed.
+
+The script lives in the repo at `.ci-scripts/bsd/dfly_configure_vm.py`. Copy it into
+`$VMDIR` (it connects to `dfly-monitor.sock` and `dfly-serial.sock` in its working
+directory) and run it there. It logs in, brings up networking, configures sshd, and
+installs your key:
+
+```sh
+VMDIR=~/vms/dragonfly-6.4.2; cd "$VMDIR"
+cp "$(git rev-parse --show-toplevel)/.ci-scripts/bsd/dfly_configure_vm.py" "$VMDIR/"
+export PUB_KEY="$(cat vm_key.pub)"
+python3 dfly_configure_vm.py
+```
+
+A `monitor_cmd.py` helper is still useful for ad-hoc screendumps when debugging boot
+problems. Create one if needed:
 
 ```sh
 VMDIR=~/vms/dragonfly-6.4.2; cd "$VMDIR"
@@ -196,20 +210,6 @@ to_png() {  # convert PPM->PNG with whichever converter is installed
 }
 python3 monitor_cmd.py "screendump $VMDIR/console1.ppm"   # absolute path is required
 to_png "$VMDIR/console1.ppm" "$VMDIR/console1.png"
-# open console1.png. If it is NOT yet at "login:", wait ~20s and re-run THIS WHOLE block
-# (a fresh shell won't have $VMDIR or to_png). Only continue once you see "login:".
-```
-
-Then run the CI console script verbatim — it lives in the repo at
-`.ci-scripts/bsd/dfly_configure_vm.py`. Copy it into `$VMDIR` (it connects to the
-`dfly-monitor.sock` in its working directory) and run it there. It logs in, brings up
-networking, configures sshd, installs your key, and formats/mounts the build disk:
-
-```sh
-VMDIR=~/vms/dragonfly-6.4.2; cd "$VMDIR"
-cp "$(git rev-parse --show-toplevel)/.ci-scripts/bsd/dfly_configure_vm.py" "$VMDIR/"
-export PUB_KEY="$(cat vm_key.pub)"
-python3 dfly_configure_vm.py
 ```
 
 ### 6. Wait for ssh
@@ -240,9 +240,25 @@ uname -a
 EOF
 ```
 
-### 7. Move `/usr/local` to the build disk, install headers, install deps
+### 7. Format and mount the build disk
 
-Root is only ~1.8G; `gcc13` alone is ~418M, so package installs must land on `/build`.
+The root partition is only ~1.8G — not enough for the build or packages. Format the
+second disk and mount it at `/build`.
+
+```sh
+VMDIR=~/vms/dragonfly-6.4.2
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i $VMDIR/vm_key -p 2222 root@localhost"
+$SSH /bin/sh <<'EOF'
+set -e
+newfs /dev/vbd1
+mkdir -p /build
+mount /dev/vbd1 /build
+EOF
+```
+
+### 8. Move `/usr/local` to the build disk, install headers, install deps
+
+`gcc13` alone is ~418M, so package installs must land on `/build`.
 
 ```sh
 VMDIR=~/vms/dragonfly-6.4.2
@@ -270,7 +286,7 @@ git config --global --add safe.directory /build/ponyc
 EOF
 ```
 
-### 8. Rsync the ponyc checkout in (exclude the host `build/`)
+### 9. Rsync the ponyc checkout in (exclude the host `build/`)
 
 Run from your ponyc checkout. Exclude the top-level `build/` (host artifacts; the VM
 builds its own). Keep `.git` (CMake runs `git rev-parse`). The vendored LLVM submodule
@@ -327,7 +343,7 @@ ctest --preset debug -L ci-core
 EOF
 ```
 
-To iterate on a fix: edit on the host, re-run Step 8's `rsync` (it's incremental — only
+To iterate on a fix: edit on the host, re-run Step 9's `rsync` (it's incremental — only
 changed files are sent), then re-run the build block above (long rebuilds should also be
 detached + polled). For exact CI parity, the tier-3 `dragonflybsd` job
 (`.github/workflows/ponyc-tier3.yml`) runs more than this — the reject-unsupported-builds
@@ -366,7 +382,8 @@ unchanged**. The local setup deliberately differs from CI, and each difference i
   `known_hosts` entry from a prior VM. CI's ephemeral runners never reuse the port, so
   `dragonfly-provision.bash` doesn't bother.
 - `-smp 8` for build speed (CI uses 4).
-- Screendump-verified boot instead of a blind `sleep 90`.
+- Both use the serial console script for boot timing; locally you can also screendump
+  for debugging.
 - No GHCR libs cache (that's token-gated CI plumbing) — you just run `cmake -P lib/build-libs.cmake` once.
 
 The FreeBSD and OpenBSD CI VMs follow the same shape


### PR DESCRIPTION
The VGA sendkey approach lost keystrokes when boot was slow — the boot loader consumed them during its countdown, and the script had no way to detect whether the login prompt was ready. The retry loop from #5796 never saved a run: when attempt 1 failed, all 4 failed.

This adds a QEMU serial console (`-serial unix:...,server,nowait`) and rewrites `dfly_configure_vm.py` to use a two-phase approach:

1. Wait past the boot loader, then type login + serial shell start via sendkey, retrying until the serial port responds with a shell prompt.
2. Run all setup commands (network, sshd, ssh key) through the serial console with prompt detection, so each command is confirmed before the next is sent.

The bash provisioning script (`dragonfly-provision.bash`) is simplified: the old 4-attempt retry loop with `poll_ssh` is replaced by a single call to the Python script (which handles retries internally) followed by a `timeout 120` SSH verification.

Tested on 3 fresh local VM boots — serial shell came up on attempts 1, 1, and 2 respectively. All 28 unit test assertions pass; ruff clean.
