### PR TITLE
Fix false unreachable match for arrow type arguments

### DIFF
--- a/src/libponyc/type/matchtype.c
+++ b/src/libponyc/type/matchtype.c
@@ -1088,6 +1088,12 @@ static bool compound_types_could_unify(subst_t* subst, ast_t* a, ast_t* b,
 //   - a union or intersection literal on either side (with neither side a
 //     bare type parameter) distributes over the arms (see
 //     compound_types_could_unify).
+//   - an arrow type (viewpoint adaptation) on either side: when both
+//     sides are arrows with the same left-hand side, the viewpoint is
+//     deterministic so the arrows unify iff the right-hand sides do.
+//     Otherwise, each arrow is reduced to its viewpoint bound
+//     (viewpoint_upper for this->X, viewpoint_lower for P->X) and the
+//     bounds are compared recursively.
 //   - two same-definition nominals unify when every pair of type arguments
 //     recursively unifies.
 //   - two tuples unify when they have the same arity and every element
@@ -1188,6 +1194,81 @@ static bool typeargs_could_unify(subst_t* subst, ast_t* a, ast_t* b,
     || (ast_id(b) == TK_UNIONTYPE) || (ast_id(b) == TK_ISECTTYPE))
   {
     return compound_types_could_unify(subst, a, b, opt);
+  }
+
+  if(ast_id(a) == TK_ARROW || ast_id(b) == TK_ARROW)
+  {
+    if(ast_id(a) == TK_ARROW && ast_id(b) == TK_ARROW)
+    {
+      ast_t* a_left = ast_child(a);
+      ast_t* b_left = ast_child(b);
+
+      bool same_lhs = false;
+
+      if(ast_id(a_left) == ast_id(b_left))
+      {
+        switch(ast_id(a_left))
+        {
+          case TK_THISTYPE:
+            same_lhs = true;
+            break;
+
+          case TK_TYPEPARAMREF:
+            same_lhs = typeparam_root((ast_t*)ast_data(a_left)) ==
+                        typeparam_root((ast_t*)ast_data(b_left));
+            break;
+
+          default:
+            same_lhs = is_eqtype(a_left, b_left, NULL, opt);
+            break;
+        }
+      }
+
+      if(same_lhs)
+      {
+        ast_t* a_right = ast_sibling(a_left);
+        ast_t* b_right = ast_sibling(b_left);
+        return typeargs_could_unify(subst, a_right, b_right, opt);
+      }
+    }
+
+    ast_t* r_a = a;
+    ast_t* r_b = b;
+
+    if(ast_id(a) == TK_ARROW)
+    {
+      AST_GET_CHILDREN(a, a_left, a_right);
+      if(ast_id(a_left) == TK_THISTYPE)
+        r_a = viewpoint_upper(a, opt);
+      else
+        r_a = viewpoint_lower(a, opt);
+
+      if(r_a == NULL)
+        return false;
+    }
+
+    if(ast_id(b) == TK_ARROW)
+    {
+      AST_GET_CHILDREN(b, b_left, b_right);
+      if(ast_id(b_left) == TK_THISTYPE)
+        r_b = viewpoint_upper(b, opt);
+      else
+        r_b = viewpoint_lower(b, opt);
+
+      if(r_b == NULL)
+      {
+        if(r_a != a)
+          ast_free_unattached(r_a);
+        return false;
+      }
+    }
+
+    bool result = typeargs_could_unify(subst, r_a, r_b, opt);
+
+    if(r_a != a) subst_keep(subst, r_a);
+    if(r_b != b) subst_keep(subst, r_b);
+
+    return result;
   }
 
   if((ast_id(a) == TK_NOMINAL) && (ast_id(b) == TK_NOMINAL))

--- a/test/libponyc/matchtype.cc
+++ b/test/libponyc/matchtype.cc
@@ -2803,3 +2803,101 @@ TEST_F(MatchTypeTest, TypeParamInTypeArgStructuralInterfaceMethodTypeParam)
   ASSERT_EQ(MATCHTYPE_REJECT,
     is_matchtype(type_of("store_u8"), type_of("i_wrap_u8"), NULL, &opt));
 }
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgArrowThisViewpoint)
+{
+  // A viewpoint-adapted type argument (this->A vs this->B) where both
+  // sides share the same viewpoint. The right-hand sides are type
+  // parameters that could reify to the same type. See #5867.
+  const char* src =
+    "class val Cell[C: Any #share]\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share, B: Any #share]\n"
+    "    (cell_this_a: Cell[this->A], cell_this_b: Cell[this->B])";
+
+  TEST_COMPILE(src);
+
+  // Cell[this->A] vs Cell[this->B] — A and B could both reify to U8.
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("cell_this_a"), type_of("cell_this_b"), NULL, &opt));
+
+  // Symmetric.
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("cell_this_b"), type_of("cell_this_a"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgArrowVsConcrete)
+{
+  // Arrow type argument vs concrete type argument. The arrow side reduces
+  // to its viewpoint bound, and the type parameter inside could reify to
+  // the concrete type. See #5867.
+  const char* src =
+    "class val Cell[C: Any #share]\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (cell_this_a: Cell[this->A], cell_u8: Cell[U8])";
+
+  TEST_COMPILE(src);
+
+  // Cell[this->A] vs Cell[U8] — A could reify to U8, and this->U8 = U8
+  // for any sendable receiver.
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("cell_this_a"), type_of("cell_u8"), NULL, &opt));
+
+  // Symmetric.
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("cell_u8"), type_of("cell_this_a"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgArrowNested)
+{
+  // Viewpoint-adapted type argument with a nested type constructor on
+  // one side.
+  const char* src =
+    "class val Cell[C: Any #share]\n"
+    "class val Wrap[C: Any #share]\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share, B: Any #share]\n"
+    "    (cell_this_a: Cell[this->A],\n"
+    "     cell_this_wrap_b: Cell[this->Wrap[B] val])";
+
+  TEST_COMPILE(src);
+
+  // Cell[this->A] vs Cell[this->Wrap[B]] — same viewpoint, so recurse
+  // on A vs Wrap[B]. A could reify to Wrap[B].
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("cell_this_a"), type_of("cell_this_wrap_b"),
+      NULL, &opt));
+
+  // Symmetric.
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("cell_this_wrap_b"), type_of("cell_this_a"),
+      NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgArrowConstraintReject)
+{
+  // Same viewpoint but the right-hand sides can never unify: A is
+  // constrained to I32 so it cannot reify to Wrap[B].
+  const char* src =
+    "class val Cell[C: Any #share]\n"
+    "class val Wrap[C: Any #share]\n"
+
+    "interface Test\n"
+    "  fun z[A: I32, B: Any #share]\n"
+    "    (cell_this_a: Cell[this->A],\n"
+    "     cell_this_wrap_b: Cell[this->Wrap[B] val])";
+
+  TEST_COMPILE(src);
+
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("cell_this_a"), type_of("cell_this_wrap_b"),
+      NULL, &opt));
+}


### PR DESCRIPTION
`typeargs_could_unify` had no `TK_ARROW` branch, so viewpoint-adapted type arguments like `Cell[this->A]` vs `Cell[this->B]` fell through to `return false`, producing a spurious "this pattern can never match" compile error.

When both sides are arrows with the same left-hand side, the viewpoint is deterministic so the arrows unify iff the right-hand sides do. Otherwise, each arrow is reduced to its viewpoint bound (`viewpoint_upper` for `this->X`, `viewpoint_lower` for `P->X`) and the bounds are compared recursively.

Closes #5867
