### PR TITLE
Fix timing tests that fail on Windows and arm64 macOS

### DIFF
--- a/test/libponyc/timing.cc
+++ b/test/libponyc/timing.cc
@@ -5,7 +5,9 @@
 
 #include "util.h"
 
+#include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 #include <cstdio>
 #include <cstdlib>
@@ -289,11 +291,10 @@ TEST_F(TimingTest, NullContextIsNoOp)
 }
 
 
-// llvm::Timer forbids starting a running timer, so only the outermost start and
-// stop may drive it. Asserting the depth alone would pass with the guard
-// dropped from either side, so assert the recorded time too: the timer banks
-// wall time only in stopTimer, so the region must read zero until the outer
-// stop and non-zero after it.
+// Depth alone would still pass with the stop-side guard dropped, so this
+// test also asserts the recorded wall time. The timer banks wall time only
+// in stopTimer, so the region must read zero until the outer stop and
+// non-zero after it.
 TEST_F(TimingTest, ReentrantSameRegionCountsSpanOnce)
 {
   pass_timers_t* t = pass_timers_create();
@@ -303,6 +304,10 @@ TEST_F(TimingTest, ReentrantSameRegionCountsSpanOnce)
 
   pass_timers_start(t, "builtin", "expr");                 // re-enter
   EXPECT_EQ(2u, pass_timers_depth(t, "builtin", "expr"));
+
+  // An empty span can measure zero. Sleeping here widens both the inner span
+  // and the outer span that contains it.
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
 
   pass_timers_stop(t, "builtin", "expr");                  // inner stop
   EXPECT_EQ(1u, pass_timers_depth(t, "builtin", "expr"));
@@ -515,14 +520,15 @@ TEST_F(TimingTest, RepeatedRegionAccumulatesIntoOneRow)
   ASSERT_TRUE(pass_timers_set_json(t, path.c_str()));
 
   pass_timers_start(t, "builtin", "parse");
+  std::this_thread::sleep_for(std::chrono::milliseconds(30));
   pass_timers_stop(t, "builtin", "parse");
   double first = pass_timers_wall(t, "builtin", "parse");
 
   pass_timers_start(t, "builtin", "parse");
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
   pass_timers_stop(t, "builtin", "parse");
   double second = pass_timers_wall(t, "builtin", "parse");
 
-  // The second span added to the first rather than replacing it.
   EXPECT_GT(second, first);
 
   ASSERT_TRUE(pass_timers_report(t));
@@ -675,7 +681,7 @@ TEST_F(TimingTest, FailedRunLeavesPreviousFileIntact)
   std::string path = temp_path("intact");
 
   // An earlier run's file.
-  FILE* f = fopen(path.c_str(), "w");
+  FILE* f = fopen(path.c_str(), "wb");
   ASSERT_NE((FILE*)NULL, f);
   fputs("{\"previous\": true}\n", f);
   fclose(f);


### PR DESCRIPTION
Two of the timing tests added in #5792 failed the first time CI ran them on Windows and arm64 macOS. #5792's later pushes never got a full CI run, main gets the test suite only from scheduled jobs and none had come round since the merge, and #5875 was the first PR whose CI ran the new tests on those platforms.

`FailedRunLeavesPreviousFileIntact` (Windows): the CI log reports the failure as an out-of-memory crash, but it is not one. `RunTest.cmake` passes `--gtest_throw_on_failure` under a debugger, so the failed assertion became a C++ exception, and the `TerminateProcessOnMemoryExhaustion` in the disassembly is lldb naming a `KernelBase.dll` address by its nearest export. The failure itself: the test wrote its sentinel file with text-mode `fopen`, so on disk the file held `\r\n` and the byte-exact comparison against `\n` failed. The file is now written in binary mode.

`RepeatedRegionAccumulatesIntoOneRow` (arm64 macOS): the test compared two empty start/stop spans, and an empty span usually measures zero. LLVM stores wall time as a double of seconds since the Unix epoch, so two reads a few hundred nanoseconds apart produce the same value, and libc++ resolves the clock only to microseconds. The failure is intermittent: the same test passed on one arm64 macOS run between the two failing ones. The test now sleeps inside both spans: 2ms in the second so the accumulated total strictly increases, and 30ms in the first so a stop that replaced the total instead of adding to it still fails the assertion. `ReentrantSameRegionCountsSpanOnce` asserts that a reentrant inner stop banks nothing (the stop-side depth guard) and that the outer stop banks a span; it now sleeps inside the inner span, so both assertions compare against a span wide enough to measure.

On Windows I reproduced the CRLF failure on plain main, three runs out of three, and after the fix the full libponyc.tests suite passes. I simulated two bugs, a stop that replaces the total instead of adding to it and a dropped stop-side depth guard, and both times the assertions failed. I did not run any of this on macOS hardware; the macOS reasoning is arithmetic, 2ms against a microsecond clock, and this PR's CI is its first real test. Because the macOS failure is intermittent, a single green run there is weaker evidence than it looks.

Closes #5876
