### PR TITLE
Fix heap-to-stack promotion allowing alloca address escapes

### DIFF
--- a/src/libponyc/codegen/genopt.cc
+++ b/src/libponyc/codegen/genopt.cc
@@ -437,7 +437,17 @@ public:
                       work.push_back(load_use);
                   }
                 }
-                else if(!isa<StoreInst>(user))
+                else if(auto *si = dyn_cast<StoreInst>(user))
+                {
+                  if(si->getValueOperand() == ptr)
+                  {
+                    print_transform(c, alloc, "captured allocation");
+                    print_transform(c, inst,
+                      "captured here (alloca address stored)");
+                    return false;
+                  }
+                }
+                else
                 {
                   print_transform(c, alloc, "captured allocation");
                   print_transform(c, inst,


### PR DESCRIPTION
PR #5906 added code to promote objects stored into fields of already-promoted allocas. The inner loop that walks users of the destination alloca skipped all StoreInst users unconditionally. When the alloca-derived pointer appears as operand 0 (the value being stored, not the destination), the alloca's address is being written into another object — an undetected escape. Cascading promotions then placed objects on the stack whose addresses had escaped through stored pointer chains, causing segfaults in peg and stallion.

The fix distinguishes operand 0 (the alloca address stored elsewhere — reject) from operand 1 (writing into the alloca — skip as before).
