### PR TITLE
Switch nightlies from cron schedule to workflow_dispatch

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,8 +1,7 @@
 name: Nightlies
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 permissions:
   packages: write


### PR DESCRIPTION
GitHub's cron scheduler has been unreliable lately. Switch to workflow_dispatch so nightlies can be triggered externally via Zapier.
