### PR TITLE
Fix data loss in collections/persistent Vec.remove

### DIFF
--- a/.release-notes/fix-vec-remove-overrun.md
+++ b/.release-notes/fix-vec-remove-overrun.md
@@ -10,7 +10,7 @@ actor Main
     try
       let v = Vec[USize].concat([as USize: 0; 1; 2; 3; 4].values())
 
-      // asks to remove index 4 and two indices that do not exist
+      // specifies removal of index 4 and two indices that do not exist
       let r = v.remove(4, 3)?
 
       // elements 2 and 3 were live, were not named, and are gone

--- a/.release-notes/fix-vec-remove-overrun.md
+++ b/.release-notes/fix-vec-remove-overrun.md
@@ -22,6 +22,6 @@ actor Main
 0 1
 ```
 
-The method removed `n` elements from the end of the vector before shifting the survivors down, so when the range ran past the end it took elements from before `i` and never put them back. No error was raised, and `size` was reduced to match the shortened vector, so nothing a caller could inspect disagreed.
+When fewer than `n` elements followed index `i`, elements before `i` were also destroyed. No error was raised, and `size` was reduced to match the shortened vector, so nothing a caller could inspect revealed the loss.
 
 This has been fixed. The count is now saturated: if fewer than `n` elements follow `i`, every element from `i` onward is removed and nothing before `i` is touched. The example above now prints `0 1 2 3`. This matches `Array.remove`, which `Vec.remove` mirrors, and `Vec.slice`, which already documented a saturated range. An index `i` that is out of bounds still raises an error.

--- a/.release-notes/fix-vec-remove-overrun.md
+++ b/.release-notes/fix-vec-remove-overrun.md
@@ -1,6 +1,6 @@
 ## Fix data loss in `collections/persistent` `Vec.remove`
 
-`Vec.remove(i, n)` destroyed elements it was not asked to remove whenever fewer than `n` elements followed index `i`.
+`Vec.remove(i, n)` destroyed elements outside the requested range whenever fewer than `n` elements followed index `i`.
 
 ```pony
 use "collections/persistent"

--- a/.release-notes/fix-vec-remove-overrun.md
+++ b/.release-notes/fix-vec-remove-overrun.md
@@ -1,0 +1,27 @@
+## Fix data loss in `collections/persistent` `Vec.remove`
+
+`Vec.remove(i, n)` destroyed elements it was not asked to remove whenever fewer than `n` elements followed index `i`.
+
+```pony
+use "collections/persistent"
+
+actor Main
+  new create(env: Env) =>
+    try
+      let v = Vec[USize].concat([as USize: 0; 1; 2; 3; 4].values())
+
+      // asks to remove index 4 and two indices that do not exist
+      let r = v.remove(4, 3)?
+
+      // elements 2 and 3 were live, were not named, and are gone
+      for x in r.values() do env.out.write(x.string() + " ") end
+    end
+```
+
+```
+0 1
+```
+
+The method removed `n` elements from the end of the vector before shifting the survivors down, so when the range ran past the end it took elements from before `i` and never put them back. No error was raised, and `size` was reduced to match the shortened vector, so nothing a caller could inspect disagreed.
+
+This has been fixed. The count is now saturated: if fewer than `n` elements follow `i`, every element from `i` onward is removed and nothing before `i` is touched. The example above now prints `0 1 2 3`. This matches `Array.remove`, which `Vec.remove` mirrors, and `Vec.slice`, which already documented a saturated range. An index `i` that is out of bounds still raises an error.

--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -569,8 +569,8 @@ class \nodoc\ iso _TestVecRemoveOverrun is UnitTest
 
   The count is saturated rather than rejected, matching `Array.remove`, which
   this method is named after, and `slice`, which already documents a saturated
-  range. Each case below is checked against `Array.remove` on the same
-  contents so the two cannot drift.
+  range. The two methods must agree on what remove means; a mismatch with
+  `Array.remove` on the same contents is a failure.
   """
   fun name(): String => "collections/persistent/Vec (remove overrun)"
 

--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -37,6 +37,7 @@ actor \nodoc\ Main is TestList
     test(_TestVecContains)
     test(_TestVecFind)
     test(_TestVecIterators)
+    test(_TestVecRemoveOverrun)
     test(_TestVecReverse)
     test(_TestVecSlice)
     test(Property1UnitTest[Array[_MapAction]](_MapIteratorsProperty))
@@ -559,6 +560,58 @@ class \nodoc\ iso _TestVecSlice is UnitTest
     h.assert_eq[USize](v.slice(n).size(), 0)
     h.assert_eq[USize](Vec[USize].slice().size(), 0)
 
+class \nodoc\ iso _TestVecRemoveOverrun is UnitTest
+  """
+  `remove` pops `n` elements off the end before it shifts the survivors down.
+  When fewer than `n` elements follow `i`, the pop takes elements the caller
+  never named and the shift loop is empty, so they are not put back. `size`
+  is reduced to match, which is why nothing downstream disagrees.
+
+  The count is saturated rather than rejected, matching `Array.remove`, which
+  this method is named after, and `slice`, which already documents a saturated
+  range. Each case below is checked against `Array.remove` on the same
+  contents so the two cannot drift.
+  """
+  fun name(): String => "collections/persistent/Vec (remove overrun)"
+
+  fun apply(h: TestHelper) ? =>
+    // a size that stays inside the tail, so a failure is about the arithmetic
+    // rather than about which trie level it landed on
+    _check(h, 5, 4, 3)?  // one element follows i, three named
+    _check(h, 5, 3, 3)?  // two follow, three named
+    _check(h, 5, 4, 4)?
+    _check(h, 5, 0, 99)? // every element named and then some
+    _check(h, 5, 4, 1)?  // exactly reaches the end, no overrun
+    _check(h, 5, 1, 2)?  // wholly inside, the case that already worked
+    _check(h, 5, 2, 0)?  // removes nothing
+
+    // and across a level boundary, where the pop walks the trie rather than
+    // the tail
+    _check(h, 33, 32, 8)?
+    _check(h, 1056, 1050, 100)?
+
+    // `i` itself out of bounds still raises: saturating the count does not
+    // make an out of range start acceptable
+    let v = _VecGen.build([as USize: 0; 1; 2])
+    h.assert_error({() ? => v.remove(3, 1)? }, "i == size")
+    h.assert_error({() ? => v.remove(9, 1)? }, "i past size")
+    h.assert_error({() ? => Vec[USize].remove(0, 1)? }, "empty vec")
+
+  fun _check(h: TestHelper, size: USize, i: USize, n: USize) ? =>
+    let elements = Array[USize](size)
+    for x in mut.Range(0, size) do elements.push(x) end
+
+    let expected = Array[USize](size) .> append(elements)
+    expected.remove(i, n)
+
+    let got = _VecCheck.contents(_VecGen.build(elements).remove(i, n)?)
+
+    let at: String val =
+      " (size " + size.string() + ", remove(" + i.string() + ", " +
+        n.string() + "))"
+    h.assert_eq[USize](expected.size(), got.size(), "size" + at)
+    h.assert_array_eq[USize](expected, got, "contents" + at)
+
 class \nodoc\ iso _TestVecReverse is UnitTest
   fun name(): String => "collections/persistent/Vec (reverse)"
 
@@ -711,7 +764,10 @@ class \nodoc\ iso _VecModelProperty is Property1[(USize, Array[_VecAction])]
       | 5 =>
         if n > 0 then
           let i = a % n
-          let count = 1 + (b % (n - i))
+          // drawn from the whole size, so a count that runs past the end is
+          // generated as readily as one that fits. `Array.remove` saturates,
+          // so the model already carries the answer `Vec.remove` must give.
+          let count = 1 + (b % n)
           v = v.remove(i, count)?
           model.remove(i, count)
         end

--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -565,7 +565,7 @@ class \nodoc\ iso _TestVecRemoveOverrun is UnitTest
   `remove` pops `n` elements off the end before it shifts the survivors down.
   When fewer than `n` elements follow `i`, the pop takes elements the caller
   never named and the shift loop is empty, so they are not put back. `size`
-  is reduced to match, which is why nothing downstream disagrees.
+  is reduced to match, which is why nothing downstream reveals a discrepancy.
 
   The count is saturated rather than rejected, matching `Array.remove`, which
   this method is named after, and `slice`, which already documents a saturated

--- a/packages/collections/persistent/vec.pony
+++ b/packages/collections/persistent/vec.pony
@@ -93,13 +93,16 @@ class val Vec[A: Any #share]
 
   fun val remove(i: USize, n: USize): Vec[A] ? =>
     """
-    Return a vector with n elements removed, beginning at index i.
+    Return a vector with n elements removed, beginning at index i. The range
+    is saturated: if fewer than n elements follow i, every element from i
+    onward is removed. Raises an error if i is out of bounds.
     """
     if i >= _size then error end
+    let count = n.min(_size - i)
     var vec = this
-    for _ in mut.Range(0, n) do vec = vec.pop()? end
-    for idx in mut.Range(i, _size - n) do
-      vec = vec.update(idx, this(idx + n)?)?
+    for _ in mut.Range(0, count) do vec = vec.pop()? end
+    for idx in mut.Range(i, _size - count) do
+      vec = vec.update(idx, this(idx + count)?)?
     end
     vec
 


### PR DESCRIPTION
Fix data loss in collections/persistent Vec.remove

Vec.remove(i, n) destroyed elements it was not asked to remove whenever
fewer than n elements followed index i. On a five element vector,
remove(4, 3) returned [0 1]: elements 2 and 3 were live, were not named
by the call, and were gone.

The method pops n elements off the end before shifting the survivors
down. That is correct only while i + n <= size. When the range overruns,
the pop takes elements from before i, and the shift loop's bound
size - n falls at or below i, so the loop is empty and nothing is put
back. No error is raised, and size is reduced to match the shortened
vector, so nothing a caller can inspect disagrees. It is the same shape
as the _MapSubNodes.remove bug fixed in #5877: act on a computed
position without confirming what is there, then adjust the derived size
to match.

Saturate the count with n.min(_size - i) instead. Vec.remove mirrors
Array.remove, which saturates the same way (builtin/array.pony), and
slice already documents a saturated range, so this is the contract the
rest of the type already implies. An out of bounds i still raises. The
docstring stated no contract for an overrunning n at all; it now says
which one it keeps.

The suite could not have caught this. The model property drew its count
as 1 + (b % (n - i)), which is clamped by construction and so
mathematically incapable of generating an overrun. Draw from the whole
size instead. The model needed no change: it is an Array, and
Array.remove already saturates, so it was carrying the right answer the
whole time.

Add an example test covering the arithmetic (one element following i,
two, exact reach, a count far beyond the end, and zero) in both
structural regimes, inside the tail and at 33 and 1056 elements where
the pop walks the trie. It pins the out of bounds i cases too, so
saturating the count cannot later be widened into accepting a bad start.

Both the new example test and the widened property fail against a tree
with the fix reverted.

