### PR TITLE
Add multi-iterator for loop sugar

### DIFF
--- a/.release-notes/add-multi-iterator-for.md
+++ b/.release-notes/add-multi-iterator-for.md
@@ -1,0 +1,11 @@
+## Add multi-iterator for loop sugar
+
+Pony's `for` loop now accepts multiple iterators, zipping them together:
+
+```pony
+for (a, b) in (iter_a, iter_b) do
+  env.out.print(a.string() + " " + b.string())
+end
+```
+
+The loop runs until the shortest iterator is exhausted. Three binding forms are supported: destructured names matching the iterator count, nested destructuring for iterators that yield tuples, and a single name that receives the full tuple of values.

--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -862,10 +862,17 @@ DEF(repeat);
 
 // FOR [annotations] idseq IN rawseq DO rawseq [ELSE annotatedseq] END
 // =>
-// (SEQ
-//   (ASSIGN (LET $1) iterator)
-//   (WHILE $1.has_next()
-//     (SEQ (ASSIGN idseq $1.next()) body) else))
+// Single iterator:
+//   (SEQ
+//     (ASSIGN (LET $1) iterator)
+//     (WHILE $1.has_next()
+//       (SEQ (ASSIGN idseq (TRY $1.next() ELSE break)) body) else))
+// Multiple iterators (rawseq is a tuple):
+//   (SEQ
+//     (ASSIGN (LET $1) iter1) (ASSIGN (LET $2) iter2) ...
+//     (WHILE $1.has_next() and $2.has_next() and ...
+//       (SEQ (ASSIGN idseq (TRY ($1.next(), $2.next(), ...) ELSE break))
+//         body) else))
 // The body is not a scope since the sugar wraps it in a seq for us.
 DEF(forloop);
   PRINT_INLINE();

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -515,41 +515,167 @@ static ast_result_t sugar_for(pass_opt_t* opt, ast_t** astp)
   ast_t* annotation = ast_consumeannotation(*astp);
 
   expand_none(for_else, true, opt);
-  const char* iter_name = package_hygienic_id(&opt->check, opt);
 
-  BUILD(try_next, for_iter,
-    NODE(TK_TRY_NO_CHECK,
-      NODE(TK_SEQ, AST_SCOPE
-        NODE(TK_CALL,
-          NODE(TK_DOT, NODE(TK_REFERENCE, ID(iter_name)) ID("next"))
+  // Check if the iterator expression is a tuple (multi-iterator for loop).
+  // for_iter is a TK_SEQ; if its sole child is a TK_TUPLE, we have
+  // multiple iterators.
+  ast_t* iter_child = ast_child(for_iter);
+  bool multi = (iter_child != NULL)
+    && (ast_sibling(iter_child) == NULL)
+    && (ast_id(iter_child) == TK_TUPLE);
+
+  if(multi)
+  {
+    // Multi-iterator for loop:
+    //   for (a, b) in (iter_a, iter_b) do body else else_body end
+    // desugars to:
+    //   (let $1 = iter_a
+    //    let $2 = iter_b
+    //    while $1.has_next() and $2.has_next() do
+    //      (a, b) = try ($1.next()?, $2.next()?) else break end
+    //      body
+    //    else else_body end)
+
+    ast_t* iter_tuple = iter_child;
+    size_t iter_count = ast_childcount(iter_tuple);
+    pony_assert(iter_count >= 2);
+
+    ast_t* outer_seq = ast_from(*astp, TK_SEQ);
+
+    const char** iter_names =
+      (const char**)ponyint_pool_alloc_size(iter_count * sizeof(const char*));
+
+    ast_t* iter_expr = ast_child(iter_tuple);
+    for(size_t i = 0; i < iter_count; i++)
+    {
+      iter_names[i] = package_hygienic_id(&opt->check, opt);
+
+      BUILD(assign, iter_expr,
+        NODE(TK_ASSIGN,
+          NODE(TK_LET, NICE_ID(iter_names[i], "for loop iterator") NONE)
+          TREE(iter_expr)));
+
+      ast_append(outer_seq, assign);
+      iter_expr = ast_sibling(iter_expr);
+    }
+
+    //   $1.has_next() and $2.has_next() and ...
+    ast_t* first_iter_expr = ast_child(iter_tuple);
+
+    BUILD(condition, first_iter_expr,
+      NODE_ERROR_AT(TK_CALL, first_iter_expr,
+        NODE(TK_DOT, NODE(TK_REFERENCE, ID(iter_names[0])) ID("has_next"))
+        NONE
+        NONE
+        NONE));
+
+    ast_t* cond_iter_expr = ast_sibling(first_iter_expr);
+    for(size_t i = 1; i < iter_count; i++)
+    {
+      BUILD(next_cond, cond_iter_expr,
+        NODE_ERROR_AT(TK_CALL, cond_iter_expr,
+          NODE(TK_DOT, NODE(TK_REFERENCE, ID(iter_names[i])) ID("has_next"))
           NONE
           NONE
-          NODE(TK_QUESTION)))
-      NODE(TK_SEQ, AST_SCOPE
-        NODE(TK_BREAK, NONE))
-      NONE));
+          NONE));
 
-  sugar_try(try_next, opt);
+      BUILD(combined, condition,
+        NODE(TK_AND,
+          TREE(condition)
+          TREE(next_cond)
+          NONE));
 
-  REPLACE(astp,
-    NODE(TK_SEQ,
-      NODE(TK_ASSIGN,
-        NODE(TK_LET, NICE_ID(iter_name, "for loop iterator") NONE)
-        TREE(for_iter))
+      condition = combined;
+      cond_iter_expr = ast_sibling(cond_iter_expr);
+    }
+
+    //   ($1.next()?, $2.next()?)
+    ast_t* next_tuple = ast_from(first_iter_expr, TK_TUPLE);
+
+    iter_expr = ast_child(iter_tuple);
+    for(size_t i = 0; i < iter_count; i++)
+    {
+      BUILD(next_call, iter_expr,
+        NODE(TK_SEQ,
+          NODE(TK_CALL,
+            NODE(TK_DOT,
+              NODE(TK_REFERENCE, ID(iter_names[i]))
+              ID("next"))
+            NONE
+            NONE
+            NODE(TK_QUESTION))));
+
+      ast_append(next_tuple, next_call);
+      iter_expr = ast_sibling(iter_expr);
+    }
+
+    //   try (tuple of nexts) else break end
+    BUILD(try_next, first_iter_expr,
+      NODE(TK_TRY_NO_CHECK,
+        NODE(TK_SEQ, AST_SCOPE
+          TREE(next_tuple))
+        NODE(TK_SEQ, AST_SCOPE
+          NODE(TK_BREAK, NONE))
+        NONE));
+
+    sugar_try(try_next, opt);
+
+    BUILD(while_loop, *astp,
       NODE(TK_WHILE, AST_SCOPE
         ANNOTATE(annotation)
-        NODE(TK_SEQ,
-          NODE_ERROR_AT(TK_CALL, for_iter,
-            NODE(TK_DOT, NODE(TK_REFERENCE, ID(iter_name)) ID("has_next"))
-            NONE
-            NONE
-            NONE))
+        NODE(TK_SEQ, TREE(condition))
         NODE(TK_SEQ, AST_SCOPE
           NODE_ERROR_AT(TK_ASSIGN, for_idseq,
             TREE(for_idseq)
             TREE(try_next))
           TREE(for_body))
-        TREE(for_else))));
+        TREE(for_else)));
+
+    ast_append(outer_seq, while_loop);
+
+    ponyint_pool_free_size(iter_count * sizeof(const char*), iter_names);
+
+    ast_replace(astp, outer_seq);
+    ast_free(for_iter);
+  }
+  else
+  {
+    const char* iter_name = package_hygienic_id(&opt->check, opt);
+
+    BUILD(try_next, for_iter,
+      NODE(TK_TRY_NO_CHECK,
+        NODE(TK_SEQ, AST_SCOPE
+          NODE(TK_CALL,
+            NODE(TK_DOT, NODE(TK_REFERENCE, ID(iter_name)) ID("next"))
+            NONE
+            NONE
+            NODE(TK_QUESTION)))
+        NODE(TK_SEQ, AST_SCOPE
+          NODE(TK_BREAK, NONE))
+        NONE));
+
+    sugar_try(try_next, opt);
+
+    REPLACE(astp,
+      NODE(TK_SEQ,
+        NODE(TK_ASSIGN,
+          NODE(TK_LET, NICE_ID(iter_name, "for loop iterator") NONE)
+          TREE(for_iter))
+        NODE(TK_WHILE, AST_SCOPE
+          ANNOTATE(annotation)
+          NODE(TK_SEQ,
+            NODE_ERROR_AT(TK_CALL, for_iter,
+              NODE(TK_DOT, NODE(TK_REFERENCE, ID(iter_name)) ID("has_next"))
+              NONE
+              NONE
+              NONE))
+          NODE(TK_SEQ, AST_SCOPE
+            NODE_ERROR_AT(TK_ASSIGN, for_idseq,
+              TREE(for_idseq)
+              TREE(try_next))
+            TREE(for_body))
+          TREE(for_else))));
+  }
 
   return AST_OK;
 }

--- a/test/full-program-tests/for-multi-iterator/main.pony
+++ b/test/full-program-tests/for-multi-iterator/main.pony
@@ -1,0 +1,64 @@
+actor Main
+  new create(env: Env) =>
+    let a = [as U32: 1; 2; 3]
+    let b = [as U32: 10; 20; 30]
+
+    // Two iterators with destructuring
+    var count: U32 = 0
+    var sum_x: U32 = 0
+    var sum_y: U32 = 0
+    for (x, y) in (a.values(), b.values()) do
+      count = count + 1
+      sum_x = sum_x + x
+      sum_y = sum_y + y
+    end
+    if (count != 3) or (sum_x != 6) or (sum_y != 60) then
+      env.exitcode(1)
+      return
+    end
+
+    // Two iterators with single name (tuple result)
+    count = 0
+    for xy in (a.values(), b.values()) do
+      count = count + 1
+    end
+    if count != 3 then
+      env.exitcode(1)
+      return
+    end
+
+    // Three iterators
+    let c = [as String: "a"; "b"; "c"]
+    count = 0
+    for (x, y, z) in (a.values(), b.values(), c.values()) do
+      count = count + 1
+    end
+    if count != 3 then
+      env.exitcode(1)
+      return
+    end
+
+    // Shortest iterator wins
+    let short = [as U32: 100]
+    count = 0
+    for (x, y) in (a.values(), short.values()) do
+      count = count + 1
+    end
+    if count != 1 then
+      env.exitcode(1)
+      return
+    end
+
+    // Else clause fires when iterators are empty
+    let empty = Array[U32]
+    var else_fired: Bool = false
+    for (x, y) in (empty.values(), a.values()) do
+      env.exitcode(1)
+      return
+    else
+      else_fired = true
+    end
+    if not else_fired then
+      env.exitcode(1)
+      return
+    end

--- a/test/libponyc/sugar.cc
+++ b/test/libponyc/sugar.cc
@@ -925,7 +925,7 @@ TEST_F(SugarTest, NotForWithElse)
 }
 
 
-TEST_F(SugarTest, MultiIteratorFor)
+TEST_F(SugarTest, DestructuredFor)
 {
   const char* short_form =
     "class Foo\n"
@@ -949,6 +949,167 @@ TEST_F(SugarTest, MultiIteratorFor)
     "        None\n"
     "      end\n"
     "      (2)\n"
+    "    else None end\n"
+    "  )";
+
+  TEST_EQUIV(short_form, full_form);
+}
+
+
+TEST_F(SugarTest, MultiIteratorForTwoIterators)
+{
+  const char* short_form =
+    "class Foo\n"
+    "  var create: U32\n"
+    "  fun f(): U32 val =>\n"
+    "    for (i, j) in (1, 2) do 3 end";
+
+  const char* full_form =
+    "use \"builtin\"\n"
+    "class ref Foo\n"
+    "  var create: U32\n"
+    "  fun box f(): U32 val =>\n"
+    "  (\n"
+    "    let $1 = (1)\n"
+    "    let $2 = (2)\n"
+    "    while $1.has_next().op_and($2.has_next()) do\n"
+    "      (let i, let j) = $try_no_check\n"
+    "        ($1.next()?, $2.next()?)\n"
+    "      else\n"
+    "        break\n"
+    "      then\n"
+    "        None\n"
+    "      end\n"
+    "      (3)\n"
+    "    else None end\n"
+    "  )";
+
+  TEST_EQUIV(short_form, full_form);
+}
+
+
+TEST_F(SugarTest, MultiIteratorForSingleName)
+{
+  const char* short_form =
+    "class Foo\n"
+    "  var create: U32\n"
+    "  fun f(): U32 val =>\n"
+    "    for x in (1, 2) do 3 end";
+
+  const char* full_form =
+    "use \"builtin\"\n"
+    "class ref Foo\n"
+    "  var create: U32\n"
+    "  fun box f(): U32 val =>\n"
+    "  (\n"
+    "    let $1 = (1)\n"
+    "    let $2 = (2)\n"
+    "    while $1.has_next().op_and($2.has_next()) do\n"
+    "      let x = $try_no_check\n"
+    "        ($1.next()?, $2.next()?)\n"
+    "      else\n"
+    "        break\n"
+    "      then\n"
+    "        None\n"
+    "      end\n"
+    "      (3)\n"
+    "    else None end\n"
+    "  )";
+
+  TEST_EQUIV(short_form, full_form);
+}
+
+
+TEST_F(SugarTest, MultiIteratorForThreeIterators)
+{
+  const char* short_form =
+    "class Foo\n"
+    "  var create: U32\n"
+    "  fun f(): U32 val =>\n"
+    "    for (a, b, c) in (1, 2, 3) do 4 end";
+
+  const char* full_form =
+    "use \"builtin\"\n"
+    "class ref Foo\n"
+    "  var create: U32\n"
+    "  fun box f(): U32 val =>\n"
+    "  (\n"
+    "    let $1 = (1)\n"
+    "    let $2 = (2)\n"
+    "    let $3 = (3)\n"
+    "    while $1.has_next().op_and($2.has_next()).op_and($3.has_next()) do\n"
+    "      (let a, let b, let c) = $try_no_check\n"
+    "        ($1.next()?, $2.next()?, $3.next()?)\n"
+    "      else\n"
+    "        break\n"
+    "      then\n"
+    "        None\n"
+    "      end\n"
+    "      (4)\n"
+    "    else None end\n"
+    "  )";
+
+  TEST_EQUIV(short_form, full_form);
+}
+
+
+TEST_F(SugarTest, MultiIteratorForWithElse)
+{
+  const char* short_form =
+    "class Foo\n"
+    "  var create: U32\n"
+    "  fun f(): U32 val =>\n"
+    "    for (i, j) in (1, 2) do 3 else 4 end";
+
+  const char* full_form =
+    "use \"builtin\"\n"
+    "class ref Foo\n"
+    "  var create: U32\n"
+    "  fun box f(): U32 val =>\n"
+    "  (\n"
+    "    let $1 = (1)\n"
+    "    let $2 = (2)\n"
+    "    while $1.has_next().op_and($2.has_next()) do\n"
+    "      (let i, let j) = $try_no_check\n"
+    "        ($1.next()?, $2.next()?)\n"
+    "      else\n"
+    "        break\n"
+    "      then\n"
+    "        None\n"
+    "      end\n"
+    "      (3)\n"
+    "    else 4 end\n"
+    "  )";
+
+  TEST_EQUIV(short_form, full_form);
+}
+
+
+TEST_F(SugarTest, MultiIteratorForNestedDestructure)
+{
+  const char* short_form =
+    "class Foo\n"
+    "  var create: U32\n"
+    "  fun f(): U32 val =>\n"
+    "    for (a, (b, c)) in (1, 2) do 3 end";
+
+  const char* full_form =
+    "use \"builtin\"\n"
+    "class ref Foo\n"
+    "  var create: U32\n"
+    "  fun box f(): U32 val =>\n"
+    "  (\n"
+    "    let $1 = (1)\n"
+    "    let $2 = (2)\n"
+    "    while $1.has_next().op_and($2.has_next()) do\n"
+    "      (let a, (let b, let c)) = $try_no_check\n"
+    "        ($1.next()?, $2.next()?)\n"
+    "      else\n"
+    "        break\n"
+    "      then\n"
+    "        None\n"
+    "      end\n"
+    "      (3)\n"
     "    else None end\n"
     "  )";
 

--- a/tools/pony-lsp/workspace/folding_ranges.pony
+++ b/tools/pony-lsp/workspace/folding_ranges.pony
@@ -21,7 +21,7 @@ primitive FoldingRanges
   the LSP processes. Fold ranges for `ifdef` expressions are produced via the
   `tk_if` arm.
 
-  Note: `for` is desugared to a `let` binding and a `while` loop by
+  Note: `for` is desugared to `let` bindings and a `while` loop by
   `sugar_for()` in `src/libponyc/pass/sugar.c`, so `tk_for` never appears in
   the AST that the LSP processes. Fold ranges for `for` expressions are
   produced via the `tk_while` arm.
@@ -178,7 +178,7 @@ primitive FoldingRanges
     produced via the tk_if arm.
 
     Note: tk_for is not matched here because sugar_for() in
-    src/libponyc/pass/sugar.c replaces the for node with a let binding
+    src/libponyc/pass/sugar.c replaces the for node with let bindings
     and a while loop before the AST reaches the LSP. Fold ranges for for
     expressions are produced via the tk_while arm.
     """


### PR DESCRIPTION
Pony's `for` loop now accepts multiple iterators:

```pony
for (a, b) in (iter_a, iter_b) do
  // a from iter_a, b from iter_b
end
```

The sugar pass detects a tuple in iterator position and desugars into separate iterator bindings with an AND-chained `has_next()` condition and a tuple of `next()` calls. The loop stops at the shortest iterator (zip semantics).

Three binding forms work:
- Destructured: `for (a, b) in (iter_a, iter_b) do ... end`
- Nested destructuring: `for (a, (k, v)) in (iter_a, map_iter) do ... end`
- Single name: `for t in (iter_a, iter_b) do ... end` — `t` receives the tuple

No grammar change — the parser already accepts tuples in that position. The single-iterator path is unchanged.

Closes #778
