### PR TITLE
Fix false unreachable match for structural interface patterns with lambda parameters

### DIFF
--- a/.release-notes/fix-structural-lambda-param-match.md
+++ b/.release-notes/fix-structural-lambda-param-match.md
@@ -1,0 +1,35 @@
+## Fix false unreachable match for structural interface patterns with lambda parameters
+
+Matching a class against a structural interface pattern produced a false "this pattern can never match" error when the class and the interface used structurally equivalent but nominally different single-method interface types in their method parameters. The most common case is a method with a lambda parameter type (`{(A): B} val`) matched against a pattern whose interface uses either a lambda written at a different source position or a user-defined interface with the same method signature:
+
+```pony
+class val Wrap[A: Any #share]
+  let _value: A
+  new val create(v: A) => _value = v
+  fun value(): A => _value
+
+interface val Mapper[A: Any #share]
+  fun map_it[B: Any #share](f: {(A): B} val): B
+
+class val Box[A: Any #share]
+  let _v: A
+  new val create(v: A) => _v = v
+  fun map_it[B: Any #share](f: {(A): B} val): B => f(_v)
+
+primitive Check
+  fun apply[A: Any #share, B: Any #share](x: Box[A]): I32 =>
+    match x
+    | let _: Mapper[Wrap[B] val] val => 42
+    else
+      1
+    end
+```
+
+```
+Error:
+main.pony:17:7: this pattern can never match
+    | let _: Mapper[Wrap[B] val] val => 42
+      ^
+```
+
+Single-method interfaces with different definitions but identical method signatures are now compared structurally rather than by identity.

--- a/src/libponyc/type/matchtype.c
+++ b/src/libponyc/type/matchtype.c
@@ -1053,6 +1053,132 @@ static bool compound_types_could_unify(subst_t* subst, ast_t* a, ast_t* b,
   return other_is_subtype_of_every_arm(compound, other, opt);
 }
 
+// Two single-method interfaces with different def pointers can still be
+// structurally equivalent — lambda types desugared at different source
+// positions, or a user-defined interface vs a lambda. When
+// typeargs_could_unify encounters two such nominals, it compares the
+// interfaces structurally rather than by identity.
+static bool single_method_interfaces_could_unify(subst_t* subst,
+  ast_t* a, ast_t* a_def, ast_t* b, ast_t* b_def, pass_opt_t* opt)
+{
+  if(ast_id(a_def) != TK_INTERFACE || ast_id(b_def) != TK_INTERFACE)
+    return false;
+
+  // Both must have exactly one member.
+  ast_t* a_members = ast_childidx(a_def, 4);
+  ast_t* b_members = ast_childidx(b_def, 4);
+  ast_t* a_method = ast_child(a_members);
+  ast_t* b_method = ast_child(b_members);
+
+  if(a_method == NULL || b_method == NULL)
+    return false;
+
+  if(ast_sibling(a_method) != NULL || ast_sibling(b_method) != NULL)
+    return false;
+
+  // Reify both methods with their class-level type arguments.
+  ast_t* a_typeparams = ast_childidx(a_def, 1);
+  ast_t* a_typeargs = ast_childidx(a, 2);
+  ast_t* b_typeparams = ast_childidx(b_def, 1);
+  ast_t* b_typeargs = ast_childidx(b, 2);
+
+  ast_t* r_a = reify_method_def(a_method, a_typeparams, a_typeargs, opt);
+  if(r_a == NULL) return false;
+
+  ast_t* r_b = reify_method_def(b_method, b_typeparams, b_typeargs, opt);
+  if(r_b == NULL)
+  {
+    if(r_a != a_method) ast_free_unattached(r_a);
+    return false;
+  }
+
+  bool result = false;
+
+  // Structural shape checks.
+  token_id t_a = ast_id(r_a);
+  token_id t_b = ast_id(r_b);
+
+  if(((t_a == TK_NEW) || (t_b == TK_NEW)) && (t_a != t_b))
+    goto cleanup;
+
+  AST_GET_CHILDREN(r_a, a_cap, a_id, a_tps, a_params, a_result, a_throws);
+  AST_GET_CHILDREN(r_b, b_cap, b_id, b_tps, b_params, b_result, b_throws);
+
+  if(ast_name(a_id) != ast_name(b_id))
+    goto cleanup;
+
+  if((ast_id(a_cap) == TK_AT) != (ast_id(b_cap) == TK_AT))
+    goto cleanup;
+
+  if(ast_childcount(a_tps) != ast_childcount(b_tps))
+    goto cleanup;
+
+  if(ast_childcount(a_params) != ast_childcount(b_params))
+    goto cleanup;
+
+  // If method-level type params exist, reify a's method with b's type params
+  // so both are in the same variable space (mirrors structural_could_match_pattern).
+  ast_t* rr_a = r_a;
+  if(ast_id(b_tps) != TK_NONE)
+  {
+    BUILD(typeargs, b_tps, NODE(TK_TYPEARGS));
+    ast_t* tp = ast_child(b_tps);
+    while(tp != NULL)
+    {
+      AST_GET_CHILDREN(tp, tp_id, tp_constraint);
+      BUILD(typearg, tp, NODE(TK_TYPEPARAMREF, TREE(tp_id) NONE NONE));
+      ast_t* def = ast_get(tp, ast_name(tp_id), NULL);
+      ast_setdata(typearg, def);
+      typeparam_set_cap(typearg);
+      ast_append(typeargs, typearg);
+      tp = ast_sibling(tp);
+    }
+
+    rr_a = reify_method_def(r_a, a_tps, typeargs, opt);
+    ast_free_unattached(typeargs);
+
+    a_result = ast_childidx(rr_a, 4);
+    a_throws = ast_childidx(rr_a, 5);
+    a_params = ast_childidx(rr_a, 3);
+  }
+
+  // Throws must match for unification.
+  if((ast_id(a_throws) == TK_QUESTION) != (ast_id(b_throws) == TK_QUESTION))
+    goto cleanup_rr;
+
+  // Result types must be unifiable.
+  if(!typeargs_could_unify(subst, a_result, b_result, opt))
+    goto cleanup_rr;
+
+  // Parameters.
+  {
+    ast_t* ap = ast_child(a_params);
+    ast_t* bp = ast_child(b_params);
+    while(ap != NULL && bp != NULL)
+    {
+      ast_t* a_type = ast_childidx(ap, 1);
+      ast_t* b_type = ast_childidx(bp, 1);
+
+      if(!typeargs_could_unify(subst, a_type, b_type, opt))
+        goto cleanup_rr;
+
+      ap = ast_sibling(ap);
+      bp = ast_sibling(bp);
+    }
+  }
+
+  result = true;
+
+cleanup_rr:
+  if(rr_a != r_a)
+    subst_keep(subst, rr_a);
+
+cleanup:
+  if(r_a != a_method) subst_keep(subst, r_a);
+  if(r_b != b_method) subst_keep(subst, r_b);
+  return result;
+}
+
 // Could two type-argument positions reify to equal types for some
 // substitution of the type parameters they contain?
 //
@@ -1277,7 +1403,8 @@ static bool typeargs_could_unify(subst_t* subst, ast_t* a, ast_t* b,
     ast_t* b_def = (ast_t*)ast_data(b);
 
     if(a_def != b_def)
-      return false;
+      return single_method_interfaces_could_unify(subst, a, a_def, b, b_def,
+        opt);
 
     ast_t* a_typeargs = ast_childidx(a, 2);
     ast_t* b_typeargs = ast_childidx(b, 2);

--- a/test/libponyc/matchtype.cc
+++ b/test/libponyc/matchtype.cc
@@ -2805,6 +2805,166 @@ TEST_F(MatchTypeTest, TypeParamInTypeArgStructuralInterfaceMethodTypeParam)
 }
 
 
+TEST_F(MatchTypeTest, TypeParamInTypeArgStructuralInterfaceLambdaParam)
+{
+  // Lambda parameters desugar into unique anonymous interfaces per source
+  // position. structural_could_match_pattern compares method signatures
+  // through typeargs_could_unify, which must recognise two structurally
+  // identical lambda interfaces as potentially equal rather than comparing
+  // by def pointer identity. See #5873.
+  const char* src =
+    "class val Wrap[A: Any #share]\n"
+    "  let _value: A\n"
+    "  new val create(v: A) => _value = v\n"
+    "  fun value(): A => _value\n"
+
+    "interface val Mapper[A: Any #share]\n"
+    "  fun map_it[B: Any #share](f: {(A): B} val): B\n"
+
+    "class val Box[A: Any #share]\n"
+    "  let _v: A\n"
+    "  new val create(v: A) => _v = v\n"
+    "  fun map_it[B: Any #share](f: {(A): B} val): B => f(_v)\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share, B: Any #share]\n"
+    "    (box_a: Box[A], mapper_wrap_b: Mapper[Wrap[B] val] val,\n"
+    "     box_u8: Box[U8], mapper_wrap_u8: Mapper[Wrap[U8] val] val)";
+
+  TEST_COMPILE(src);
+
+  // Box[A] structurally satisfies Mapper[A]; A could reify to Wrap[B] —
+  // accept despite lambda parameter types having different def pointers.
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("box_a"), type_of("mapper_wrap_b"), NULL, &opt));
+
+  // Box[U8] structurally satisfies Mapper[U8]; U8 is concrete and cannot
+  // equal Wrap[U8] — reject.
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("box_u8"), type_of("mapper_wrap_u8"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgStructuralInterfaceLambdaNoMethodTypeParam)
+{
+  // Lambda interfaces without method-level type parameters exercise the path
+  // where method-level reification is skipped in lambda_interfaces_could_unify.
+  const char* src =
+    "interface val Applier[A: Any #share]\n"
+    "  fun apply_it(f: {(A): U8} val): U8\n"
+
+    "class val Doer[A: Any #share]\n"
+    "  let _v: A\n"
+    "  new val create(v: A) => _v = v\n"
+    "  fun apply_it(f: {(A): U8} val): U8 => f(_v)\n"
+
+    "interface Test\n"
+    "  fun z[X: Any #share]\n"
+    "    (doer_x: Doer[X], applier_x: Applier[X] val)";
+
+  TEST_COMPILE(src);
+
+  // Doer[X] structurally satisfies Applier[X]; the lambda {(X): U8} has no
+  // method-level type params — accept.
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("doer_x"), type_of("applier_x"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgStructuralInterfaceLambdaThrowsMismatch)
+{
+  // A partial lambda ({(A): B ?} val) must not unify with a total lambda
+  // ({(A): B} val) — throws annotations must match.
+  const char* src =
+    "interface val TotalMapper[A: Any #share]\n"
+    "  fun map_it[B: Any #share](f: {(A): B} val): B\n"
+
+    "class val PartialBox[A: Any #share]\n"
+    "  let _v: A\n"
+    "  new val create(v: A) => _v = v\n"
+    "  fun map_it[B: Any #share](f: {(A): B ?} val): B ? => f(_v)?\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (pbox_a: PartialBox[A],\n"
+    "     total_a: TotalMapper[A] val)";
+
+  TEST_COMPILE(src);
+
+  // PartialBox has a partial lambda param; TotalMapper has a total lambda
+  // param — throws mismatch, reject.
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("pbox_a"), type_of("total_a"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgStructuralInterfaceLambdaBareMismatch)
+{
+  // A bare lambda (@{(A): B} val) must not unify with a non-bare lambda
+  // ({(A): B} val) — bareness must match.
+  const char* src =
+    "interface val NonBareMapper[A: Any #share]\n"
+    "  fun map_it[B: Any #share](f: {(A): B} val): B\n"
+
+    "class val BareBox[A: Any #share]\n"
+    "  let _v: A\n"
+    "  new val create(v: A) => _v = v\n"
+    "  fun map_it[B: Any #share](f: @{(A): B} val): B => f(_v)\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share]\n"
+    "    (bare_a: BareBox[A],\n"
+    "     nonbare_a: NonBareMapper[A] val)";
+
+  TEST_COMPILE(src);
+
+  // BareBox has a bare lambda param; NonBareMapper has a non-bare lambda
+  // param — bareness mismatch, reject.
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("bare_a"), type_of("nonbare_a"), NULL, &opt));
+}
+
+
+TEST_F(MatchTypeTest, TypeParamInTypeArgStructuralInterfaceUserDefinedVsLambda)
+{
+  // A user-defined single-method interface (MyFunc) and a lambda type
+  // ({(A): B} val) are structurally equivalent but have different defs.
+  // typeargs_could_unify must recognise them as potentially equal.
+  const char* src =
+    "interface val MyFunc[A: Any #share, B: Any #share]\n"
+    "  fun apply(a: A): B\n"
+
+    "class val Wrap[A: Any #share]\n"
+    "  let _value: A\n"
+    "  new val create(v: A) => _value = v\n"
+
+    "interface val UserMapper[A: Any #share]\n"
+    "  fun map_it[B: Any #share](f: MyFunc[A, B]): B\n"
+
+    "class val Box[A: Any #share]\n"
+    "  let _v: A\n"
+    "  new val create(v: A) => _v = v\n"
+    "  fun map_it[B: Any #share](f: {(A): B} val): B => f(_v)\n"
+
+    "interface Test\n"
+    "  fun z[A: Any #share, B: Any #share]\n"
+    "    (box_a: Box[A], user_mapper_wrap_b: UserMapper[Wrap[B] val] val,\n"
+    "     box_u8: Box[U8], user_mapper_wrap_u8: UserMapper[Wrap[U8] val] val)";
+
+  TEST_COMPILE(src);
+
+  // Box[A] vs UserMapper[Wrap[B] val]: Box's lambda param {(A): B} and
+  // UserMapper's MyFunc[A, B] are structurally identical single-method
+  // interfaces — accept.
+  ASSERT_EQ(MATCHTYPE_ACCEPT,
+    is_matchtype(type_of("box_a"), type_of("user_mapper_wrap_b"), NULL, &opt));
+
+  // Box[U8] vs UserMapper[Wrap[U8] val]: U8 cannot equal Wrap[U8] — reject.
+  ASSERT_EQ(MATCHTYPE_REJECT,
+    is_matchtype(type_of("box_u8"), type_of("user_mapper_wrap_u8"), NULL, &opt));
+}
+
+
 TEST_F(MatchTypeTest, TypeParamInTypeArgArrowThisViewpoint)
 {
   // A viewpoint-adapted type argument (this->A vs this->B) where both


### PR DESCRIPTION
`typeargs_could_unify` compared nominals by def pointer identity. Two single-method interfaces with different defs — lambda types desugared at different source positions, or a user-defined interface vs a lambda — were treated as different types even when their method signatures matched.

When both nominals are single-method `TK_INTERFACE` types with different defs, the new `single_method_interfaces_could_unify` compares their method signatures structurally through the existing `typeargs_could_unify` machinery instead of returning false.

Closes #5873
