### PR TITLE
Add cron schedule back to nightlies

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,6 +1,8 @@
 name: Nightlies
 
 on:
+  schedule:
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Keep the cron schedule as a fallback alongside workflow_dispatch.
