### PR TITLE
Remove workaround for resolved compiler assertion in flatten_next

### DIFF
--- a/packages/promises/promise.pony
+++ b/packages/promises/promise.pony
@@ -204,7 +204,7 @@ actor Promise[A: Any #share]
         let p: Promise[B] = outer
 
         fun ref apply(value: A) =>
-          let fulfill' = f = _PromiseFulFill[A, B]
+          let fulfill' = f = {(value: A) => Promise[B] }
 
           try
             let inner = (consume fulfill').apply(value)?
@@ -423,11 +423,3 @@ actor _Join[A: Any #share]
     end
 
 primitive _None
-
-class iso _PromiseFulFill[A: Any #share, B: Any #share]
-  is Fulfill[A, Promise[B]]
-  """
-  Fulfill discarding its input value of `A` and returning a promise of type `B`.
-  """
-  new iso create() => None
-  fun ref apply(value: A): Promise[B] => Promise[B]

--- a/test/full-program-tests/promise-flatten-next-regression-3856/main.pony
+++ b/test/full-program-tests/promise-flatten-next-regression-3856/main.pony
@@ -3,7 +3,6 @@ use "promises"
 actor FlattenNextProbe
   new create(handler: Handler iso) =>
     let promise = Promise[String]
-    // We need a call to next to be present with a call to flatten_next to trigger the issue during reachability analysis
     promise.next[Any tag](recover this~behaviour() end)
     (consume handler)(recover String end, promise)
 
@@ -14,11 +13,9 @@ actor FlattenNextProbe
 class Handler
   fun ref apply(line: String, prompt: Promise[String]) =>
     let p = Promise[String]
-    // BUG: Can't change the flatten_next
     p.flatten_next[String]({ (x: String) => Promise[String] })
 
 
 actor Main
   new create(env: Env) =>
-    // BUG: Can't change this
     let term = FlattenNextProbe(Handler)


### PR DESCRIPTION
The `_PromiseFulFill` class was introduced in #3991 as a workaround for #4014 — a compiler assertion where generic lambdas inside `flatten_next` weren't fully reified during reachability analysis. The underlying compiler bug has since been fixed (the reifier now follows the type parameter chain to its root), so the workaround class is no longer needed.

This restores the original lambda and removes the class. Also cleans up stale "BUG:" comments in the regression test that described the bug as a current condition.
