### PR TITLE
Fix compiler accepting `?` functions whose only error source is self-recursion

### DIFF
--- a/.release-notes/fix-vacuously-partial-self-recursion.md
+++ b/.release-notes/fix-vacuously-partial-self-recursion.md
@@ -1,0 +1,13 @@
+## Fix compiler accepting `?` functions whose only error source is self-recursion
+
+A function marked `?` compiled successfully when its only source of partiality was a recursive call to itself. The partiality was circular — the call raises because the function is partial, and the function is partial because of the call — so no error could ever be raised:
+
+```pony
+primitive Foo
+  fun apply(x: Bool): Bool ? =>
+    apply(not x)?
+```
+
+The compiler now rejects this with "function signature is marked as partial but the function body cannot raise an error."
+
+Mutual recursion — A calls B, B calls A, neither with an independent error source — is not yet detected.

--- a/src/libponyc/verify/fun.c
+++ b/src/libponyc/verify/fun.c
@@ -1,5 +1,6 @@
 #include "fun.h"
 #include "../type/alias.h"
+#include "../type/typealias.h"
 #include "../type/cap.h"
 #include "../type/compattype.h"
 #include "../type/lookup.h"
@@ -323,6 +324,101 @@ static bool verify_any_final(pass_opt_t* opt, ast_t* ast)
   return ok;
 }
 
+static bool is_receiver_enclosing_type(pass_opt_t* opt, ast_t* type)
+{
+  switch(ast_id(type))
+  {
+    case TK_NOMINAL:
+      return (ast_t*)ast_data(type) == opt->check.frame->type;
+
+    case TK_ARROW:
+      return is_receiver_enclosing_type(opt, ast_childidx(type, 1));
+
+    case TK_TYPEALIASREF:
+    {
+      ast_t* unfolded = typealias_unfold(type);
+
+      if(unfolded == NULL)
+        return false;
+
+      bool result = is_receiver_enclosing_type(opt, unfolded);
+      ast_free_unattached(unfolded);
+      return result;
+    }
+
+    default:
+      return false;
+  }
+}
+
+static bool is_call_to_method(pass_opt_t* opt, ast_t* ast, ast_t* method)
+{
+  pony_assert((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_FUNCHAIN) ||
+    (ast_id(ast) == TK_NEWREF));
+
+  AST_GET_CHILDREN(ast, receiver, method_name);
+
+  if(ast_id(receiver) == ast_id(ast))
+    AST_GET_CHILDREN_NO_DECL(receiver, receiver, method_name);
+
+  ast_t* receiver_type = ast_type(receiver);
+
+  if(!is_receiver_enclosing_type(opt, receiver_type))
+    return false;
+
+  deferred_reification_t* method_def = lookup_try(opt, receiver,
+    receiver_type, ast_name(method_name), true);
+
+  if(method_def == NULL)
+    return false;
+
+  ast_t* method_ast = method_def->ast;
+  deferred_reify_free(method_def);
+
+  return method_ast == method;
+}
+
+static bool has_independent_error(pass_opt_t* opt, ast_t* ast, ast_t* method)
+{
+  ast_t* child = ast_child(ast);
+
+  if((ast_id(ast) == TK_TRY) || (ast_id(ast) == TK_TRY_NO_CHECK))
+  {
+    pony_assert(child != NULL);
+    child = ast_sibling(child);
+  }
+
+  bool found_child_error = false;
+
+  while(child != NULL)
+  {
+    if(ast_canerror(child))
+    {
+      found_child_error = true;
+
+      if(has_independent_error(opt, child, method))
+        return true;
+    }
+
+    child = ast_sibling(child);
+  }
+
+  if(ast_canerror(ast))
+  {
+    if(ast_id(ast) == TK_ERROR)
+      return true;
+
+    if((ast_id(ast) == TK_FUNREF) || (ast_id(ast) == TK_FUNCHAIN) ||
+      (ast_id(ast) == TK_NEWREF))
+      return !is_call_to_method(opt, ast, method);
+
+    if(!found_child_error)
+      return true;
+  }
+
+  return false;
+}
+
 static bool show_partiality(pass_opt_t* opt, ast_t* ast)
 {
   ast_t* child = ast_child(ast);
@@ -445,6 +541,19 @@ bool verify_fun(pass_opt_t* opt, ast_t* ast)
     {
       ast_error(opt->check.errors, can_error, "function signature is marked as "
         "partial but the function body cannot raise an error");
+      return false;
+    }
+
+    if(!is_trait &&
+      ast_canerror(body) &&
+      (ast_type(body) != NULL) &&
+      (ast_id(ast_type(body)) != TK_COMPILE_INTRINSIC) &&
+      !has_independent_error(opt, body, ast))
+    {
+      ast_error(opt->check.errors, can_error, "function signature is marked as "
+        "partial but the function body cannot raise an error");
+      ast_error_continue(opt->check.errors, can_error, "only source of "
+        "partiality is a recursive call to this method");
       return false;
     }
   } else {

--- a/test/libponyc/verify.cc
+++ b/test/libponyc/verify.cc
@@ -354,6 +354,134 @@ TEST_F(VerifyTest, PartialFunctionNoError)
     "body cannot raise an error");
 }
 
+TEST_F(VerifyTest, PartialFunctionSelfRecursiveOnly)
+{
+  // From issue #2392
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply() ? =>\n"
+    "    apply()?";
+
+  TEST_ERRORS_1(src, "function signature is marked as partial but the function "
+    "body cannot raise an error");
+}
+
+TEST_F(VerifyTest, PartialFunctionSelfRecursiveWithError)
+{
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply(x: Bool) ? =>\n"
+    "    if x then error end\n"
+    "    apply(x)?";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, PartialFunctionSelfRecursiveInTry)
+{
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply() ? =>\n"
+    "    try\n"
+    "      apply()?\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "function signature is marked as partial but the function "
+    "body cannot raise an error");
+}
+
+TEST_F(VerifyTest, PartialFunctionSelfRecursiveInTryElse)
+{
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply() ? =>\n"
+    "    try\n"
+    "      apply()?\n"
+    "    else\n"
+    "      apply()?\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "function signature is marked as partial but the function "
+    "body cannot raise an error");
+}
+
+TEST_F(VerifyTest, PartialFunctionSelfRecursiveInBranch)
+{
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply(x: Bool) ? =>\n"
+    "    if x then\n"
+    "      apply(x)?\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "function signature is marked as partial but the function "
+    "body cannot raise an error");
+}
+
+TEST_F(VerifyTest, PartialFunctionSelfRecursiveDifferentArgs)
+{
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply(x: Bool) ? =>\n"
+    "    apply(not x)?";
+
+  TEST_ERRORS_1(src, "function signature is marked as partial but the function "
+    "body cannot raise an error");
+}
+
+TEST_F(VerifyTest, PartialFunctionRecursiveOnUnionType)
+{
+  const char* src =
+    "type Step is (StepA | StepB)\n"
+    "\n"
+    "primitive StepA\n"
+    "  fun run(next: Step) ? =>\n"
+    "    next.run(StepB)?\n"
+    "\n"
+    "primitive StepB\n"
+    "  fun run(next: Step) ? =>\n"
+    "    error";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, PartialFunctionSelfRecursiveChainedCall)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun other(): Foo ? => error\n"
+    "  fun apply(): Foo ? =>\n"
+    "    apply()?.other()?";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(VerifyTest, PartialFunctionSelfRecursiveViaTypeAlias)
+{
+  const char* src =
+    "type MyFoo is Foo ref\n"
+    "class Foo\n"
+    "  fun ref apply(x: Bool): Bool ? =>\n"
+    "    let f: MyFoo = this\n"
+    "    f.apply(x)?";
+
+  TEST_ERRORS_1(src, "function signature is marked as partial but the function "
+    "body cannot raise an error");
+}
+
+TEST_F(VerifyTest, PartialFunctionSelfRecursiveViaTypeAliasWithError)
+{
+  const char* src =
+    "type MyFoo is Foo ref\n"
+    "class Foo\n"
+    "  fun ref apply(x: Bool): Bool ? =>\n"
+    "    if x then error end\n"
+    "    let f: MyFoo = this\n"
+    "    f.apply(x)?";
+
+  TEST_COMPILE(src);
+}
+
 TEST_F(VerifyTest, PartialFunctionError)
 {
   const char* src =


### PR DESCRIPTION
A function marked `?` whose only error source is a recursive call to itself can never raise an error — the partiality is circular. The compiler accepted these because the recursive call's `?` satisfied the check that first set it.

After the verify pass sets CAN_ERROR flags, walk the function body. If every leaf error source resolves to a call to the enclosing method, reject the function. The receiver type is checked against the enclosing type to avoid false positives on union-typed receivers where method lookup returns a representative that happens to pointer-equal the current method.

Direct recursion only. Mutual recursion (A calls B calls A, neither with an independent error source) requires SCC analysis across functions and is left for future work.

Closes #2392
