### PR TITLE
Derive tuple capability from element capabilities

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -588,3 +588,34 @@ main.pony:11:43: argument not assignable to parameter
 
 The compiler now uses the narrowed capability when computing `this->` viewpoint types inside `iftype` branches.
 
+## Fix tuple subtyping for tuples with tag elements
+
+Tuples containing `tag` elements were rejected where `#read` or `val` capabilities were required. The most common trigger was a type alias like `type Rec is (USize, Actr tag)` used with a generic constrained to `Any #read`, such as a priority queue. The compiler applied the outer capability to every tuple element, which produced an impossible type when an element was already constrained — actors, for example, are always `tag`. The tuple's capability is now derived from its element capabilities, and these cases compile as expected.
+
+```pony
+actor Actr
+type Rec is (USize, Actr tag)
+
+class PQ[T: Any #read]
+  fun ref insert(value: T) => None
+
+actor Main
+  new create(env: Env) =>
+    let pq = PQ[Rec]
+    pq.insert((1, Actr))
+```
+
+## Applying a capability to a tuple type alias is a compile error
+
+A tuple's capability is derived from its element capabilities. Writing `FooPair val` where `type FooPair is (Foo, Foo)` now produces a compile error. Specify capabilities on each element directly.
+
+```pony
+// Before: the capability was distributed to each element
+type FooPair is (Foo, Foo)
+let x: FooPair val = ...
+
+// After: specify capabilities on the elements
+type FooPair is (Foo val, Foo val)
+let x: FooPair = ...
+```
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix data loss in collections/persistent Vec.remove ([PR #5903](https://github.com/ponylang/ponyc/pull/5903))
 - Fix object literal compilation with union-constrained type parameters ([PR #5905](https://github.com/ponylang/ponyc/pull/5905))
 - Fix iftype narrowing for methods that use `this->` viewpoint ([PR #5907](https://github.com/ponylang/ponyc/pull/5907))
+- Fix tuple subtyping for tuples with tag elements ([PR #5900](https://github.com/ponylang/ponyc/pull/5900))
 
 ### Added
 
@@ -38,6 +39,7 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Changed
 
 - Type parameter constraints now respect the default cap of the named type ([PR #5886](https://github.com/ponylang/ponyc/pull/5886))
+- Applying a capability to a tuple type alias is a compile error ([PR #5900](https://github.com/ponylang/ponyc/pull/5900))
 
 ## [0.69.1] - 2026-08-21
 

--- a/src/libponyc/pass/flatten.c
+++ b/src/libponyc/pass/flatten.c
@@ -523,6 +523,33 @@ ast_result_t pass_flatten(ast_t** astp, pass_opt_t* options)
     case TK_TYPEPARAMREF:
       return flatten_typeparamref(options, ast);
 
+    case TK_TYPEALIASREF:
+    {
+      AST_GET_CHILDREN(ast, id, typeargs, cap, eph);
+
+      if(ast_id(cap) != TK_NONE)
+      {
+        ast_t* unfolded = typealias_unfold(ast);
+
+        if(unfolded != NULL)
+        {
+          if(ast_id(unfolded) == TK_TUPLETYPE)
+          {
+            ast_error(options->check.errors, cap,
+              "can't apply a capability to a tuple type alias");
+            ast_error_continue(options->check.errors, ast,
+              "a tuple's capability is derived from its element capabilities");
+            ast_free_unattached(unfolded);
+            return AST_ERROR;
+          }
+
+          ast_free_unattached(unfolded);
+        }
+      }
+
+      break;
+    }
+
     case TK_EMBED:
     {
       // An embedded field must have a known, class type.

--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -629,6 +629,164 @@ token_id cap_dispatch(ast_t* type)
   return TK_NONE;
 }
 
+static bool tuple_cap_collect(ast_t* type, bool* has_iso, bool* has_trn,
+  bool* has_ref, bool* has_val, bool* has_box, bool* has_tag,
+  bool* all_ephemeral, pass_opt_t* opt)
+{
+  switch(ast_id(type))
+  {
+    case TK_TUPLETYPE:
+    {
+      ast_t* child = ast_child(type);
+      while(child != NULL)
+      {
+        if(!tuple_cap_collect(child, has_iso, has_trn, has_ref, has_val,
+          has_box, has_tag, all_ephemeral, opt))
+          return false;
+        child = ast_sibling(child);
+      }
+      return true;
+    }
+
+    case TK_NOMINAL:
+    case TK_TYPEPARAMREF:
+    {
+      ast_t* cap_ast = cap_fetch(type);
+      ast_t* eph_ast = ast_sibling(cap_ast);
+      token_id cap = ast_id(cap_ast);
+      token_id eph = ast_id(eph_ast);
+      cap_aliasing(&cap, &eph);
+
+      if(eph != TK_EPHEMERAL)
+      {
+        // Non-ephemeral element prevents the tuple from being ephemeral,
+        // unless the cap is val or tag (which don't meaningfully alias).
+        if(cap != TK_VAL && cap != TK_TAG)
+          *all_ephemeral = false;
+      }
+
+      switch(cap)
+      {
+        case TK_ISO: *has_iso = true; return true;
+        case TK_TRN: *has_trn = true; return true;
+        case TK_REF: *has_ref = true; return true;
+        case TK_VAL: *has_val = true; return true;
+        case TK_BOX: *has_box = true; return true;
+        case TK_TAG: *has_tag = true; return true;
+
+        case TK_CAP_READ:
+          *has_ref = true; *has_val = true; *has_box = true;
+          *all_ephemeral = false;
+          return true;
+
+        case TK_CAP_SEND:
+          *has_iso = true; *has_val = true; *has_tag = true;
+          return true;
+
+        case TK_CAP_SHARE:
+          *has_val = true; *has_tag = true;
+          return true;
+
+        case TK_CAP_ALIAS:
+          *has_ref = true; *has_val = true; *has_box = true; *has_tag = true;
+          *all_ephemeral = false;
+          return true;
+
+        case TK_CAP_ANY:
+          *has_iso = true; *has_trn = true; *has_ref = true;
+          *has_val = true; *has_box = true; *has_tag = true;
+          *all_ephemeral = false;
+          return true;
+
+        default: return false;
+      }
+    }
+
+    case TK_UNIONTYPE:
+    case TK_ISECTTYPE:
+    {
+      ast_t* child = ast_child(type);
+      while(child != NULL)
+      {
+        if(!tuple_cap_collect(child, has_iso, has_trn, has_ref, has_val,
+          has_box, has_tag, all_ephemeral, opt))
+          return false;
+        child = ast_sibling(child);
+      }
+      return true;
+    }
+
+    case TK_TYPEALIASREF:
+    {
+      ast_t* unfolded = typealias_unfold(type);
+      if(unfolded == NULL)
+        return false;
+      bool ok = tuple_cap_collect(unfolded, has_iso, has_trn, has_ref,
+        has_val, has_box, has_tag, all_ephemeral, opt);
+      ast_free_unattached(unfolded);
+      return ok;
+    }
+
+    case TK_ARROW:
+    {
+      ast_t* upper = viewpoint_upper(type, opt);
+      if(upper == NULL)
+        return false;
+      bool ok = tuple_cap_collect(upper, has_iso, has_trn, has_ref,
+        has_val, has_box, has_tag, all_ephemeral, opt);
+      ast_free_unattached(upper);
+      return ok;
+    }
+
+    default:
+      return false;
+  }
+}
+
+void tuple_cap_and_eph(ast_t* type, token_id* out_cap, token_id* out_eph,
+  pass_opt_t* opt)
+{
+  pony_assert(ast_id(type) == TK_TUPLETYPE);
+
+  bool has_iso = false;
+  bool has_trn = false;
+  bool has_ref = false;
+  bool has_val = false;
+  bool has_box = false;
+  bool has_tag = false;
+  bool all_ephemeral = true;
+
+  if(!tuple_cap_collect(type, &has_iso, &has_trn, &has_ref, &has_val,
+    &has_box, &has_tag, &all_ephemeral, opt))
+  {
+    *out_cap = TK_REF;
+    *out_eph = TK_NONE;
+    return;
+  }
+
+  // Sylvan's rule: the tuple cap is derived from element caps using
+  // the viewpoint adaptation table and safe-to-write constraints.
+  // A tuple is never tag because its fields are always accessible.
+  if(!has_iso && !has_trn && !has_ref && !has_box)
+    *out_cap = TK_VAL;
+  else if(!has_iso && !has_trn && !has_ref)
+    *out_cap = TK_BOX;
+  else if(!has_trn && !has_ref && !has_box)
+    *out_cap = TK_ISO;
+  else if(!has_ref && !has_box)
+    *out_cap = TK_TRN;
+  else
+    *out_cap = TK_REF;
+
+  // The tuple is ephemeral only if the derived cap is iso or trn
+  // (caps that are meaningful with ephemeral) and all elements that
+  // contribute that cap are ephemeral.
+  if(all_ephemeral && (*out_cap == TK_ISO || *out_cap == TK_TRN))
+    *out_eph = TK_EPHEMERAL;
+  else
+    *out_eph = TK_NONE;
+}
+
 token_id cap_for_this(typecheck_t* t)
 {
   // If this is a primitive, it's a val.

--- a/src/libponyc/type/cap.h
+++ b/src/libponyc/type/cap.h
@@ -4,6 +4,7 @@
 #include <platform.h>
 #include "../ast/ast.h"
 #include "../ast/frame.h"
+#include "../pass/pass.h"
 
 PONY_EXTERN_C_BEGIN
 
@@ -65,6 +66,14 @@ token_id cap_single(ast_t* type);
  * Get the capability that should be used for dispatch.
  */
 token_id cap_dispatch(ast_t* type);
+
+/**
+ * Get the derived capability and ephemeral of a tuple type from its element
+ * capabilities. Uses viewpoint adaptation: the tuple cap is the cap that sees
+ * all element caps as themselves. A tuple is never tag.
+ */
+void tuple_cap_and_eph(ast_t* type, token_id* out_cap, token_id* out_eph,
+  pass_opt_t* opt);
 
 /**
  * The receiver capability is ref for constructors and behaviours. For

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -883,18 +883,49 @@ static bool is_tuple_sub_nominal(ast_t* sub, ast_t* super,
 {
   if(is_top_type(super, true, opt))
   {
-    for(ast_t* child = ast_child(sub);
-      child != NULL;
-      child = ast_sibling(child))
+    if(check_cap != CHECK_CAP_IGNORE)
     {
-      if(!is_x_sub_x(child, super, check_cap, errorf, opt))
+      token_id sub_cap;
+      token_id sub_eph;
+      tuple_cap_and_eph(sub, &sub_cap, &sub_eph, opt);
+
+      ast_t* super_cap_ast = cap_fetch(super);
+      ast_t* super_eph_ast = ast_sibling(super_cap_ast);
+      token_id super_cap_id = ast_id(super_cap_ast);
+      token_id super_eph_id = ast_id(super_eph_ast);
+
+      bool cap_ok;
+      switch(check_cap)
+      {
+        case CHECK_CAP_EQ:
+          cap_ok = is_cap_sub_cap_constraint(sub_cap, sub_eph,
+            super_cap_id, super_eph_id);
+          break;
+
+        case CHECK_CAP_BOUND:
+          cap_ok = is_cap_sub_cap_bound(sub_cap, sub_eph,
+            super_cap_id, super_eph_id);
+          break;
+
+        default:
+          cap_ok = is_cap_sub_cap(sub_cap, sub_eph,
+            super_cap_id, super_eph_id);
+          break;
+      }
+
+      if(!cap_ok)
       {
         if(errorf != NULL)
         {
-          ast_error_frame(errorf, child,
-            "%s is not a subtype of %s: %s is not a subtype of %s",
-            ast_print_type(sub, opt->strtab), ast_print_type(super, opt->strtab),
-            ast_print_type(child, opt->strtab), ast_print_type(super, opt->strtab));
+          ast_error_frame(errorf, sub,
+            "%s is not a subtype of %s: tuple cap %s%s is not a subcap of"
+            " %s%s",
+            ast_print_type(sub, opt->strtab),
+            ast_print_type(super, opt->strtab),
+            token_id_desc(sub_cap),
+            sub_eph == TK_EPHEMERAL ? "^" : "",
+            token_id_desc(super_cap_id),
+            super_eph_id == TK_EPHEMERAL ? "^" : "");
         }
         return false;
       }

--- a/src/libponyc/type/typealias.c
+++ b/src/libponyc/type/typealias.c
@@ -14,7 +14,6 @@ static void apply_cap_to_type(ast_t* type, token_id tcap, token_id teph)
   {
     case TK_UNIONTYPE:
     case TK_ISECTTYPE:
-    case TK_TUPLETYPE:
     {
       for(ast_t* child = ast_child(type);
         child != NULL;
@@ -25,6 +24,11 @@ static void apply_cap_to_type(ast_t* type, token_id tcap, token_id teph)
 
       return;
     }
+
+    case TK_TUPLETYPE:
+      // A tuple's capability is derived from its element capabilities,
+      // not imposed from outside. Leave element caps unchanged.
+      return;
 
     case TK_NOMINAL:
     case TK_TYPEPARAMREF:

--- a/test/libponyc/type_check_subtype.cc
+++ b/test/libponyc/type_check_subtype.cc
@@ -1117,7 +1117,7 @@ TEST_F(SubTypeTest, TupleTagTagSubAnyTag)
 }
 
 
-TEST_F(SubTypeTest, TupleTagTagNotSubAnyVal)
+TEST_F(SubTypeTest, TupleTagTagSubAnyVal)
 {
   const char* src =
     "class C\n"
@@ -1126,7 +1126,7 @@ TEST_F(SubTypeTest, TupleTagTagNotSubAnyVal)
     "  fun apply(x: (C tag, C tag)) =>\n"
     "    let x': Any val = consume x";
 
-  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+  TEST_COMPILE(src);
 }
 
 
@@ -1165,6 +1165,283 @@ TEST_F(SubTypeTest, TupleValRefNotSubAnyShare)
     "    C[(String val, String ref)]";
 
   TEST_ERRORS_1(src, "type argument is outside its constraint");
+}
+
+
+TEST_F(SubTypeTest, TupleValTagDerivedCapIsVal)
+{
+  // A tuple of (val, tag) elements has derived cap val.
+  const char* src =
+    "actor Actr\n"
+
+    "type Rec is (USize, Actr tag)\n"
+
+    "class PQ[T: Any #read]\n"
+    "  let _data: Array[T]\n"
+    "  new create() => _data = Array[T]\n"
+    "  fun ref insert(value: T) => _data.push(value)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let pq = PQ[Rec]\n"
+    "    pq.insert((1, Actr))";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleValTagWithExplicitValCap)
+{
+  // A capability on a tuple type alias is an error — the tuple's cap is
+  // derived from its elements, not applied from outside.
+  const char* src =
+    "actor Actr\n"
+
+    "type Rec is (USize, Actr tag)\n"
+
+    "class PQ[T: Any #read]\n"
+    "  let _data: Array[T]\n"
+    "  new create() => _data = Array[T]\n"
+    "  fun ref insert(value: T) => _data.push(value)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let pq = PQ[Rec val]\n"
+    "    pq.insert((1, Actr))";
+
+  TEST_ERRORS_1(src, "can't apply a capability to a tuple type alias");
+}
+
+
+TEST_F(SubTypeTest, TupleIsoValDerivedCapIsIso)
+{
+  // A tuple of (iso, val) elements has derived cap iso.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C iso, C val)) =>\n"
+    "    let x': Any iso = consume x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleTrnValDerivedCapIsTrn)
+{
+  // A tuple of (trn, val) elements has derived cap trn.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C trn, C val)) =>\n"
+    "    let x': Any trn = consume x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleValBoxDerivedCapIsBox)
+{
+  // A tuple of (val, box) elements has derived cap box.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C val, C box)) =>\n"
+    "    let x': Any box = x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleIsoTrnDerivedCapIsTrn)
+{
+  // A tuple of (iso, trn) elements has derived cap trn.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C iso, C trn)) =>\n"
+    "    let x': Any trn = consume x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleTrnBoxDerivedCapIsRef)
+{
+  // A tuple of (trn, box) elements has derived cap ref, not trn,
+  // because box is not safe to write through trn.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C trn, C box)) =>\n"
+    "    let x': Any ref = consume x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleTrnBoxNotSubAnyTrn)
+{
+  // A tuple of (trn, box) has derived cap ref, which is not a subcap of trn.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C trn, C box)) =>\n"
+    "    let x': Any trn = consume x";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+
+
+TEST_F(SubTypeTest, TupleValBoxNotSubAnyVal)
+{
+  // A tuple of (val, box) has derived cap box, which is not a subcap of val.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C val, C box)) =>\n"
+    "    let x': Any val = x";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+
+
+TEST_F(SubTypeTest, TupleRefIsoNotSubAnyVal)
+{
+  // A tuple of (ref, iso) elements has derived cap ref, not a subcap of val.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C ref, C iso)) =>\n"
+    "    let x': Any val = consume x";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+
+
+TEST_F(SubTypeTest, TupleIsoValConsumedDerivedCapIsEphemeralIso)
+{
+  // Consuming a tuple of (iso, val) produces ephemeral iso^ derived cap.
+  // Without ephemeral tracking, non-ephemeral iso is not a subcap of iso.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C iso, C val)) =>\n"
+    "    let x': Any iso = consume x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleIsoValNonEphemeralNotSubAnyIso)
+{
+  // Without consume, the derived cap iso is non-ephemeral,
+  // which is not a subcap of iso.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: (C iso, C val)) =>\n"
+    "    let x': Any iso = x";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+
+
+TEST_F(SubTypeTest, TupleGenericReadCapDerivedCapIsRef)
+{
+  // A type parameter with #read cap expands to {ref, val, box}.
+  // Combined with tag, the derived cap is ref.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply[A: Any #read](x: (A, C tag)) =>\n"
+    "    let x': Any ref = x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleGenericReadCapNotSubAnyVal)
+{
+  // A type parameter with #read cap expands to {ref, val, box}.
+  // Combined with tag, the derived cap is ref, not a subcap of val.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply[A: Any #read](x: (A, C tag)) =>\n"
+    "    let x': Any val = x";
+
+  TEST_ERRORS_1(src, "right side must be a subtype of left side");
+}
+
+
+TEST_F(SubTypeTest, TupleNestedDerivedCapFromLeafElements)
+{
+  // Nested tuple: caps are collected from all leaf elements.
+  // ((iso, val), tag) has leaf caps {iso, val, tag}, derived cap iso.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply(x: ((C iso, C val), C tag)) =>\n"
+    "    let x': Any iso = consume x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleTypeParamElementDerivedCap)
+{
+  // A type parameter element is handled as TK_TYPEPARAMREF.
+  // A ref type parameter combined with val gives derived cap ref.
+  const char* src =
+    "class C\n"
+
+    "primitive P\n"
+    "  fun apply[A: C ref](x: (A, C val)) =>\n"
+    "    let x': Any ref = x";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(SubTypeTest, TupleAliasCapAnnotationIsError)
+{
+  // Any capability on a tuple type alias is rejected, even when the cap
+  // matches the derived cap.
+  const char* src =
+    "type Pair is (String, U64)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Pair val = (\"hello\", 42)";
+
+  TEST_ERRORS_1(src, "can't apply a capability to a tuple type alias");
+}
+
+
+TEST_F(SubTypeTest, TupleAliasCapAnnotationEphemeralIsError)
+{
+  // An ephemeral annotation on a tuple type alias is also rejected.
+  const char* src =
+    "type Pair is (String, U64)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Pair iso^ = (\"hello\", 42)";
+
+  TEST_ERRORS_1(src, "can't apply a capability to a tuple type alias");
 }
 
 


### PR DESCRIPTION
Applying a capability to a tuple type alias smashed that cap onto every element. `(USize, Actr tag) val` forced `Actr tag` to become `Actr val`, which is not a valid capability for an actor.

A tuple's capability is now derived from its element capabilities using the viewpoint adaptation table. The derived cap is the narrowest cap where viewpoint adaptation sees all element caps as themselves — `val` when elements are only `val` and `tag`, `box` when `box` is also present, and so on up to `ref`. This follows the rule Sylvan specified in https://github.com/ponylang/ponyc/issues/2196#issuecomment-339449322.

This is both a fix and a breaking change. The fix: tuples with `tag` elements now work in `#read` and `val` contexts. The breaking change: capability annotations on tuple type aliases are now a compile error — the annotation has no effect since the tuple's cap comes from its elements.
