### PR TITLE
Fix `style/blank-lines` false positive on block comments between declarations

### DIFF
--- a/.release-notes/fix-blank-lines-block-comment.md
+++ b/.release-notes/fix-blank-lines-block-comment.md
@@ -1,0 +1,18 @@
+## Fix `style/blank-lines` false positive on block comments between declarations
+
+`pony-lint`'s `style/blank-lines` rule fired on block comments placed between type declarations when the comment contained blank lines (paragraph breaks). No arrangement of blank lines around the comment satisfied the rule:
+
+```pony
+class val Foo
+  let x: U8
+  new val create(x': U8) => x = x'
+
+/*
+Comment with
+
+a paragraph break.
+*/
+type Bar is (Foo | None)
+```
+
+Blank lines inside `/* */` comments are now excluded from the between-entities count. A blank line before the comment still satisfies the one-blank-line requirement between declarations.

--- a/tools/pony-lint/blank_lines.pony
+++ b/tools/pony-lint/blank_lines.pony
@@ -240,20 +240,56 @@ primitive BlankLines is ASTRule
   =>
     """
     Count blank lines between `after_line` and `before_line` (1-based,
-    exclusive on both ends).
+    exclusive on both ends). Blank lines inside block comments are not
+    counted — they are paragraph breaks in comment prose, not entity
+    separators.
     """
     if before_line <= (after_line + 1) then return 0 end
     var count: USize = 0
+    var comment_depth: USize = 0
     var line_idx = after_line // 0-based index of next line to check
     while line_idx < (before_line - 1) do
       try
-        if _is_blank(source.lines(line_idx)?) then
+        let line = source.lines(line_idx)?
+        comment_depth = _comment_depth_after(line, comment_depth)
+        if (comment_depth == 0) and _is_blank(line) then
           count = count + 1
         end
       end
       line_idx = line_idx + 1
     end
     count
+
+  fun _comment_depth_after(line: String val, depth: USize): USize =>
+    """
+    Scan a source line for `/*` and `*/` delimiters and return the
+    updated nesting depth. Handles multiple opens/closes on one
+    line and Pony's nested block comments.
+    """
+    var i: USize = 0
+    var d = depth
+    let len = line.size()
+    if len < 2 then return d end
+    while i < (len - 1) do
+      try
+        let c0 = line(i)?
+        let c1 = line(i + 1)?
+        if (c0 == '/') and (c1 == '/') and (d == 0) then
+          return d
+        elseif (c0 == '/') and (c1 == '*') then
+          d = d + 1
+          i = i + 2
+        elseif (c0 == '*') and (c1 == '/') and (d > 0) then
+          d = d - 1
+          i = i + 2
+        else
+          i = i + 1
+        end
+      else
+        i = i + 1
+      end
+    end
+    d
 
   fun _is_blank(line: String val): Bool =>
     """

--- a/tools/pony-lint/test/_test_blank_lines.pony
+++ b/tools/pony-lint/test/_test_blank_lines.pony
@@ -820,6 +820,168 @@ class \nodoc\ _TestBlankLinesLeadingBlankDocEntitiesNoBlank is UnitTest
       h.fail("compilation failed")
     end
 
+class \nodoc\ _TestBlankLinesBlockCommentBetweenEntitiesClean is UnitTest
+  """
+  Block comment with blank lines between entities, with 1 blank
+  line before the comment — should be clean. The blank lines inside
+  the comment are paragraph breaks, not entity separators.
+  Regression test for #5893.
+  """
+  fun name(): String =>
+    "BlankLines: block comment between entities is clean"
+
+  fun apply(h: TestHelper) =>
+    let sf =
+      lint.SourceFile(
+        "test.pony",
+        "class Foo\n" +                       // 1
+        "  fun apply(): None => None\n" +     // 2
+        "\n" +                                // 3 (blank — separator)
+        "/*\n" +                              // 4
+        "Comment with\n" +                    // 5
+        "\n" +                                // 6 (blank inside comment)
+        "a paragraph break.\n" +              // 7
+        "*/\n" +                              // 8
+        "type Bar is (Foo | None)\n",         // 9
+        ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+          .> push(("Bar", ast.TokenIds.tk_type(), 9, 9))
+      end
+    let diags = lint.BlankLines.check_module(entities, sf)
+    h.assert_eq[USize](0, diags.size())
+
+class \nodoc\ _TestBlankLinesBlockCommentNoSeparator is UnitTest
+  """
+  Block comment immediately after entity with no blank separator
+  — should be flagged. The comment doesn't substitute for the
+  blank line. Regression test for #5893.
+  """
+  fun name(): String =>
+    "BlankLines: block comment no blank separator flagged"
+
+  fun apply(h: TestHelper) =>
+    let sf =
+      lint.SourceFile(
+        "test.pony",
+        "class Foo\n" +                       // 1
+        "  fun apply(): None => None\n" +     // 2
+        "/* comment */\n" +                   // 3
+        "type Bar is (Foo | None)\n",         // 4
+        ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+          .> push(("Bar", ast.TokenIds.tk_type(), 4, 4))
+      end
+    let diags = lint.BlankLines.check_module(entities, sf)
+    h.assert_eq[USize](1, diags.size())
+    try
+      h.assert_true(diags(0)?.message.contains("between entities"))
+    else
+      h.fail("could not access diagnostic")
+    end
+
+class \nodoc\ _TestBlankLinesNestedBlockCommentClean is UnitTest
+  """
+  Nested block comment with blank lines between entities —
+  should be clean. Regression test for #5893.
+  """
+  fun name(): String =>
+    "BlankLines: nested block comment between entities is clean"
+
+  fun apply(h: TestHelper) =>
+    let sf =
+      lint.SourceFile(
+        "test.pony",
+        "class Foo\n" +                       // 1
+        "  fun apply(): None => None\n" +     // 2
+        "\n" +                                // 3
+        "/* outer /* inner\n" +               // 4
+        "\n" +                                // 5 (blank inside nested)
+        "*/ still outer */\n" +               // 6
+        "type Bar is (Foo | None)\n",         // 7
+        ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+          .> push(("Bar", ast.TokenIds.tk_type(), 7, 7))
+      end
+    let diags = lint.BlankLines.check_module(entities, sf)
+    h.assert_eq[USize](0, diags.size())
+
+class \nodoc\ _TestBlankLinesLineCommentWithBlockDelimiterClean is UnitTest
+  """
+  Line comment containing `/*` between entities does not poison
+  the block-comment depth tracker. Regression test for #5893.
+  """
+  fun name(): String =>
+    "BlankLines: line comment with block delimiter is clean"
+
+  fun apply(h: TestHelper) =>
+    let sf =
+      lint.SourceFile(
+        "test.pony",
+        "class Foo\n" +                       // 1
+        "  fun apply(): None => None\n" +     // 2
+        "// contains /* unmatched\n" +        // 3
+        "\n" +                                // 4 (blank — separator)
+        "type Bar is (Foo | None)\n",         // 5
+        ".")
+    let entities =
+      recover val
+        Array[(String val, ast.TokenId, USize, USize)]
+          .> push(("Foo", ast.TokenIds.tk_class(), 1, 2))
+          .> push(("Bar", ast.TokenIds.tk_type(), 5, 5))
+      end
+    let diags = lint.BlankLines.check_module(entities, sf)
+    h.assert_eq[USize](0, diags.size())
+
+class \nodoc\ _TestBlankLinesBlockCommentBetweenMethodsClean is UnitTest
+  """
+  Block comment with blank lines between methods within an entity
+  — should be clean. Regression test for #5893.
+  """
+  fun name(): String =>
+    "BlankLines: block comment between methods is clean"
+
+  fun exclusion_group(): String => "ast-compile"
+
+  fun apply(h: TestHelper) =>
+    let source: String val =
+      "class Foo\n" +
+      "  fun foo(): U32 =>\n" +
+      "    U32(1)\n" +
+      "\n" +
+      "  /*\n" +
+      "  Comment with\n" +
+      "\n" +
+      "  a paragraph break.\n" +
+      "  */\n" +
+      "  fun bar(): U32 =>\n" +
+      "    U32(2)\n"
+    try
+      (let program, let sf) = _ASTTestHelper.compile(h, source)?
+      match program.package()
+      | let pkg: ast.Package val =>
+        match pkg.module()
+        | let mod: ast.Module val =>
+          let diags = _CollectRuleDiags(mod, sf, lint.BlankLines)
+          h.assert_eq[USize](0, diags.size())
+        else
+          h.fail("no module")
+        end
+      else
+        h.fail("no package")
+      end
+    else
+      h.fail("compilation failed")
+    end
+
 class \nodoc\ _TestBlankLinesLeadingBlankDocMethodClean is UnitTest
   """
   Abstract method with docstring that starts with a blank line

--- a/tools/pony-lint/test/main.pony
+++ b/tools/pony-lint/test/main.pony
@@ -336,6 +336,11 @@ actor \nodoc\ Main is TestList
     test(_TestBlankLinesLeadingBlankDocEntitiesNoBlank)
     test(_TestBlankLinesLeadingBlankDocMethodClean)
     test(_TestBlankLinesLeadingBlankDocMethodNoBlank)
+    test(_TestBlankLinesBlockCommentBetweenEntitiesClean)
+    test(_TestBlankLinesBlockCommentNoSeparator)
+    test(_TestBlankLinesNestedBlockCommentClean)
+    test(_TestBlankLinesLineCommentWithBlockDelimiterClean)
+    test(_TestBlankLinesBlockCommentBetweenMethodsClean)
 
     // IndentationSize tests
     test(_TestIndentationSizeClean)


### PR DESCRIPTION
`_count_blank_lines` counted blank lines inside `/* */` block comments as entity separators, firing a false positive when a block comment with paragraph breaks sat between declarations. No arrangement of blank lines around the comment satisfied the rule.

The fix tracks `/* */` nesting depth while scanning lines between entities. Blank lines at depth > 0 are skipped. `//` at depth 0 stops the scan so that `/*` inside a line comment does not poison the depth tracker.

Closes #5893
