### PR TITLE
Fix object literal compilation with union-constrained type parameters

### DIFF
--- a/.release-notes/fix-object-literal-union-constraint.md
+++ b/.release-notes/fix-object-literal-union-constraint.md
@@ -1,0 +1,26 @@
+## Fix object literal compilation with union-constrained type parameters
+
+Object literals inside methods whose type parameters have union constraints with mixed capabilities failed to compile:
+
+```pony
+interface box FnBox[A, B]
+  fun apply(a: A): B ?
+interface ref FnRef[A, B]
+  fun ref apply(a: A): B ?
+type Fn[A, B] is (FnBox[A, B] box | FnRef[A, B] ref)
+
+actor Main
+  new create(env: Env) => None
+  fun bar[A, B, F: Fn[A, B]](f: F) =>
+    object ref
+      fun ref foo(a: A) ? =>
+        iftype F <: FnBox[A, B] box then f(consume a)?
+        elseif F <: FnRef[A, B] ref then f(consume a)?
+        else error
+        end
+    end
+```
+
+The compiler reported "type argument is outside its constraint" for the object literal's captured type parameters. The same code without the object literal compiled correctly.
+
+This has been fixed. Object literals inside methods with union-constrained type parameters now compile correctly.

--- a/src/libponyc/type/typeparam.c
+++ b/src/libponyc/type/typeparam.c
@@ -539,8 +539,51 @@ static bool apply_cap_to_single(ast_t* type, token_id tcap, token_id teph)
       break;
 
     default:
-      if(ast_id(cap) != tcap)
-        return false;
+    {
+      // When tcap is a generic cap, keep members whose concrete cap is a
+      // valid reification. Return early to preserve the concrete cap rather
+      // than overwriting it with the generic at ast_setid below.
+      switch(tcap)
+      {
+        case TK_CAP_READ:
+          switch(ast_id(cap))
+          {
+            case TK_REF: case TK_VAL: case TK_BOX: return true;
+            default: return false;
+          }
+
+        case TK_CAP_SEND:
+          switch(ast_id(cap))
+          {
+            case TK_ISO: case TK_VAL: case TK_TAG: return true;
+            default: return false;
+          }
+
+        case TK_CAP_SHARE:
+          switch(ast_id(cap))
+          {
+            case TK_VAL: case TK_TAG: return true;
+            default: return false;
+          }
+
+        case TK_CAP_ALIAS:
+          switch(ast_id(cap))
+          {
+            case TK_REF: case TK_VAL: case TK_BOX: case TK_TAG:
+              return true;
+            default: return false;
+          }
+
+        case TK_CAP_ANY:
+          return true;
+
+        default:
+          if(ast_id(cap) != tcap)
+            return false;
+          break;
+      }
+      break;
+    }
   }
 
   // Set the capability.

--- a/test/libponyc/object.cc
+++ b/test/libponyc/object.cc
@@ -149,3 +149,80 @@ TEST_F(ObjectTest, ObjectProvidesEnclosingTraitWithTypeParams)
   TEST_COMPILE(src);
 }
 
+TEST_F(ObjectTest, ObjectInMethodWithUnionConstraint)
+{
+  // From issue #2924: an object literal inside a method whose type parameter
+  // has a union constraint with mixed capabilities should compile.
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun bar[F: (U32 val | String ref)]() =>\n"
+    "    object val end\n";
+  TEST_COMPILE(src);
+}
+
+TEST_F(ObjectTest, ObjectInMethodWithUnionConstraintShare)
+{
+  // Union of val and tag derives #share.
+  const char* src =
+    "actor Tag1\n"
+    "  new create() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun bar[F: (U32 val | Tag1 tag)]() =>\n"
+    "    object val end\n";
+  TEST_COMPILE(src);
+}
+
+TEST_F(ObjectTest, ObjectInMethodWithUnionConstraintSend)
+{
+  // Union of iso and tag derives #send.
+  const char* src =
+    "class iso Iso1\n"
+    "  new iso create() => None\n"
+    "actor Tag2\n"
+    "  new create() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun bar[F: (Iso1 iso | Tag2 tag)]() =>\n"
+    "    object val end\n";
+  TEST_COMPILE(src);
+}
+
+TEST_F(ObjectTest, ObjectInMethodWithUnionConstraintAlias)
+{
+  // Union of ref and tag derives #alias.
+  const char* src =
+    "actor Tag3\n"
+    "  new create() => None\n"
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun bar[F: (String ref | Tag3 tag)]() =>\n"
+    "    object val end\n";
+  TEST_COMPILE(src);
+}
+
+TEST_F(ObjectTest, ObjectInMethodWithUnionConstraintAndIftype)
+{
+  // From issue #2924: iftype inside an object literal that captures type
+  // parameters from a method with a union constraint.
+  const char* src =
+    "interface box FnBox[A, B]\n"
+    "  fun apply(a: A): B ?\n"
+    "interface ref FnRef[A, B]\n"
+    "  fun ref apply(a: A): B ?\n"
+    "type Fn[A, B] is (FnBox[A, B] box | FnRef[A, B] ref)\n"
+    "\n"
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun bar[A, B, F: Fn[A, B]](f: F) =>\n"
+    "    object ref\n"
+    "      fun ref foo(a: A) ? =>\n"
+    "        iftype F <: FnBox[A, B] box then f(consume a)?\n"
+    "        elseif F <: FnRef[A, B] ref then f(consume a)?\n"
+    "        else error\n"
+    "        end\n"
+    "    end\n";
+  TEST_COMPILE(src);
+}
+


### PR DESCRIPTION
When computing the upper bound of a type parameter with a union constraint, `apply_cap_to_single` filtered out members whose concrete capability didn't exactly match the derived generic cap. A union like `(FnBox box | FnRef ref)` derives `#read`, but neither `box` nor `ref` passes an exact match against `#read`, so both members were removed and the constraint was treated as empty.

Accept any concrete capability that is a valid reification of the generic cap — `ref`, `val`, and `box` for `#read`, and so on for the other generic caps.

Closes #2924
