### PR TITLE
Fix `repeat` loop field initialization tracking with `break`

### DIFF
--- a/.release-notes/fix-repeat-field-init-with-break.md
+++ b/.release-notes/fix-repeat-field-init-with-break.md
@@ -1,0 +1,15 @@
+## Fix `repeat` loop field initialization tracking with `break`
+
+The compiler rejected valid programs where a `repeat` loop body initialized a field before an unconditional `break`. The `else` clause was required to also initialize the field, even though the body always did so before exiting. This program now compiles:
+
+```pony
+actor Main
+  var _s: (String | None)
+  new create(env: Env) =>
+    repeat
+      _s = None
+      break
+    until true else
+      None
+    end
+```

--- a/src/libponyc/pass/refer.c
+++ b/src/libponyc/pass/refer.c
@@ -1528,6 +1528,32 @@ static bool refer_while(pass_opt_t* opt, ast_t* ast)
   return true;
 }
 
+// Returns true if the subtree contains a TK_BREAK targeting the enclosing
+// loop. Stops at nested loop and lambda boundaries.
+static bool subtree_contains_break(ast_t* ast)
+{
+  if(ast == NULL)
+    return false;
+
+  token_id id = ast_id(ast);
+
+  if(id == TK_BREAK)
+    return true;
+
+  if(id == TK_WHILE || id == TK_REPEAT ||
+    id == TK_LAMBDA || id == TK_BARELAMBDA)
+    return false;
+
+  for(ast_t* child = ast_child(ast); child != NULL;
+    child = ast_sibling(child))
+  {
+    if(subtree_contains_break(child))
+      return true;
+  }
+
+  return false;
+}
+
 static bool refer_repeat(pass_opt_t* opt, ast_t* ast)
 {
   pony_assert(ast_id(ast) == TK_REPEAT);
@@ -1542,10 +1568,40 @@ static bool refer_repeat(pass_opt_t* opt, ast_t* ast)
   }
 
   size_t branch_count = 0;
+  bool body_falls_through = !ast_checkflag(body, AST_FLAG_JUMPS_AWAY);
 
-  // No symbol status is inherited from the loop body. Nothing from outside the
-  // loop body can be consumed, and definitions in the body may not occur.
-  if(!ast_checkflag(body, AST_FLAG_JUMPS_AWAY))
+  // When the body jumps away via a trailing break with no earlier breaks,
+  // the body-end status accurately reflects what is defined on the break
+  // path (all definitions precede the break). When there are earlier
+  // conditional breaks, the body-end status may include definitions that
+  // happen after an early break, making it unsafe to trust.
+  bool body_break_clean = false;
+
+  if(!body_falls_through && ast_checkflag(body, AST_FLAG_MAY_BREAK))
+  {
+    ast_t* last = ast_childlast(body);
+
+    if((last != NULL) && (ast_id(last) == TK_BREAK))
+    {
+      body_break_clean = true;
+
+      for(ast_t* child = ast_child(body); child != last;
+        child = ast_sibling(child))
+      {
+        if(subtree_contains_break(child))
+        {
+          body_break_clean = false;
+          break;
+        }
+      }
+    }
+  }
+
+  // Count the body as a definition branch when its end-of-sequence status
+  // is accurate for the exit path: either the body falls through to the
+  // condition (normal path), or its only break is a trailing one whose
+  // definitions are the body-end definitions.
+  if(body_falls_through || body_break_clean)
   {
     branch_count++;
     ast_inheritbranch(ast, body);
@@ -1553,15 +1609,13 @@ static bool refer_repeat(pass_opt_t* opt, ast_t* ast)
 
   if(!ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY))
   {
-    // Only include the else clause in the branch analysis
-    // if the loop has a break statement somewhere in it.
-    // This allows us to treat the entire loop body as being
-    // sure to execute in every case, at least for the purposes
-    // of analyzing variables being defined in its scope.
-    // For the case of errors and return statements that may
-    // exit the loop, they do not affect our analysis here
-    // because they will skip past more than just the loop itself.
-    if(ast_checkflag(body, AST_FLAG_MAY_BREAK))
+    // The else clause is reachable via continue and via valueless break
+    // (see gen_repeat: break_novalue_target = else_block). Count it as a
+    // definition branch when those paths exist. When the body has early
+    // conditional breaks (body_break_clean is false), the body-end status
+    // is unsafe, so the else serves as a conservative proxy.
+    if(ast_checkflag(body, AST_FLAG_MAY_CONTINUE) ||
+      (!body_break_clean && ast_checkflag(body, AST_FLAG_MAY_BREAK)))
     {
       branch_count++;
       ast_inheritbranch(ast, else_clause);
@@ -1570,18 +1624,17 @@ static bool refer_repeat(pass_opt_t* opt, ast_t* ast)
 
   ast_consolidate_branches(ast, branch_count);
 
-  // The loop produces no value -- and so jumps away -- only when none of its
-  // exits yields one. branch_count is 0 when the body never falls through to
-  // the condition. On top of that, a break carrying a value gives the loop that
-  // value, and a continue routes to the else clause (see gen_repeat), so a body
-  // that may continue past a non-jumps-away else gives the loop that else's
-  // value. Any of those is a value-producing exit that lets control resume past
-  // the loop.
-  bool value_via_continue = ast_checkflag(body, AST_FLAG_MAY_CONTINUE) &&
-    !ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY);
+  // The loop jumps away only when no exit yields a value. Both continue
+  // and valueless break route through the else clause (see gen_repeat),
+  // so either path past a non-jumps-away else gives the loop a value.
+  bool exits_via_else =
+    !ast_checkflag(else_clause, AST_FLAG_JUMPS_AWAY) &&
+    (ast_checkflag(body, AST_FLAG_MAY_CONTINUE) ||
+      (ast_checkflag(body, AST_FLAG_MAY_BREAK) &&
+        !ast_checkflag(body, AST_FLAG_MAY_BREAK_VALUE)));
 
-  if((branch_count == 0) && !ast_checkflag(body, AST_FLAG_MAY_BREAK_VALUE) &&
-    !value_via_continue)
+  if(!body_falls_through && !ast_checkflag(body, AST_FLAG_MAY_BREAK_VALUE) &&
+    !exits_via_else)
     ast_setflag(ast, AST_FLAG_JUMPS_AWAY);
 
   // Push our symbol status to our parent scope.

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -6118,6 +6118,301 @@ TEST_F(VerifyTest, TryElseNoFieldInitializationInElse)
     "constructor with undefined fields is here");
 }
 
+TEST_F(VerifyTest, RepeatFieldInitInBody)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      _s = None\n"
+    "    until true end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, RepeatFieldInitInBodyWithElse)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      _s = None\n"
+    "    until true else\n"
+    "      None\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, RepeatFieldInitInBodyAndElseWithBreak)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      _s = None\n"
+    "      if true then break end\n"
+    "    until true else\n"
+    "      _s = None\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, RepeatFieldInitInBodyAndElseWithContinue)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      _s = None\n"
+    "      if true then continue end\n"
+    "    until true else\n"
+    "      _s = None\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, RepeatNoFieldInitialization)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      None\n"
+    "    until true end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}
+
+TEST_F(VerifyTest, RepeatNoFieldInitializationWithElse)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      None\n"
+    "    until true else\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}
+
+TEST_F(VerifyTest, RepeatFieldInitOnlyInElse)
+{
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      None\n"
+    "    until true else\n"
+    "      _s = None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}
+
+TEST_F(VerifyTest, RepeatFieldInitInBodyNotElseWithBreak)
+{
+  // Issue #4010. The body unconditionally initializes _s before breaking,
+  // so the field is always defined. The valueless break routes through the
+  // else clause (see gen_repeat), but the body's definitions carry through.
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      _s = None\n"
+    "      break\n"
+    "    until true else\n"
+    "      None\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, RepeatFieldInitAfterBreak)
+{
+  // Field init after a conditional break — the break path exits without
+  // initializing the field.
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      if true then break end\n"
+    "      _s = None\n"
+    "    until true else\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}
+
+TEST_F(VerifyTest, RepeatFieldInitInConditionalWithBreak)
+{
+  // Field is only initialized in one branch of an if inside the body.
+  // With a break present, the else also becomes a branch, and neither
+  // path guarantees initialization.
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      if true then\n"
+    "        _s = None\n"
+    "        break\n"
+    "      end\n"
+    "    until true else\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}
+
+TEST_F(VerifyTest, RepeatFieldInitInBodyWithBreakAndContinue)
+{
+  // Both break and continue paths exist. Both route through else
+  // (valueless break and continue), so body and else must both init.
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      _s = None\n"
+    "      if true then\n"
+    "        break\n"
+    "      else\n"
+    "        continue\n"
+    "      end\n"
+    "    until true else\n"
+    "      _s = None\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, RepeatFieldInitInBodyNotElseWithBreakAndContinue)
+{
+  // Both break and continue paths exist but else does not init the field.
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      _s = None\n"
+    "      if true then\n"
+    "        break\n"
+    "      else\n"
+    "        continue\n"
+    "      end\n"
+    "    until true else\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}
+
+TEST_F(VerifyTest, RepeatFieldInitInBodyNotElseWithBreakCodeAfterLoop)
+{
+  // Valueless break routes through the else clause to post (see gen_repeat).
+  // Code after the loop must be considered reachable.
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      _s = None\n"
+    "      break\n"
+    "    until true else\n"
+    "      None\n"
+    "    end\n"
+    "    None";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, RepeatFieldInitConditionalBreakBeforeInit)
+{
+  // A conditional break before the field init can exit the loop without
+  // initializing the field, even though the body-end status shows it as
+  // defined.
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      if true then break end\n"
+    "      _s = None\n"
+    "      break\n"
+    "    until true else\n"
+    "      None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}
+
+TEST_F(VerifyTest, RepeatFieldInitInBodyWithBreakValue)
+{
+  // Break with a value routes directly to post (break_target = post_block),
+  // bypassing the else clause entirely. The body initializes the field before
+  // breaking, so this should compile.
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    _s = repeat\n"
+    "      _s = None\n"
+    "      break _s\n"
+    "    until true else\n"
+    "      None\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, RepeatFieldInitBodyUnconditionalError)
+{
+  // Body unconditionally errors — no path through the loop defines the
+  // field, and the loop jumps away entirely.
+  const char* src =
+    "actor Main\n"
+    "  var _s: (String | None)\n"
+    "  new create(env: Env) =>\n"
+    "    repeat\n"
+    "      error\n"
+    "    until true else\n"
+    "      _s = None\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "field left undefined in constructor",
+    "constructor with undefined fields is here");
+}
+
 // The compile-time disjoint-concrete check from #1977 must not flag these
 // cases. Each test pins down a specific shape the rule is intentionally
 // blind to (same type, alias, trait/interface, union, type parameter, or


### PR DESCRIPTION
The compiler required the else clause to initialize fields whenever a break existed in a repeat body, even when the body unconditionally initialized the field before breaking. This rejected valid programs like:

```pony
repeat
  _s = None
  break
until true else
  None
end
```

The body-end symbol status is now trusted when the body's sole break is a trailing unconditional one — no earlier breaks can exit before definitions are reached. A `subtree_contains_break` helper detects early conditional breaks to prevent a soundness hole where the body-end status includes definitions that happen after an early break exit.

Also fixes JUMPS_AWAY: valueless break routes through the else clause to post in codegen (`break_novalue_target = else_block`), so the loop produces a value when that path reaches a non-jumping else.

Closes #4010
