### PR TITLE
Fix deferred stdout output on Windows

### DIFF
--- a/.release-notes/fix-windows-stdout-buffering.md
+++ b/.release-notes/fix-windows-stdout-buffering.md
@@ -1,0 +1,3 @@
+## Fix deferred stdout output on Windows
+
+On Windows, stdout and stderr were left at the C runtime's default full buffering. Output from `env.out` could sit in the buffer and not appear until the program exited, especially when the program spent time in blocking FFI calls between prints. The same buffering was already configured on Unix (unbuffered for a terminal, line-buffered otherwise) but the Windows path was missing it.

--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -441,6 +441,16 @@ PONY_API void pony_os_stdout_setup()
   GetConsoleScreenBufferInfo(handle, &csbi);
   stderr_reset = csbi.wAttributes;
   is_stderr_tty = (type == FILE_TYPE_CHAR);
+
+  if(is_stdout_tty)
+    setvbuf(stdout, NULL, _IONBF, 0);
+  else
+    setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
+
+  if(is_stderr_tty)
+    setvbuf(stderr, NULL, _IONBF, 0);
+  else
+    setvbuf(stderr, NULL, _IOLBF, BUFSIZ);
 #else
   is_stdout_tty = (fd_type(STDOUT_FILENO) == FD_TYPE_TTY);
   is_stderr_tty = (fd_type(STDERR_FILENO) == FD_TYPE_TTY);


### PR DESCRIPTION
`pony_os_stdout_setup` configures stdout and stderr buffering on Unix — unbuffered for a terminal, line-buffered otherwise — but the Windows path never called `setvbuf`. The MSVC runtime defaults to full buffering, so output from `env.out` could sit in the buffer and not appear until the program exited.

Adds the same `setvbuf` calls to the Windows path.

Closes #2945
