### PR TITLE
Fix stack overflow (SEGV) in persistent List from unbounded recursion

### DIFF
--- a/.release-notes/fix-list-recursion-depth.md
+++ b/.release-notes/fix-list-recursion-depth.md
@@ -1,0 +1,22 @@
+## Fix stack overflow (SEGV) in persistent List from unbounded recursion
+
+Most persistent `List` operations caused a stack overflow at ordinary list sizes.
+
+```pony
+use "collections/persistent"
+use mut = "collections"
+
+actor Main
+  new create(env: Env) =>
+    var l: List[USize] = Lists[USize].empty()
+    for i in mut.Range(0, 50_000) do l = l.prepend(i) end
+    env.out.print(l.map[USize]({(x) => x * 2 }).size().string())
+```
+
+```
+Segmentation fault (core dumped)
+```
+
+The length that crashed depended on the stack size and the build, so the same program could work on one machine and crash on another. In a debug build with an 8 MB stack, `map`, `filter`, and `concat` crashed at around 50,000 elements; `apply` and `Lists.eq` at around 200,000 even in a release build.
+
+This has been fixed. The example above now prints `50000`. No signatures changed.

--- a/packages/collections/persistent/_test.pony
+++ b/packages/collections/persistent/_test.pony
@@ -20,6 +20,7 @@ actor \nodoc\ Main is TestList
     test(_TestListFlatMap)
     test(_TestListFold)
     test(_TestListFrom)
+    test(_TestListLong)
     test(_TestListMap)
     test(_TestListPartition)
     test(_TestListPrepend)
@@ -132,6 +133,57 @@ class \nodoc\ iso _TestListConcat is UnitTest
     let l8 = Lists[U32]([1])
     let l9 = l8.reverse()
     h.assert_true(Lists[U32].eq(l9, Lists[U32]([1]))?)
+
+class \nodoc\ iso _TestListLong is UnitTest
+  """
+  Every transformation, over a list long enough that one stack frame per
+  element would exhaust the stack.
+
+  These used to recurse once per element. A Pony stack overflow is not an
+  error a caller can catch: it takes the runtime down, and every actor with
+  it. Nothing here would have failed on that, because no other example test
+  in this file builds a list long enough for recursion depth to matter.
+
+  200_000 is about five times the length that overflowed an 8 MB stack. A
+  machine with a larger stack raises that length, so a regression shows up as
+  the test binary dying rather than as a failed assertion.
+  """
+  fun name(): String => "collections/persistent/List (long list)"
+
+  fun apply(h: TestHelper) ? =>
+    let n: USize = 200_000
+    let source = Array[USize](n)
+    for i in mut.Range(0, n) do source.push(i) end
+
+    // `Lists.apply` reverses, so building the list exercises `reverse`
+    let l = Lists[USize](source)
+    h.assert_eq[USize](l.size(), n)
+    h.assert_eq[USize](l(0)?, 0, "apply, first")
+    h.assert_eq[USize](l(n - 1)?, n - 1, "apply, last")
+
+    h.assert_eq[USize](l.reverse()(0)?, n - 1, "reverse")
+    h.assert_eq[USize](l.map[USize]({(x) => x + 1 })(0)?, 1, "map")
+    h.assert_eq[USize](l.filter({(x) => (x % 2) == 0 }).size(), n / 2, "filter")
+    h.assert_eq[USize](
+      l.fold[USize]({(acc, x) => acc + 1 }, 0), n, "fold")
+    h.assert_true(l.every({(x) => x < n }), "every")
+    h.assert_true(l.exists({(x) => x == (n - 1) }), "exists")
+    h.assert_eq[USize](l.concat(l).size(), n * 2, "concat")
+    h.assert_eq[USize](
+      l.flat_map[USize]({(x) => Lists[USize]([x]) }).size(), n, "flat_map")
+    h.assert_eq[USize](l.take(n).size(), n, "take")
+    h.assert_eq[USize](
+      l.take_while({(x) => true }).size(), n, "take_while")
+    h.assert_eq[USize](l.drop(1).size(), n - 1, "drop")
+
+    (let hits, let misses) = l.partition({(x) => (x % 2) == 0 })
+    h.assert_eq[USize](hits.size(), n / 2, "partition, hits")
+    h.assert_eq[USize](misses.size(), n / 2, "partition, misses")
+
+    l.for_each({(x) => None })
+
+    // `eq` walks both lists, and was not tail called even in a release build
+    h.assert_true(Lists[USize].eq[USize](l, Lists[USize](source))?, "eq")
 
 class \nodoc\ iso _TestListMap is UnitTest
   fun name(): String => "collections/persistent/Lists (map)"

--- a/packages/collections/persistent/list.pony
+++ b/packages/collections/persistent/list.pony
@@ -72,17 +72,16 @@ primitive Lists[A]
     """
     Checks whether two lists are equal.
     """
-    if (l1.is_empty() and l2.is_empty()) then
-      true
-    elseif (l1.is_empty() and l2.is_non_empty()) then
-      false
-    elseif (l1.is_non_empty() and l2.is_empty()) then
-      false
-    elseif (l1.head()? != l2.head()?) then
-      false
-    else
-      eq[T](l1.tail()?, l2.tail()?)?
+    var a: List[T] = l1
+    var b: List[T] = l2
+    while true do
+      if a.is_empty() and b.is_empty() then return true end
+      if a.is_empty() or b.is_empty() then return false end
+      if a.head()? != b.head()? then return false end
+      a = a.tail()?
+      b = b.tail()?
     end
+    true
 
 primitive Nil[A] is ReadSeq[val->A]
   """
@@ -255,10 +254,22 @@ class val Cons[A] is ReadSeq[val->A]
     """
     Returns the i-th element of the list. Errors if the index is out of bounds.
     """
-    match i
-    | 0 => _head
-    else _tail(i - 1)?
+    if i == 0 then return _head end
+    // `apply` has a box receiver, so the walk starts from the tail field
+    // rather than from `this`
+    var cur: List[A] = _tail
+    var n = i - 1
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        if n == 0 then return cons.head() end
+        cur = cons.tail()
+        n = n - 1
+      else
+        error
+      end
     end
+    error
 
   fun values(): Iterator[val->A]^ =>
     """
@@ -298,17 +309,18 @@ class val Cons[A] is ReadSeq[val->A]
     """
     Builds a new list by reversing the elements in the list.
     """
-    _reverse(this, Nil[A])
-
-  fun val _reverse(l: List[A], acc: List[A]): List[A] =>
-    """
-    Private helper for reverse, recursively working on elements.
-    """
-    match l
-    | let cons: Cons[A] => _reverse(cons.tail(), acc.prepend(cons.head()))
-    else
-      acc
+    var out: List[A] = Nil[A]
+    var cur: List[A] = this
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        out = out.prepend(cons.head())
+        cur = cons.tail()
+      else
+        break
+      end
     end
+    out
 
   fun val prepend(a: val->A): Cons[A] =>
     """
@@ -321,166 +333,147 @@ class val Cons[A] is ReadSeq[val->A]
     Builds a new list that is the concatenation of this list and the provided
     list.
     """
-    _concat(l, this.reverse())
-
-  fun val _concat(l: List[A], acc: List[A]): List[A] =>
-    """
-    Private helper for concat that recursively builds the new list.
-    """
-    match l
-    | let cons: Cons[A] => _concat(cons.tail(), acc.prepend(cons.head()))
-    else
-      acc.reverse()
+    var out: List[A] = this.reverse()
+    var cur: List[A] = l
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        out = out.prepend(cons.head())
+        cur = cons.tail()
+      else
+        break
+      end
     end
+    out.reverse()
 
   fun val map[B](f: {(val->A): val->B} box): List[B] =>
     """
     Builds a new list by applying a function to every member of the list.
     """
-    _map[B](this, f, Nil[B])
-
-  fun _map[B](l: List[A], f: {(val->A): val->B} box, acc: List[B]): List[B] =>
-    """
-    Private helper for map, recursively applying function to elements.
-    """
-    match l
-    | let cons: Cons[A] =>
-      _map[B](cons.tail(), f, acc.prepend(f(cons.head())))
-    else
-      acc.reverse()
+    var out: List[B] = Nil[B]
+    var cur: List[A] = this
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        out = out.prepend(f(cons.head()))
+        cur = cons.tail()
+      else
+        break
+      end
     end
+    out.reverse()
 
   fun val flat_map[B](f: {(val->A): List[B]} box): List[B] =>
     """
     Builds a new list by applying a function to every member of the list and
     using the elements of the resulting lists.
     """
-    _flat_map[B](this, f, Nil[B])
-
-  fun _flat_map[B](l: List[A], f: {(val->A): List[B]} box, acc: List[B]):
-  List[B] =>
-    """
-    Private helper for flat_map, recursively working on elements.
-    """
-    match l
-    | let cons: Cons[A] =>
-      _flat_map[B](cons.tail(), f, _rev_prepend[B](f(cons.head()), acc))
-    else
-      acc.reverse()
+    var out: List[B] = Nil[B]
+    var cur: List[A] = this
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        // each result is prepended in order, which reverses it into `out`;
+        // the reverse at the end puts both levels back the right way round
+        var inner: List[B] = f(cons.head())
+        while true do
+          match inner
+          | let icons: Cons[B] =>
+            out = out.prepend(icons.head())
+            inner = icons.tail()
+          else
+            break
+          end
+        end
+        cur = cons.tail()
+      else
+        break
+      end
     end
-
-  fun tag _rev_prepend[B](l: List[B], target: List[B]): List[B] =>
-    """
-    Prepends l in reverse order onto target
-    """
-    match l
-    | let cns: Cons[B] =>
-      _rev_prepend[B](cns.tail(), target.prepend(cns.head()))
-    else
-      target
-    end
+    out.reverse()
 
   fun val for_each(f: {(val->A)} box) =>
     """
     Applies the supplied function to every element of the list in order.
     """
-    _for_each(this, f)
-
-  fun _for_each(l: List[A], f: {(val->A)} box) =>
-    """
-    Private helper for for_each, recursively working on elements.
-    """
-    match l
-    | let cons: Cons[A] =>
-      f(cons.head())
-      _for_each(cons.tail(), f)
+    var cur: List[A] = this
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        f(cons.head())
+        cur = cons.tail()
+      else
+        break
+      end
     end
 
   fun val filter(f: {(val->A): Bool} box): List[A] =>
     """
     Builds a new list with those elements that satisfy a provided predicate.
     """
-    _filter(this, f, Nil[A])
-
-  fun _filter(l: List[A], f: {(val->A): Bool} box, acc: List[A]): List[A] =>
-    """
-    Private helper for filter, recursively working on elements, keeping those
-    that match the predicate and discarding those that don't.
-    """
-    match l
-    | let cons: Cons[A] =>
-      if (f(cons.head())) then
-        _filter(cons.tail(), f, acc.prepend(cons.head()))
+    var out: List[A] = Nil[A]
+    var cur: List[A] = this
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        if f(cons.head()) then out = out.prepend(cons.head()) end
+        cur = cons.tail()
       else
-        _filter(cons.tail(), f, acc)
+        break
       end
-    else
-      acc.reverse()
     end
+    out.reverse()
 
   fun val fold[B](f: {(B, val->A): B^} box, acc: B): B =>
     """
     Folds the elements of the list using the supplied function.
     """
-    _fold[B](this, f, consume acc)
-
-  fun val _fold[B](l: List[A], f: {(B, val->A): B^} box, acc: B): B =>
-    """
-    Private helper for fold, recursively working on elements.
-    """
-    match l
-    | let cons: Cons[A] =>
-      _fold[B](cons.tail(), f, f(consume acc, cons.head()))
-    else
-      acc
+    var out: B = consume acc
+    var cur: List[A] = this
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        out = f(consume out, cons.head())
+        cur = cons.tail()
+      else
+        break
+      end
     end
+    consume out
 
   fun val every(f: {(val->A): Bool} box): Bool =>
     """
     Returns true if every element satisfies the provided predicate, false
     otherwise.
     """
-    _every(this, f)
-
-  fun _every(l: List[A], f: {(val->A): Bool} box): Bool =>
-    """
-    Private helper for every, recursively testing predicate on elements,
-    returning false immediately on an element that fails to satisfy the
-    predicate.
-    """
-    match l
-    | let cons: Cons[A] =>
-      if (f(cons.head())) then
-        _every(cons.tail(), f)
+    var cur: List[A] = this
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        if not f(cons.head()) then return false end
+        cur = cons.tail()
       else
-        false
+        break
       end
-    else
-      true
     end
+    true
 
   fun val exists(f: {(val->A): Bool} box): Bool =>
     """
     Returns true if at least one element satisfies the provided predicate,
     false otherwise.
     """
-    _exists(this, f)
-
-  fun _exists(l: List[A], f: {(val->A): Bool} box): Bool =>
-    """
-    Private helper for exists, recursively testing predicate on elements,
-    returning true immediately on an element satisfying the predicate.
-    """
-    match l
-    | let cons: Cons[A] =>
-      if (f(cons.head())) then
-        true
+    var cur: List[A] = this
+    while true do
+      match cur
+      | let cons: Cons[A] =>
+        if f(cons.head()) then return true end
+        cur = cons.tail()
       else
-        _exists(cons.tail(), f)
+        break
       end
-    else
-      false
     end
+    false
 
   fun val partition(f: {(val->A): Bool} box): (List[A], List[A]) =>
     """


### PR DESCRIPTION
Every operation recursed once per element. Most were tail calls that LLVM turned into loops in release builds but not debug. Cons.apply and Lists.eq were not tail calls (the recursive call sits under a partial call), so they never became loops and overflowed at around 200,000 elements even in release builds.

No signatures changed.
