### PR TITLE
Improve heap-to-stack promotion for stored objects

### DIFF
--- a/.release-notes/improve-heap-to-stack-stores.md
+++ b/.release-notes/improve-heap-to-stack-stores.md
@@ -1,0 +1,5 @@
+## Improve heap-to-stack promotion for stored objects
+
+The heap-to-stack optimization pass now promotes objects that are stored into fields of already-stack-promoted parents. Previously, storing a `pony_alloc`'d pointer into any field caused the pass to treat the allocation as escaped, keeping it on the heap even when the parent was local and never left the function.
+
+A common case this unlocks: a local `String` whose backing buffer is a separate allocation stored into a String field. When the String is promoted to the stack, the buffer can now follow it.

--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -368,14 +368,84 @@ public:
 
         case Instruction::Store:
         {
-          // If we store the pointer, it is captured.
-          // TODO: if we store the pointer in something that is stack allocated
-          // is it still captured?
           if(value == inst->getOperand(0))
           {
-            print_transform(c, alloc, "captured allocation");
-            print_transform(c, inst, "captured here (store)");
-            return false;
+            Value* dest = inst->getOperand(1);
+            const DataLayout& dl =
+              inst->getModule()->getDataLayout();
+
+            APInt store_offset(64, 0);
+            Value* store_base =
+              dest->stripAndAccumulateConstantOffsets(dl, store_offset,
+                true);
+
+            if(!isa<AllocaInst>(store_base))
+            {
+              print_transform(c, alloc, "captured allocation");
+              print_transform(c, inst, "captured here (store to non-stack)");
+              return false;
+            }
+
+            // Walk every use of the alloca to find loads from the same
+            // (base, offset). Those loads may produce our pointer.
+            AllocaInst* slot = cast<AllocaInst>(store_base);
+            SmallVector<Value*, 8> slot_ptrs;
+            SmallSet<Value*, 8> slot_seen;
+            slot_ptrs.push_back(slot);
+            slot_seen.insert(slot);
+
+            while(!slot_ptrs.empty())
+            {
+              Value* ptr = slot_ptrs.pop_back_val();
+
+              for(auto ui = ptr->user_begin(), ue = ptr->user_end();
+                ui != ue; ++ui)
+              {
+                Instruction* user = dyn_cast<Instruction>(*ui);
+                if(user == nullptr)
+                  continue;
+
+                if(isa<GetElementPtrInst>(user) ||
+                  isa<BitCastInst>(user))
+                {
+                  if(slot_seen.insert(user).second)
+                    slot_ptrs.push_back(user);
+                }
+                else if(auto *li = dyn_cast<LoadInst>(user))
+                {
+                  Value* load_addr = li->getPointerOperand();
+                  APInt load_offset(64, 0);
+                  Value* load_base =
+                    load_addr->stripAndAccumulateConstantOffsets(
+                      dl, load_offset, true);
+
+                  // Skip only when we can prove the load accesses a
+                  // different field: same base, different offset.
+                  if(load_base == store_base &&
+                    load_offset != store_offset)
+                    continue;
+
+                  if(canBeReused(li, alloc, dt))
+                    return false;
+
+                  for(auto lui = li->use_begin(), lue = li->use_end();
+                    lui != lue; ++lui)
+                  {
+                    Use* load_use = &(*lui);
+
+                    if(visited.insert(load_use).second)
+                      work.push_back(load_use);
+                  }
+                }
+                else if(!isa<StoreInst>(user))
+                {
+                  print_transform(c, alloc, "captured allocation");
+                  print_transform(c, inst,
+                    "captured here (alloca use in call/unknown)");
+                  return false;
+                }
+              }
+            }
           }
           break;
         }

--- a/test/libponyc/codegen_optimisation.cc
+++ b/test/libponyc/codegen_optimisation.cc
@@ -146,3 +146,73 @@ TEST_F(CodegenOptimisationTest, MergeSendTracedProducesSendNext)
 
   ASSERT_GT(count_calls_to("pony_send_next"), (size_t)0);
 }
+
+
+TEST_F(CodegenOptimisationTest, HeapToStackStoreToAlloca)
+{
+  // An object stored into a field of a stack-promoted parent should also
+  // be promotable.
+  const char* src =
+    "class Inner\n"
+    "  let x: U64\n"
+    "  new create(x': U64) => x = x'\n"
+
+    "class Outer\n"
+    "  let inner: Inner\n"
+    "  new create() =>\n"
+    "    inner = Inner(42)\n"
+
+    "  fun get_x(): U64 => inner.x\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let o = Outer\n"
+    "    let x = o.get_x()";
+
+  opt.release = true;
+
+  TEST_COMPILE(src);
+
+  size_t before = count_calls_to("pony_alloc_small");
+  DO(optimise());
+  size_t after = count_calls_to("pony_alloc_small");
+
+  ASSERT_LT(after, before);
+}
+
+
+TEST_F(CodegenOptimisationTest, HeapToStackStoreToEscapingNotPromoted)
+{
+  // An object stored into an actor field escapes — it must stay on the
+  // heap, so the optimization should not reduce pony_alloc_small calls.
+  const char* src =
+    "class Inner\n"
+    "  let x: U64\n"
+    "  new create(x': U64) => x = x'\n"
+
+    "class Outer\n"
+    "  let inner: Inner\n"
+    "  new create() =>\n"
+    "    inner = Inner(42)\n"
+
+    "  fun get_x(): U64 => inner.x\n"
+
+    "actor Main\n"
+    "  var _o: (Outer | None)\n"
+    "  new create(env: Env) =>\n"
+    "    _o = Outer\n"
+    "    let x = match _o\n"
+    "    | let o: Outer => o.get_x()\n"
+    "    else 0\n"
+    "    end";
+
+  opt.release = true;
+
+  TEST_COMPILE(src);
+
+  size_t before = count_calls_to("pony_alloc_small");
+  DO(optimise());
+  size_t after = count_calls_to("pony_alloc_small");
+
+  ASSERT_GE(after, before);
+}


### PR DESCRIPTION
The HeapToStack pass bailed unconditionally when a `pony_alloc`'d pointer was stored — appearing as the value operand of a `StoreInst`. This prevented stack promotion of objects stored into fields of parents that were themselves stack-promotable, a pattern that appears after constructor inlining (e.g., a String's backing buffer stored into the String's field).

Now the pass checks whether the store destination is stack memory (an `AllocaInst`). If so, it walks loads from the same (base, offset) and feeds their uses back into the escape analysis. The pass already restarts after each promotion, so outer objects promoted in one iteration make their fields visible as stack destinations in the next.

Closes #1431
