### PR TITLE
Type parameter constraints now respect the default cap of the named type

### DIFF
--- a/.release-notes/respect-default-cap-in-constraints.md
+++ b/.release-notes/respect-default-cap-in-constraints.md
@@ -1,0 +1,38 @@
+## Type parameter constraints now respect the default cap of the named type
+
+When a type name appeared in a type parameter constraint without an explicit capability, the compiler substituted `#any` instead of using the type's declared default capability (`ref` for classes and interfaces, `val` for primitives, `tag` for actors). This was the only context in the language where default capabilities were ignored.
+
+```pony
+class Foo
+  fun bar() => None
+
+// Before: A: Foo meant A: Foo #any
+// After:  A: Foo means A: Foo ref (the default cap of class Foo)
+fun example[A: Foo](x: A) => None
+```
+
+Code that relied on the implicit `#any` needs an explicit capability. The most common case is intersection constraints where one member had an explicit cap and the other did not:
+
+```pony
+// Before (compiled because Stringable got #any):
+fun test_sort[A: (Comparable[A] val & Stringable)](x: A) => None
+
+// After (Stringable needs an explicit val to match):
+fun test_sort[A: (Comparable[A] val & Stringable val)](x: A) => None
+```
+
+The same applies to `iftype` conditions. If a type parameter is constrained to a `val` capability and the `iftype` supertype is an interface, that interface now gets its default `ref` cap, making the condition unsatisfiable. Add an explicit cap that matches:
+
+```pony
+// Before (HasDocs got #any, so the condition was satisfiable):
+fun foo[A: AST val](node: A) =>
+  iftype A <: HasDocs then
+    node.docs()
+  end
+
+// After (HasDocs needs val to be compatible with the constraint):
+fun foo[A: AST val](node: A) =>
+  iftype A <: HasDocs val then
+    node.docs()
+  end
+```

--- a/packages/collections/_test.pony
+++ b/packages/collections/_test.pony
@@ -605,7 +605,7 @@ class \nodoc\ iso _TestSort is UnitTest
       [""; "%*&^*&^&"; "***"; "Hello"; "bar"; "f00"; "foo"; "foo"],
       [""; "Hello"; "foo"; "bar"; "foo"; "f00"; "%*&^*&^&"; "***"])
 
-  fun test_sort[A: (Comparable[A] val & Stringable)](
+  fun test_sort[A: (Comparable[A] val & Stringable val)](
     h: TestHelper,
     sorted: Array[A],
     unsorted: Array[A])

--- a/packages/collections/persistent/map.pony
+++ b/packages/collections/persistent/map.pony
@@ -1,6 +1,6 @@
 use mut = "collections"
 
-type Map[K: (mut.Hashable val & Equatable[K]), V: Any #share] is
+type Map[K: (mut.Hashable val & Equatable[K] val), V: Any #share] is
   HashMap[K, V, mut.HashEq[K]]
   """
   A map that uses structural equality on the key.

--- a/packages/collections/persistent/set.pony
+++ b/packages/collections/persistent/set.pony
@@ -1,6 +1,6 @@
 use mut = "collections"
 
-type Set[A: (mut.Hashable val & Equatable[A])] is HashSet[A, mut.HashEq[A]]
+type Set[A: (mut.Hashable val & Equatable[A] val)] is HashSet[A, mut.HashEq[A]]
 
 type SetIs[A: Any #share] is HashSet[A, mut.HashIs[A]]
 

--- a/packages/pony_test/i_test.pony
+++ b/packages/pony_test/i_test.pony
@@ -165,7 +165,7 @@ class val TestHelper
     """
     _check_eq[A]("eq", expect, actual, msg, loc)
 
-  fun _check_eq[A: (Equatable[A] #read & Stringable)]
+  fun _check_eq[A: (Equatable[A] #read & Stringable #read)]
     (check: String, expect: A, actual: A, msg: String, loc: SourceLoc)
     : Bool
   =>
@@ -227,7 +227,7 @@ class val TestHelper
     """
     _check_ne[A]("ne", not_expect, actual, msg, loc)
 
-  fun _check_ne[A: (Equatable[A] #read & Stringable)]
+  fun _check_ne[A: (Equatable[A] #read & Stringable #read)]
     (check: String, not_expect: A, actual: A, msg: String, loc: SourceLoc)
     : Bool
   =>

--- a/src/libponyc/pass/names.c
+++ b/src/libponyc/pass/names.c
@@ -129,18 +129,7 @@ static bool names_type(pass_opt_t* opt, ast_t** astp, ast_t* def)
 
   if(tcap == TK_NONE)
   {
-    if((opt->check.frame->constraint != NULL) ||
-      (opt->check.frame->iftype_constraint != NULL))
-    {
-      // A primitive constraint is a val, otherwise #any.
-      if(ast_id(def) == TK_PRIMITIVE)
-        tcap = TK_VAL;
-      else
-        tcap = TK_CAP_ANY;
-    } else {
-      // Use the default capability.
-      tcap = ast_id(def_cap);
-    }
+    tcap = ast_id(def_cap);
   }
 
   ast_setid(cap, tcap);

--- a/src/libponyc/type/typeparam.c
+++ b/src/libponyc/type/typeparam.c
@@ -222,8 +222,20 @@ static token_id cap_isect_constraint(token_id a, token_id b)
     case TK_ISO:
       switch(b)
       {
+        case TK_TAG:
         case TK_CAP_SEND:
           return TK_ISO;
+
+        default: {}
+      }
+      break;
+
+    case TK_TRN:
+      switch(b)
+      {
+        case TK_BOX:
+        case TK_TAG:
+          return TK_TRN;
 
         default: {}
       }
@@ -232,6 +244,8 @@ static token_id cap_isect_constraint(token_id a, token_id b)
     case TK_REF:
       switch(b)
       {
+        case TK_BOX:
+        case TK_TAG:
         case TK_CAP_READ:
         case TK_CAP_ALIAS:
           return TK_REF;
@@ -243,6 +257,8 @@ static token_id cap_isect_constraint(token_id a, token_id b)
     case TK_VAL:
       switch(b)
       {
+        case TK_BOX:
+        case TK_TAG:
         case TK_CAP_READ:
         case TK_CAP_SEND:
         case TK_CAP_SHARE:
@@ -256,6 +272,12 @@ static token_id cap_isect_constraint(token_id a, token_id b)
     case TK_BOX:
       switch(b)
       {
+        case TK_TRN:
+        case TK_REF:
+        case TK_VAL:
+          return b;
+
+        case TK_TAG:
         case TK_CAP_READ:
         case TK_CAP_ALIAS:
           return TK_BOX;
@@ -267,10 +289,24 @@ static token_id cap_isect_constraint(token_id a, token_id b)
     case TK_TAG:
       switch(b)
       {
+        case TK_ISO:
+        case TK_TRN:
+        case TK_REF:
+        case TK_VAL:
+        case TK_BOX:
+          return b;
+
+        case TK_CAP_READ:
+          return TK_CAP_READ;
+
         case TK_CAP_SEND:
+          return TK_CAP_SEND;
+
         case TK_CAP_SHARE:
+          return TK_CAP_SHARE;
+
         case TK_CAP_ALIAS:
-          return TK_TAG;
+          return TK_CAP_ALIAS;
 
         default: {}
       }
@@ -284,6 +320,7 @@ static token_id cap_isect_constraint(token_id a, token_id b)
         case TK_BOX:
           return b;
 
+        case TK_TAG:
         case TK_CAP_ALIAS:
           return TK_CAP_READ;
 
@@ -300,8 +337,10 @@ static token_id cap_isect_constraint(token_id a, token_id b)
       {
         case TK_ISO:
         case TK_VAL:
-        case TK_TAG:
           return b;
+
+        case TK_TAG:
+          return TK_CAP_SEND;
 
         case TK_CAP_READ:
           return TK_VAL;
@@ -318,8 +357,10 @@ static token_id cap_isect_constraint(token_id a, token_id b)
       switch(b)
       {
         case TK_VAL:
-        case TK_TAG:
           return b;
+
+        case TK_TAG:
+          return TK_CAP_SHARE;
 
         case TK_CAP_READ:
           return TK_VAL;
@@ -338,8 +379,10 @@ static token_id cap_isect_constraint(token_id a, token_id b)
         case TK_REF:
         case TK_VAL:
         case TK_BOX:
-        case TK_TAG:
           return b;
+
+        case TK_TAG:
+          return TK_CAP_ALIAS;
 
         case TK_CAP_READ:
           return TK_CAP_READ;

--- a/test/full-program-tests/regression-2408/main.pony
+++ b/test/full-program-tests/regression-2408/main.pony
@@ -2,7 +2,7 @@ interface SafeOps[T]
   fun addc(t: T): (T, Bool)
   fun subc(t: T): (T, Bool)
 
-class GenericSum[T: (Int & Integer[T] val & SafeOps[T])]
+class GenericSum[T: (Int & Integer[T] val & SafeOps[T] val)]
   fun _plus_safe(x: T, y: T): (T, Bool) =>
     x.addc(y)
 

--- a/test/libponyc/iftype.cc
+++ b/test/libponyc/iftype.cc
@@ -67,7 +67,7 @@ TEST_F(IftypeTest, ThenClause_CapConstraint)
     "  new create(env: Env) =>\n"
     "    foo[C](C)\n"
 
-    "  fun foo[A: C](x: A) =>\n"
+    "  fun foo[A: C #any](x: A) =>\n"
     "    iftype A <: C box then\n"
     "      x.c()\n"
     "    end";
@@ -86,7 +86,7 @@ TEST_F(IftypeTest, ElseClause_NoCapConstraint)
     "  new create(env: Env) =>\n"
     "    foo[C](C)\n"
 
-    "  fun foo[A: C](x: A) =>\n"
+    "  fun foo[A: C #any](x: A) =>\n"
     "    iftype A <: C box then\n"
     "      None\n"
     "    else\n"
@@ -663,7 +663,7 @@ TEST_F(IftypeTest, AsAroundIftypeWithNarrowedCall)
     "  new create(env: Env) => None\n"
     "  fun foo[A: AST val](node: A) =>\n"
     "    try\n"
-    "      iftype A <: HasDocs\n"
+    "      iftype A <: HasDocs val\n"
     "      then node.docs()\n"
     "      end as LitString\n"
     "    end";
@@ -685,7 +685,7 @@ TEST_F(IftypeTest, AsAroundIftypeTupleTypeparam)
     "  new create(env: Env) => None\n"
     "  fun foo[A: AST val, B: AST val](a: A, b: B) =>\n"
     "    try\n"
-    "      iftype (A, B) <: (HasDocs, HasDocs)\n"
+    "      iftype (A, B) <: (HasDocs val, HasDocs val)\n"
     "      then a.docs()\n"
     "      end as LitString\n"
     "    end";
@@ -708,8 +708,8 @@ TEST_F(IftypeTest, AsAroundNestedIftypeWithNarrowedCall)
     "  new create(env: Env) => None\n"
     "  fun foo[A: AST val](node: A) =>\n"
     "    try\n"
-    "      iftype A <: HasText then\n"
-    "        iftype A <: HasDocs\n"
+    "      iftype A <: HasText val then\n"
+    "        iftype A <: HasDocs val\n"
     "        then node.docs()\n"
     "        end\n"
     "      end as LitString\n"
@@ -732,7 +732,7 @@ TEST_F(IftypeTest, AsTupleAroundIftypeWithNarrowedCall)
     "  new create(env: Env) => None\n"
     "  fun foo[A: AST val](node: A) =>\n"
     "    try\n"
-    "      iftype A <: HasDocs\n"
+    "      iftype A <: HasDocs val\n"
     "      then node.docs()\n"
     "      end as (LitString, LitString)\n"
     "    end";

--- a/test/libponyc/type_params.cc
+++ b/test/libponyc/type_params.cc
@@ -9,8 +9,47 @@
 #define TEST_ERROR(src) DO(test_error(src, "expr"))
 #define TEST_EQUIV(src, expect) DO(test_equiv(src, "expr", expect, "expr"))
 
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "ir", errs)); }
+
 class TypeParamsTest : public PassTest
 {};
+
+TEST_F(TypeParamsTest, DefaultCapInConstraint_ClassGetsRef)
+{
+  // From issue #5116. A bare class name in a constraint uses the class's
+  // default cap (ref), so a ref-receiver method is callable.
+  const char* src =
+    "class C\n"
+    "  fun ref mutate() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    foo[C](C)\n"
+
+    "  fun foo[A: C](x: A) =>\n"
+    "    x.mutate()";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(TypeParamsTest, DefaultCapInConstraint_ValNotSubtypeOfRef)
+{
+  // From issue #5116. A bare class name in a constraint uses the class's
+  // default cap (ref). A val type argument does not satisfy a ref constraint.
+  const char* src =
+    "class C\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let c: C val = recover val C end\n"
+    "    foo[C val](c)\n"
+
+    "  fun foo[A: C](x: A) => None";
+
+  TEST_ERRORS_1(src, "type argument is outside its constraint");
+}
 
 TEST_F(TypeParamsTest, ReifySimultaneously)
 {


### PR DESCRIPTION
When a type name appeared in a type parameter constraint without an explicit capability, the compiler substituted `#any` (or `val` for primitives) instead of using the type's declared default capability. This was the only context in the language where default capabilities were ignored.

The fix removes the special case in `names_type()` and updates `cap_isect_constraint()` to handle concrete-cap and tag-vs-cap-set intersections correctly using subtyping. Stdlib code that relied on the implicit `#any` now uses explicit caps.

This is a breaking change — code that relied on the implicit `#any` in constraints needs an explicit capability annotation. The release note has before/after examples for the three affected patterns.

Closes #5116
