### PR TITLE
Fix false "unreachable code" error when all branches jump away in a None-returning function

### DIFF
--- a/.release-notes/fix-false-unreachable-implicit-none.md
+++ b/.release-notes/fix-false-unreachable-implicit-none.md
@@ -1,0 +1,23 @@
+## Fix false "unreachable code" error when all branches jump away in a None-returning function
+
+Previously, a function returning `None` where every branch of a control construct jumped away (via `return`, `error`, `break`, or `continue`) was rejected with a false "unreachable code" error:
+
+```pony
+actor Main
+  fun maybe_error(dont_err: Bool = false) ? =>
+    if dont_err then
+      return
+    else
+      error
+    end
+
+  new create(env: Env) =>
+    try maybe_error()? end
+```
+
+```
+Error:
+main.pony:8:5: unreachable code
+```
+
+This affected `if`, `iftype`, `while`, `repeat`, `try`, `match`, and `with` constructs. The error pointed at compiler-generated code the user never wrote. This has been fixed.

--- a/src/libponyc/codegen/gencontrol.c
+++ b/src/libponyc/codegen/gencontrol.c
@@ -23,6 +23,9 @@ LLVMValueRef gen_seq(compile_t* c, ast_t* ast)
     if(value == NULL)
       return NULL;
 
+    if(value == GEN_NOVALUE)
+      break;
+
     child = ast_sibling(child);
   }
 

--- a/src/libponyc/expr/control.c
+++ b/src/libponyc/expr/control.c
@@ -12,6 +12,29 @@
 #include "../type/alias.h"
 #include "../type/typeparam.h"
 #include "ponyassert.h"
+#include <string.h>
+
+// The sugar pass appends a TK_REFERENCE("None") to the body of every
+// None-returning function (fun_defaults in sugar.c). By the time the expr
+// pass runs, the refer pass has resolved it to a TK_TYPEREF whose second
+// child is TK_ID("None"). When the preceding expression jumps away in all
+// branches, the expr pass would flag this trailing None as unreachable.
+// But the user never wrote it, so the error is misleading. This helper
+// identifies the shape so the error can be suppressed.
+bool is_trailing_none_ref(ast_t* ast)
+{
+  if(ast_sibling(ast) != NULL)
+    return false;
+
+  if(ast_id(ast) == TK_TYPEREF)
+  {
+    ast_t* id = ast_childidx(ast, 1);
+    return (id != NULL) && (ast_id(id) == TK_ID)
+      && !strcmp(ast_name(id), "None");
+  }
+
+  return false;
+}
 
 bool expr_seq(pass_opt_t* opt, ast_t* ast)
 {
@@ -132,8 +155,11 @@ bool expr_if(pass_opt_t* opt, ast_t* ast)
   {
     if((ast_id(ast_parent(ast)) == TK_SEQ) && ast_sibling(ast) != NULL)
     {
-      ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
-      return false;
+      if(!is_trailing_none_ref(ast_sibling(ast)))
+      {
+        ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
+        return false;
+      }
     }
   }
 
@@ -177,8 +203,11 @@ bool expr_iftype(pass_opt_t* opt, ast_t* ast)
   {
     if((ast_id(ast_parent(ast)) == TK_SEQ) && ast_sibling(ast) != NULL)
     {
-      ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
-      return false;
+      if(!is_trailing_none_ref(ast_sibling(ast)))
+      {
+        ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
+        return false;
+      }
     }
   }
 
@@ -242,17 +271,20 @@ bool expr_while(pass_opt_t* opt, ast_t* ast)
 
   // A loop with no value-producing exit yields nothing and control never
   // resumes past it (the refer pass flags it AST_FLAG_JUMPS_AWAY). Any sibling
-  // in the enclosing sequence is therefore unreachable. This includes the
-  // implicit `None` the sugar pass appends to a None-returning function body
-  // (fun_defaults in sugar.c), which would otherwise be emitted after the
-  // loop's unreachable-terminated post block in codegen, producing invalid IR.
-  // Mirrors the same guard in expr_if/expr_iftype.
+  // in the enclosing sequence is therefore unreachable -- unless it is just
+  // the trailing None the sugar pass appends to None-returning function bodies
+  // (fun_defaults in sugar.c), in which case the error would be misleading
+  // since the user never wrote it. gen_seq stops emitting code after a
+  // GEN_NOVALUE child, so the dead node is harmless in codegen.
   if(ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     if((ast_id(ast_parent(ast)) == TK_SEQ) && ast_sibling(ast) != NULL)
     {
-      ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
-      return false;
+      if(!is_trailing_none_ref(ast_sibling(ast)))
+      {
+        ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
+        return false;
+      }
     }
   }
 
@@ -330,14 +362,16 @@ bool expr_repeat(pass_opt_t* opt, ast_t* ast)
       ast_free_unattached(prev_type);
   }
 
-  // See the matching comment in expr_while: a jumps-away loop makes any sibling
-  // unreachable, including the sugar-appended implicit `None`.
+  // See the matching comment in expr_while.
   if(ast_checkflag(ast, AST_FLAG_JUMPS_AWAY))
   {
     if((ast_id(ast_parent(ast)) == TK_SEQ) && ast_sibling(ast) != NULL)
     {
-      ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
-      return false;
+      if(!is_trailing_none_ref(ast_sibling(ast)))
+      {
+        ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
+        return false;
+      }
     }
   }
 
@@ -375,8 +409,11 @@ bool expr_try(pass_opt_t* opt, ast_t* ast)
 
   if((type == NULL) && (ast_sibling(ast) != NULL))
   {
-    ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
-    return false;
+    if(!is_trailing_none_ref(ast_sibling(ast)))
+    {
+      ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
+      return false;
+    }
   }
 
   ast_t* then_type = ast_type(then_clause);
@@ -419,8 +456,11 @@ bool expr_disposing_block(pass_opt_t* opt, ast_t* ast)
 
   if((type == NULL) && (ast_sibling(ast) != NULL))
   {
-    ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
-    return false;
+    if(!is_trailing_none_ref(ast_sibling(ast)))
+    {
+      ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
+      return false;
+    }
   }
 
   ast_t* dispose_type = ast_type(dispose_clause);

--- a/src/libponyc/expr/control.h
+++ b/src/libponyc/expr/control.h
@@ -7,6 +7,7 @@
 
 PONY_EXTERN_C_BEGIN
 
+bool is_trailing_none_ref(ast_t* ast);
 bool expr_seq(pass_opt_t* opt, ast_t* ast);
 bool expr_if(pass_opt_t* opt, ast_t* ast);
 bool expr_iftype(pass_opt_t* opt, ast_t* ast);

--- a/src/libponyc/expr/match.c
+++ b/src/libponyc/expr/match.c
@@ -461,8 +461,11 @@ bool expr_match(pass_opt_t* opt, ast_t* ast)
 
   if((type == NULL) && (ast_sibling(ast) != NULL))
   {
-    ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
-    return false;
+    if(!is_trailing_none_ref(ast_sibling(ast)))
+    {
+      ast_error(opt->check.errors, ast_sibling(ast), "unreachable code");
+      return false;
+    }
   }
 
   ast_settype(ast, type);

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -2993,17 +2993,10 @@ TEST_F(BadPonyTest, UnconstrainedTypeParameterCompiles)
 
 TEST_F(BadPonyTest, WhileBodyAndElseJumpAwayInSeparateFunction)
 {
-  // From issue #2792 (first example). A while loop whose body and else both
-  // jump away (a valueless break runs the else, which returns) produces no
-  // value and never resumes past the loop -- it jumps away. The sugar pass
-  // appends an implicit `None` to the None-returning function body, which is
-  // then unreachable. This is rejected as "unreachable code", the same error
-  // an equivalent `if true then return else return end` gets. (Previously the
-  // loop compiled, relying on the implicit `None` to luckily terminate the
-  // dead post block; once that block is terminated as unreachable in codegen
-  // -- required for the try-wrapped case -- the implicit `None` would land
-  // after the terminator, producing invalid IR. The expr pass now rejects the
-  // shape before codegen sees it.)
+  // From issue #2792. A while loop whose body and else both jump away
+  // produces no value and never resumes past the loop. The only sibling is
+  // the implicit None the sugar pass appends; that is not user-written code,
+  // so no "unreachable code" error should be reported.
   const char* src =
     "actor Main\n"
     "  fun a() =>\n"
@@ -3016,14 +3009,12 @@ TEST_F(BadPonyTest, WhileBodyAndElseJumpAwayInSeparateFunction)
     "  new create(env: Env) =>\n"
     "    a()";
 
-  TEST_ERRORS_1(src, "unreachable code");
+  TEST_COMPILE(src);
 }
 
 TEST_F(BadPonyTest, RepeatBodyAndElseJumpAwayInSeparateFunction)
 {
   // Same shape as WhileBodyAndElseJumpAwayInSeparateFunction but for repeat.
-  // The guard in expr_repeat mirrors the one in expr_while; this guards against
-  // a future regression that special-cases one loop kind.
   const char* src =
     "actor Main\n"
     "  fun a() =>\n"
@@ -3037,7 +3028,7 @@ TEST_F(BadPonyTest, RepeatBodyAndElseJumpAwayInSeparateFunction)
     "  new create(env: Env) =>\n"
     "    a()";
 
-  TEST_ERRORS_1(src, "unreachable code");
+  TEST_COMPILE(src);
 }
 
 TEST_F(BadPonyTest, WhileWithLiteralBreakValueAndJumpsAwayElse)
@@ -3082,6 +3073,119 @@ TEST_F(BadPonyTest, RepeatWithLiteralBreakValueAndJumpsAwayElse)
     "    a()";
 
   TEST_ERRORS_1(src, "Cannot infer type of unused literal");
+}
+
+// Issue #4565: when all branches of a control construct jump away and the
+// function returns None, the sugar-appended implicit None is the only
+// unreachable sibling. Since the user never wrote it, no error is reported.
+
+TEST_F(BadPonyTest, IfAllBranchesJumpAwayInNoneFunction)
+{
+  const char* src =
+    "actor Main\n"
+    "  fun maybe_error(dont_err: Bool = false) ? =>\n"
+    "    if dont_err then\n"
+    "      return\n"
+    "    else\n"
+    "      error\n"
+    "    end\n"
+
+    "  new create(env: Env) =>\n"
+    "    try maybe_error()? end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, TryAllBranchesJumpAwayInNoneFunction)
+{
+  const char* src =
+    "actor Main\n"
+    "  fun a() ? =>\n"
+    "    try\n"
+    "      error\n"
+    "    else\n"
+    "      error\n"
+    "    end\n"
+
+    "  new create(env: Env) =>\n"
+    "    try a()? end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, MatchAllCasesJumpAwayInNoneFunction)
+{
+  const char* src =
+    "actor Main\n"
+    "  fun a(x: (U32 | String)) ? =>\n"
+    "    match x\n"
+    "    | let _: U32 => return\n"
+    "    | let _: String => error\n"
+    "    else\n"
+    "      error\n"
+    "    end\n"
+
+    "  new create(env: Env) =>\n"
+    "    try a(U32(1))? end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, IftypeAllBranchesJumpAwayInNoneFunction)
+{
+  const char* src =
+    "trait T\n"
+    "class C is T\n"
+
+    "actor Main\n"
+    "  fun a[A: T]() ? =>\n"
+    "    iftype A <: C then\n"
+    "      return\n"
+    "    else\n"
+    "      error\n"
+    "    end\n"
+
+    "  new create(env: Env) =>\n"
+    "    try a[C]()? end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, WithBodyJumpsAwayInNoneFunction)
+{
+  const char* src =
+    "class Disposable\n"
+    "  fun ref dispose() => None\n"
+
+    "actor Main\n"
+    "  fun a() ? =>\n"
+    "    with d = Disposable do\n"
+    "      error\n"
+    "    end\n"
+
+    "  new create(env: Env) =>\n"
+    "    try a()? end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, IfAllBranchesJumpAwayWithRealUnreachable)
+{
+  // Real user code after a fully-jumping if is still an error.
+  const char* src =
+    "actor Main\n"
+    "  fun a() ? =>\n"
+    "    if true then\n"
+    "      return\n"
+    "    else\n"
+    "      error\n"
+    "    end\n"
+    "    let x: U32 = 42\n"
+
+    "  new create(env: Env) =>\n"
+    "    try a()? end";
+
+  TEST_ERRORS_1(src, "unreachable code");
 }
 
 // A control expression that jumps away with no value (`error`, `return`,


### PR DESCRIPTION
The sugar pass appends an implicit `None` to every None-returning function body. When all branches of a control construct jump away, the expr pass flags the implicit `None` as unreachable -- but the user never wrote it. This shows up as a false "unreachable code" error.

Two-part fix:

- Suppress the error when the only unreachable sibling matches the shape the sugar pass creates (trailing `TK_TYPEREF` with `TK_ID("None")` and no further sibling). Applied at all 7 unreachable-code sites in the expr pass (6 in control.c, 1 in match.c).
- Harden `gen_seq` to stop emitting code after a `GEN_NOVALUE` child, so the dead node never reaches LLVM.
