### PR TITLE
Add HTML backend to pony-doc with table of contents

### DIFF
--- a/tools/pony-doc/_html_assets.pony
+++ b/tools/pony-doc/_html_assets.pony
@@ -1,0 +1,204 @@
+primitive _HtmlAssets
+  """
+  Embedded CSS for the self-contained HTML documentation output.
+  """
+
+  fun css(): String =>
+    """
+    Stylesheet based on the Material-themed stdlib docs layout.
+    """
+    ":root {\n" +
+    "  --bg: #fafafa;\n" +
+    "  --fg: #212121;\n" +
+    "  --fg-light: #616161;\n" +
+    "  --link: #795548;\n" +
+    "  --link-hover: #5d4037;\n" +
+    "  --border: #e0e0e0;\n" +
+    "  --code-bg: #f5f5f5;\n" +
+    "  --code-border: #e0e0e0;\n" +
+    "  --toc-bg: #fff;\n" +
+    "  --header-bg: #795548;\n" +
+    "  --header-fg: #fff;\n" +
+    "  --nav-bg: #fff;\n" +
+    "}\n" +
+    "@media (prefers-color-scheme: dark) {\n" +
+    "  :root {\n" +
+    "    --bg: #1e1e1e;\n" +
+    "    --fg: #e0e0e0;\n" +
+    "    --fg-light: #9e9e9e;\n" +
+    "    --link: #bcaaa4;\n" +
+    "    --link-hover: #d7ccc8;\n" +
+    "    --border: #424242;\n" +
+    "    --code-bg: #2d2d2d;\n" +
+    "    --code-border: #424242;\n" +
+    "    --toc-bg: #252525;\n" +
+    "    --header-bg: #4e342e;\n" +
+    "    --header-fg: #e0e0e0;\n" +
+    "    --nav-bg: #252525;\n" +
+    "  }\n" +
+    "}\n" +
+    "*, *::before, *::after { box-sizing: border-box; }\n" +
+    "body {\n" +
+    "  margin: 0;\n" +
+    "  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI',\n" +
+    "    Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;\n" +
+    "  font-size: 16px;\n" +
+    "  line-height: 1.6;\n" +
+    "  color: var(--fg);\n" +
+    "  background: var(--bg);\n" +
+    "}\n" +
+    ".header {\n" +
+    "  background: var(--header-bg);\n" +
+    "  color: var(--header-fg);\n" +
+    "  padding: 0.5rem 1.5rem;\n" +
+    "  display: flex;\n" +
+    "  align-items: center;\n" +
+    "  gap: 0.75rem;\n" +
+    "}\n" +
+    ".header img {\n" +
+    "  height: 32px;\n" +
+    "  width: 32px;\n" +
+    "}\n" +
+    ".header a {\n" +
+    "  color: var(--header-fg);\n" +
+    "  text-decoration: none;\n" +
+    "  font-weight: 600;\n" +
+    "  font-size: 1.1rem;\n" +
+    "}\n" +
+    ".breadcrumb {\n" +
+    "  padding: 0.5rem 1.5rem;\n" +
+    "  font-size: 0.85rem;\n" +
+    "  color: var(--fg-light);\n" +
+    "  border-bottom: 1px solid var(--border);\n" +
+    "}\n" +
+    ".breadcrumb a {\n" +
+    "  color: var(--link);\n" +
+    "  text-decoration: none;\n" +
+    "}\n" +
+    ".breadcrumb a:hover { text-decoration: underline; }\n" +
+    "main {\n" +
+    "  max-width: 52rem;\n" +
+    "  margin: 0 auto;\n" +
+    "  padding: 1.5rem;\n" +
+    "}\n" +
+    "a { color: var(--link); }\n" +
+    "a:hover { color: var(--link-hover); }\n" +
+    "h1 { font-size: 1.8rem; border-bottom: 2px solid var(--border);\n" +
+    "  padding-bottom: 0.3rem; margin-top: 0; }\n" +
+    "h2 { font-size: 1.4rem; border-bottom: 1px solid var(--border);\n" +
+    "  padding-bottom: 0.2rem; margin-top: 2rem; }\n" +
+    "h3 { font-size: 1.15rem; margin-top: 1.5rem; }\n" +
+    "h4 { font-size: 1rem; margin-top: 1rem; color: var(--fg-light); }\n" +
+    "code {\n" +
+    "  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono',\n" +
+    "    Menlo, monospace;\n" +
+    "  font-size: 0.875em;\n" +
+    "  background: var(--code-bg);\n" +
+    "  padding: 0.15em 0.35em;\n" +
+    "  border-radius: 3px;\n" +
+    "}\n" +
+    "pre {\n" +
+    "  background: var(--code-bg);\n" +
+    "  border: 1px solid var(--code-border);\n" +
+    "  border-radius: 4px;\n" +
+    "  padding: 1rem;\n" +
+    "  overflow-x: auto;\n" +
+    "  line-height: 1.45;\n" +
+    "}\n" +
+    "pre code {\n" +
+    "  background: none;\n" +
+    "  padding: 0;\n" +
+    "  font-size: 0.85rem;\n" +
+    "}\n" +
+    ".source-link {\n" +
+    "  font-size: 0.85rem;\n" +
+    "  margin-left: 0.5rem;\n" +
+    "}\n" +
+    ".source-link a { text-decoration: none; }\n" +
+    ".source-link a:hover { text-decoration: underline; }\n" +
+    "hr {\n" +
+    "  border: none;\n" +
+    "  border-top: 1px solid var(--border);\n" +
+    "  margin: 1.5rem 0;\n" +
+    "}\n" +
+    "ul.type-list {\n" +
+    "  list-style: none;\n" +
+    "  padding-left: 0;\n" +
+    "}\n" +
+    "ul.type-list li {\n" +
+    "  padding: 0.15rem 0;\n" +
+    "}\n" +
+    "nav.toc {\n" +
+    "  background: var(--toc-bg);\n" +
+    "  border: 1px solid var(--border);\n" +
+    "  border-radius: 4px;\n" +
+    "  padding: 1rem 1.25rem;\n" +
+    "  margin: 1.5rem 0;\n" +
+    "}\n" +
+    "nav.toc h2 {\n" +
+    "  font-size: 1.1rem;\n" +
+    "  margin: 0 0 0.5rem 0;\n" +
+    "  border: none;\n" +
+    "  padding: 0;\n" +
+    "}\n" +
+    "nav.toc ul {\n" +
+    "  list-style: none;\n" +
+    "  padding-left: 0;\n" +
+    "  margin: 0;\n" +
+    "}\n" +
+    "nav.toc li {\n" +
+    "  padding: 0.1rem 0;\n" +
+    "  font-size: 0.9rem;\n" +
+    "}\n" +
+    "nav.toc li a {\n" +
+    "  text-decoration: none;\n" +
+    "}\n" +
+    "nav.toc li a code {\n" +
+    "  font-size: 0.8rem;\n" +
+    "}\n" +
+    "nav.toc li a:hover { text-decoration: underline; }\n" +
+    "nav.toc h3 {\n" +
+    "  font-size: 0.95rem;\n" +
+    "  margin: 0.75rem 0 0.25rem 0;\n" +
+    "  border: none;\n" +
+    "  color: var(--fg-light);\n" +
+    "}\n" +
+    "nav.toc h3:first-child { margin-top: 0; }\n" +
+    ".params li, .returns li {\n" +
+    "  padding: 0.1rem 0;\n" +
+    "}\n" +
+    ".source-table {\n" +
+    "  width: 100%;\n" +
+    "  border-collapse: collapse;\n" +
+    "  background: var(--code-bg);\n" +
+    "  border: 1px solid var(--code-border);\n" +
+    "  border-radius: 4px;\n" +
+    "  padding: 0.5rem;\n" +
+    "  overflow-x: auto;\n" +
+    "  display: block;\n" +
+    "}\n" +
+    ".source-table td {\n" +
+    "  padding: 0;\n" +
+    "  vertical-align: top;\n" +
+    "  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono',\n" +
+    "    Menlo, monospace;\n" +
+    "  font-size: 0.85rem;\n" +
+    "  line-height: 1.45;\n" +
+    "}\n" +
+    ".source-table .line-num {\n" +
+    "  width: 1%;\n" +
+    "  white-space: nowrap;\n" +
+    "  padding-right: 1rem;\n" +
+    "  text-align: right;\n" +
+    "  color: var(--fg-light);\n" +
+    "  user-select: none;\n" +
+    "  -webkit-user-select: none;\n" +
+    "}\n" +
+    ".source-table .line-num a {\n" +
+    "  color: var(--fg-light);\n" +
+    "  text-decoration: none;\n" +
+    "}\n" +
+    ".source-table .line-num a:hover {\n" +
+    "  color: var(--link);\n" +
+    "}\n" +
+    ".source-code { white-space: pre; }\n"

--- a/tools/pony-doc/html_backend.pony
+++ b/tools/pony-doc/html_backend.pony
@@ -1,0 +1,759 @@
+use "files"
+
+primitive HtmlBackend is Backend
+  """
+  Generates self-contained HTML documentation output.
+
+  Produces a directory of static HTML files viewable directly in a browser
+  with no external dependencies. Each entity page includes a table of
+  contents listing members with their full signatures.
+  """
+  fun generate(
+    program: DocProgram box,
+    output_dir: FilePath,
+    include_private: Bool)
+    ?
+  =>
+    """
+    Write HTML files to `output_dir/<program-name>-docs/`.
+    """
+    let base_name: String val = program.name + "-docs"
+    let base_dir = output_dir.join(base_name)?
+    base_dir.mkdir()
+    let src_dir = base_dir.join("src")?
+    src_dir.mkdir()
+    let assets_dir = base_dir.join("assets")?
+    assets_dir.mkdir()
+
+    let home_links = recover iso String(1024) end
+    let written_sources = Array[String]
+
+    for pkg in program.packages.values() do
+      let pkg_tqfn = TQFN(pkg.qualified_name, "-index")
+      let sanitized_pkg =
+        PathSanitize.replace_path_separator(pkg.qualified_name)
+
+      home_links.append("<li><a href=\"")
+      home_links.append(HtmlEscape.attribute(pkg_tqfn))
+      home_links.append(".html\">")
+      home_links.append(HtmlEscape.content(pkg.qualified_name))
+      home_links.append("</a></li>\n")
+
+      let public_type_links = recover iso String(512) end
+      let private_type_links = recover iso String(512) end
+
+      for entity in pkg.public_types.values() do
+        public_type_links.append("<li><a href=\"")
+        public_type_links.append(HtmlEscape.attribute(entity.tqfn))
+        public_type_links.append(".html\">")
+        public_type_links.append(HtmlEscape.content(
+          entity.kind.keyword() + " " + entity.name))
+        public_type_links.append("</a></li>\n")
+
+        _write_entity_page(
+          base_dir, entity, sanitized_pkg, program.name,
+          pkg.qualified_name, include_private)?
+      end
+
+      for entity in pkg.private_types.values() do
+        private_type_links.append("<li><a href=\"")
+        private_type_links.append(HtmlEscape.attribute(entity.tqfn))
+        private_type_links.append(".html\">")
+        private_type_links.append(HtmlEscape.content(
+          entity.kind.keyword() + " " + entity.name))
+        private_type_links.append("</a></li>\n")
+
+        _write_entity_page(
+          base_dir, entity, sanitized_pkg, program.name,
+          pkg.qualified_name, include_private)?
+      end
+
+      _write_package_page(
+        base_dir, pkg, pkg_tqfn, program.name,
+        consume public_type_links, consume private_type_links,
+        include_private)?
+
+      for sf in pkg.source_files.values() do
+        let source_key: String val = sanitized_pkg + "/" + sf.filename
+        var already_written = false
+        for written in written_sources.values() do
+          if written == source_key then
+            already_written = true
+            break
+          end
+        end
+        if not already_written then
+          written_sources.push(source_key)
+          let pkg_src_dir = src_dir.join(sanitized_pkg)?
+          pkg_src_dir.mkdir()
+          _write_source_page(
+            src_dir, sanitized_pkg, sf, program.name)?
+        end
+      end
+    end
+
+    _write_home_page(base_dir, program.name, consume home_links)?
+    _write_assets(assets_dir)?
+
+  fun _html_page(
+    title: String,
+    site_name: String,
+    breadcrumb: String,
+    content: String val,
+    root_prefix: String = "")
+    : String val
+  =>
+    let result = recover iso String(content.size() + 1024) end
+    result.append("<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n")
+    result.append("<meta charset=\"utf-8\">\n")
+    result.append(
+      "<meta name=\"viewport\" " +
+        "content=\"width=device-width, initial-scale=1\">\n")
+    result.append("<title>")
+    result.append(HtmlEscape.content(title))
+    result.append(" - ")
+    result.append(HtmlEscape.content(site_name))
+    result.append("</title>\n")
+    result.append("<link rel=\"stylesheet\" href=\"")
+    result.append(root_prefix)
+    result.append("assets/style.css\">\n")
+    result.append("</head>\n<body>\n")
+
+    result.append("<div class=\"header\">\n")
+    result.append("<a href=\"")
+    result.append(root_prefix)
+    result.append("index.html\">")
+    result.append(HtmlEscape.content(site_name))
+    result.append("</a>\n</div>\n")
+
+    if breadcrumb.size() > 0 then
+      result.append("<div class=\"breadcrumb\">")
+      result.append(breadcrumb)
+      result.append("</div>\n")
+    end
+
+    result.append("<main>\n")
+    result.append(content)
+    result.append("\n</main>\n</body>\n</html>\n")
+    consume result
+
+  fun _write_home_page(
+    base_dir: FilePath,
+    site_name: String,
+    links: String val)
+    ?
+  =>
+    let content = recover iso String(512) end
+    content.append("<h1>Packages</h1>\n")
+    content.append("<ul class=\"type-list\">\n")
+    content.append(links)
+    content.append("</ul>\n")
+
+    let page = _html_page(
+      "Packages", site_name, "", consume content)
+    _write_file(base_dir, "index.html", page)?
+
+  fun _write_package_page(
+    base_dir: FilePath,
+    pkg: DocPackage box,
+    pkg_tqfn: String,
+    site_name: String,
+    public_type_links: String val,
+    private_type_links: String val,
+    include_private: Bool)
+    ?
+  =>
+    let content = recover iso String(1024) end
+
+    content.append("<h1>")
+    content.append(HtmlEscape.content(pkg.qualified_name))
+    content.append("</h1>\n")
+
+    match pkg.doc_string
+    | let ds: String =>
+      content.append("<p>")
+      content.append(HtmlEscape.content(ds))
+      content.append("</p>\n")
+    else
+      content.append("<p>No package doc string provided for ")
+      content.append(HtmlEscape.content(pkg.qualified_name))
+      content.append(".</p>\n")
+    end
+
+    if public_type_links.size() > 0 then
+      content.append("<h2>Public Types</h2>\n")
+      content.append("<ul class=\"type-list\">\n")
+      content.append(public_type_links)
+      content.append("</ul>\n")
+    end
+
+    if include_private and (private_type_links.size() > 0) then
+      content.append("<h2>Private Types</h2>\n")
+      content.append("<ul class=\"type-list\">\n")
+      content.append(private_type_links)
+      content.append("</ul>\n")
+    end
+
+    let breadcrumb = "<a href=\"index.html\">Packages</a>"
+    let page = _html_page(
+      pkg.qualified_name, site_name, breadcrumb, consume content)
+    _write_file(base_dir, pkg_tqfn + ".html", page)?
+
+  fun _write_entity_page(
+    base_dir: FilePath,
+    entity: DocEntity box,
+    sanitized_pkg: String,
+    site_name: String,
+    pkg_qualified_name: String,
+    include_private: Bool)
+    ?
+  =>
+    let content = recover iso String(4096) end
+    let pkg_tqfn = TQFN(pkg_qualified_name, "-index")
+
+    content.append("<h1>")
+    content.append(HtmlEscape.content(entity.name))
+    content.append(HtmlEscape.content(
+      TypeRenderer.render_type_params(
+        entity.type_params, None, false, include_private)))
+    content.append(
+      _source_link(entity.source, sanitized_pkg))
+    content.append("</h1>\n")
+
+    match entity.doc_string
+    | let ds: String =>
+      content.append("<p>")
+      content.append(HtmlEscape.content(ds))
+      content.append("</p>\n")
+    end
+
+    content.append("<pre><code>")
+    content.append(HtmlEscape.content(
+      entity.kind.keyword() + " "))
+    match entity.cap
+    | let c: String =>
+      content.append(HtmlEscape.content(c + " "))
+    end
+    content.append(HtmlEscape.content(entity.name))
+    content.append(HtmlEscape.content(
+      TypeRenderer.render_type_params(
+        entity.type_params, None, true, include_private)))
+    content.append(HtmlEscape.content(
+      TypeRenderer.render_provides(
+        entity.provides, " is\n  ", ",\n  ", "", None, include_private)))
+    content.append("</code></pre>\n")
+
+    match entity.kind
+    | EntityTypeAlias =>
+      content.append(
+        _render_provides_section(
+          entity.provides, "Type Alias For", include_private))
+    else
+      content.append(
+        _render_provides_section(
+          entity.provides, "Implements", include_private))
+    end
+
+    content.append(
+      _render_toc(entity, include_private))
+
+    content.append(
+      _render_methods(
+        entity.constructors, "Constructors",
+        sanitized_pkg, include_private))
+    content.append(
+      _render_fields(
+        entity.public_fields, "Public Fields",
+        sanitized_pkg, include_private))
+    content.append(
+      _render_methods(
+        entity.public_behaviours, "Public Behaviours",
+        sanitized_pkg, include_private))
+    content.append(
+      _render_methods(
+        entity.public_functions, "Public Functions",
+        sanitized_pkg, include_private))
+    content.append(
+      _render_methods(
+        entity.private_behaviours, "Private Behaviours",
+        sanitized_pkg, include_private))
+    content.append(
+      _render_methods(
+        entity.private_functions, "Private Functions",
+        sanitized_pkg, include_private))
+
+    let breadcrumb: String val =
+      "<a href=\"index.html\">Packages</a> &raquo; " +
+        "<a href=\"" + HtmlEscape.attribute(pkg_tqfn) + ".html\">" +
+        HtmlEscape.content(pkg_qualified_name) + "</a>"
+    let page = _html_page(
+      entity.name, site_name, breadcrumb, consume content)
+    _write_file(base_dir, entity.tqfn + ".html", page)?
+
+  fun _render_toc(
+    entity: DocEntity box,
+    include_private: Bool)
+    : String val
+  =>
+    if (entity.constructors.size() == 0) and
+      (entity.public_fields.size() == 0) and
+      (entity.public_behaviours.size() == 0) and
+      (entity.public_functions.size() == 0) and
+      (entity.private_behaviours.size() == 0) and
+      (entity.private_functions.size() == 0)
+    then
+      return ""
+    end
+
+    let result = recover iso String(2048) end
+    result.append("<nav class=\"toc\">\n")
+    result.append("<h2>Members</h2>\n")
+
+    result.append(
+      _render_toc_methods(
+        entity.constructors, "Constructors", include_private))
+    result.append(
+      _render_toc_fields(entity.public_fields, "Public Fields"))
+    result.append(
+      _render_toc_methods(
+        entity.public_behaviours, "Public Behaviours", include_private))
+    result.append(
+      _render_toc_methods(
+        entity.public_functions, "Public Functions", include_private))
+    result.append(
+      _render_toc_methods(
+        entity.private_behaviours, "Private Behaviours", include_private))
+    result.append(
+      _render_toc_methods(
+        entity.private_functions, "Private Functions", include_private))
+
+    result.append("</nav>\n")
+    consume result
+
+  fun _render_toc_methods(
+    methods: Array[DocMethod] val,
+    title: String,
+    include_private: Bool)
+    : String val
+  =>
+    if methods.size() == 0 then return "" end
+
+    let result = recover iso String(512) end
+    result.append("<h3>")
+    result.append(title)
+    result.append("</h3>\n<ul>\n")
+
+    for method in methods.values() do
+      result.append("<li><a href=\"#")
+      result.append(HtmlEscape.attribute(method.name))
+      result.append("\"><code>")
+      result.append(HtmlEscape.content(method.kind.string()))
+      result.append(" ")
+      result.append(HtmlEscape.content(method.name))
+      result.append(HtmlEscape.content(
+        TypeRenderer.render_type_params(
+          method.type_params, None, false, include_private)))
+      result.append(
+        _toc_method_params(method, include_private))
+      match method.kind
+      | MethodConstructor | MethodFunction =>
+        match method.return_type
+        | let rt: DocType =>
+          result.append(": ")
+          result.append(HtmlEscape.content(
+            TypeRenderer.render(rt, None, false, include_private)))
+        end
+        if method.is_partial then
+          result.append(" ?")
+        end
+      end
+      result.append("</code></a></li>\n")
+    end
+
+    result.append("</ul>\n")
+    consume result
+
+  fun _toc_method_params(
+    method: DocMethod box,
+    include_private: Bool)
+    : String val
+  =>
+    let result = recover iso String(256) end
+    result.append("(")
+    for (i, param) in method.params.pairs() do
+      if i > 0 then result.append(", ") end
+      result.append(HtmlEscape.content(param.name))
+      result.append(": ")
+      result.append(HtmlEscape.content(
+        TypeRenderer.render(
+          param.param_type, None, false, include_private)))
+    end
+    result.append(")")
+    consume result
+
+  fun _render_toc_fields(
+    fields: Array[DocField] val,
+    title: String)
+    : String val
+  =>
+    if fields.size() == 0 then return "" end
+
+    let result = recover iso String(256) end
+    result.append("<h3>")
+    result.append(title)
+    result.append("</h3>\n<ul>\n")
+
+    for field in fields.values() do
+      result.append("<li><a href=\"#")
+      result.append(HtmlEscape.attribute(field.name))
+      result.append("\"><code>")
+      result.append(HtmlEscape.content(
+        field.kind.string() + " " + field.name))
+      result.append("</code></a></li>\n")
+    end
+
+    result.append("</ul>\n")
+    consume result
+
+  fun _render_provides_section(
+    provides: Array[DocType] val,
+    title: String,
+    include_private: Bool)
+    : String val
+  =>
+    if provides.size() == 0 then return "" end
+
+    let result = recover iso String(256) end
+    result.append("<h4>")
+    result.append(title)
+    result.append("</h4>\n<ul>\n")
+
+    for p in provides.values() do
+      result.append("<li>")
+      result.append(
+        TypeRenderer.render(p, HtmlLinkFormat, true, include_private))
+      result.append("</li>\n")
+    end
+
+    result.append("</ul>\n<hr>\n")
+    consume result
+
+  fun _render_methods(
+    methods: Array[DocMethod] val,
+    title: String,
+    sanitized_pkg: String,
+    include_private: Bool)
+    : String val
+  =>
+    if methods.size() == 0 then return "" end
+
+    let result = recover iso String(2048) end
+    result.append("<h2>")
+    result.append(title)
+    result.append("</h2>\n")
+
+    for method in methods.values() do
+      result.append(
+        _render_method(method, sanitized_pkg, include_private))
+    end
+
+    consume result
+
+  fun _render_method(
+    method: DocMethod box,
+    sanitized_pkg: String,
+    include_private: Bool)
+    : String val
+  =>
+    let result = recover iso String(1024) end
+
+    result.append("<h3 id=\"")
+    result.append(HtmlEscape.attribute(method.name))
+    result.append("\">")
+    result.append(HtmlEscape.content(method.name))
+    result.append(HtmlEscape.content(
+      TypeRenderer.render_type_params(
+        method.type_params, None, false, include_private)))
+    result.append(_source_link(method.source, sanitized_pkg))
+    result.append("</h3>\n")
+
+    match method.doc_string
+    | let ds: String =>
+      result.append("<p>")
+      result.append(HtmlEscape.content(ds))
+      result.append("</p>\n")
+    end
+
+    result.append("<pre><code>")
+    result.append(HtmlEscape.content(method.kind.string()))
+    result.append(" ")
+
+    match method.kind
+    | MethodConstructor | MethodFunction =>
+      match method.cap
+      | let c: String =>
+        result.append(HtmlEscape.content(c))
+        result.append(" ")
+      end
+    end
+
+    result.append(HtmlEscape.content(method.name))
+    result.append(HtmlEscape.content(
+      TypeRenderer.render_type_params(
+        method.type_params, None, true, include_private)))
+
+    result.append("(")
+    for (i, param) in method.params.pairs() do
+      if i > 0 then
+        result.append(",\n")
+      else
+        result.append("\n")
+      end
+      result.append("  ")
+      result.append(HtmlEscape.content(param.name))
+      result.append(": ")
+      result.append(HtmlEscape.content(
+        TypeRenderer.render(
+          param.param_type, None, true, include_private)))
+      match param.default_value
+      | let dv: String =>
+        result.append(" = ")
+        result.append(HtmlEscape.content(dv))
+      end
+    end
+    result.append(")")
+
+    match method.kind
+    | MethodConstructor | MethodFunction =>
+      result.append("\n: ")
+      match method.return_type
+      | let rt: DocType =>
+        result.append(HtmlEscape.content(
+          TypeRenderer.render(rt, None, true, include_private)))
+      end
+      if method.is_partial then
+        result.append(" ?")
+      end
+    end
+
+    result.append("</code></pre>\n")
+
+    if method.params.size() > 0 then
+      result.append("<h4>Parameters</h4>\n<ul class=\"params\">\n")
+      for param in method.params.values() do
+        result.append("<li>")
+        result.append(HtmlEscape.content(param.name))
+        result.append(": ")
+        result.append(
+          TypeRenderer.render(
+            param.param_type, HtmlLinkFormat, true, include_private))
+        match param.default_value
+        | let dv: String =>
+          result.append(" = ")
+          result.append(HtmlEscape.content(dv))
+        end
+        result.append("</li>\n")
+      end
+      result.append("</ul>\n")
+    end
+
+    match method.kind
+    | MethodConstructor | MethodFunction =>
+      result.append("<h4>Returns</h4>\n<ul class=\"returns\">\n<li>")
+      match method.return_type
+      | let rt: DocType =>
+        result.append(
+          TypeRenderer.render(
+            rt, HtmlLinkFormat, true, include_private))
+      end
+      if method.is_partial then
+        result.append(" ?")
+      end
+      result.append("</li>\n</ul>\n")
+    end
+
+    result.append("<hr>\n")
+    consume result
+
+  fun _render_fields(
+    fields: Array[DocField] val,
+    title: String,
+    sanitized_pkg: String,
+    include_private: Bool)
+    : String val
+  =>
+    if fields.size() == 0 then return "" end
+
+    let result = recover iso String(1024) end
+    result.append("<h2>")
+    result.append(title)
+    result.append("</h2>\n")
+
+    for field in fields.values() do
+      result.append("<h3 id=\"")
+      result.append(HtmlEscape.attribute(field.name))
+      result.append("\">")
+      result.append(HtmlEscape.content(
+        field.kind.string() + " " + field.name))
+      result.append(": ")
+      result.append(
+        TypeRenderer.render(
+          field.field_type, HtmlLinkFormat, false, include_private))
+      result.append(_source_link(field.source, sanitized_pkg))
+      result.append("</h3>\n")
+
+      match field.doc_string
+      | let ds: String =>
+        result.append("<p>")
+        result.append(HtmlEscape.content(ds))
+        result.append("</p>\n")
+      end
+
+      result.append("<hr>\n")
+    end
+
+    consume result
+
+  fun _write_source_page(
+    src_dir: FilePath,
+    sanitized_pkg: String,
+    sf: DocSourceFile box,
+    site_name: String)
+    ?
+  =>
+    let content = recover iso String(sf.content.size() + 2048) end
+    let filename = sf.filename
+
+    content.append("<h1>")
+    content.append(HtmlEscape.content(filename))
+    content.append("</h1>\n")
+    content.append("<table class=\"source-table\">\n")
+
+    var line_num: USize = 1
+    var line_start: USize = 0
+    var i: USize = 0
+    let src = sf.content
+    while i < src.size() do
+      try
+        if src(i)? == '\n' then
+          let line: String val = src.substring(
+            line_start.isize(), i.isize())
+          content.append(_source_line_html(line_num, line))
+          line_num = line_num + 1
+          line_start = i + 1
+        end
+      end
+      i = i + 1
+    end
+    // Last line (if no trailing newline)
+    if line_start < src.size() then
+      let line: String val = src.substring(
+        line_start.isize(), src.size().isize())
+      content.append(_source_line_html(line_num, line))
+    end
+
+    content.append("</table>\n")
+
+    let root = "../../"
+    let breadcrumb: String val =
+      "<a href=\"" + root + "index.html\">Packages</a>"
+    let page = _html_page(
+      filename, site_name, breadcrumb, consume content
+      where root_prefix = root)
+
+    let pkg_dir = src_dir.join(sanitized_pkg)?
+    let filename_no_ext = _remove_ext(filename)
+    _write_file(pkg_dir, filename_no_ext + ".html", page)?
+
+  fun _source_line_html(
+    line_num: USize,
+    line: String)
+    : String val
+  =>
+    let result = recover iso String(line.size() + 128) end
+    result.append("<tr>")
+    result.append("<td class=\"line-num\" id=\"L")
+    result.append(line_num.string())
+    result.append("\"><a href=\"#L")
+    result.append(line_num.string())
+    result.append("\">")
+    result.append(line_num.string())
+    result.append("</a></td>")
+    result.append("<td class=\"source-code\">")
+    result.append(HtmlEscape.content(line))
+    result.append("</td></tr>\n")
+    consume result
+
+  fun _write_assets(assets_dir: FilePath) ? =>
+    _write_file(assets_dir, "style.css", _HtmlAssets.css())?
+    _write_binary(assets_dir, "logo.png", _Assets.logo())?
+
+  fun _source_link(
+    source: (DocSourceLocation | None),
+    sanitized_pkg: String)
+    : String val
+  =>
+    match source
+    | let loc: DocSourceLocation =>
+      if loc.file_path.size() > 0 then
+        let filename = Path.base(loc.file_path)
+        let filename_no_ext = _remove_ext(filename)
+        let result = recover iso String(128) end
+        result.append(
+          " <span class=\"source-link\">[<a href=\"src/")
+        result.append(HtmlEscape.attribute(sanitized_pkg))
+        result.append("/")
+        result.append(HtmlEscape.attribute(filename_no_ext))
+        result.append(".html#L")
+        result.append(loc.line.string())
+        result.append("\">Source</a>]</span>")
+        consume result
+      else
+        ""
+      end
+    else
+      ""
+    end
+
+  fun _remove_ext(filename: String): String =>
+    var last_dot: USize = filename.size()
+    var i: USize = 0
+    while i < filename.size() do
+      try if filename(i)? == '.' then last_dot = i end end
+      i = i + 1
+    end
+    if last_dot < filename.size() then
+      filename.substring(0, last_dot.isize())
+    else
+      filename
+    end
+
+  fun _write_file(
+    dir: FilePath,
+    name: String,
+    content: String val)
+    ?
+  =>
+    let path = dir.join(name)?
+    match CreateFile(path)
+    | let file: File =>
+      file.write(content)
+      file.dispose()
+    else
+      error
+    end
+
+  fun _write_binary(
+    dir: FilePath,
+    name: String,
+    data: Array[U8] val)
+    ?
+  =>
+    let path = dir.join(name)?
+    match CreateFile(path)
+    | let file: File =>
+      file.write(data)
+      file.dispose()
+    else
+      error
+    end

--- a/tools/pony-doc/html_escape.pony
+++ b/tools/pony-doc/html_escape.pony
@@ -1,0 +1,37 @@
+primitive HtmlEscape
+  """
+  Escapes strings for safe insertion into HTML.
+  """
+
+  fun content(s: String box): String =>
+    """
+    Escapes `&`, `<`, and `>` for use in HTML text content.
+    """
+    let result = recover iso String(s.size()) end
+    for byte in s.values() do
+      match byte
+      | '&' => result.append("&amp;")
+      | '<' => result.append("&lt;")
+      | '>' => result.append("&gt;")
+      else
+        result.push(byte)
+      end
+    end
+    consume result
+
+  fun attribute(s: String box): String =>
+    """
+    Escapes `&`, `<`, `>`, and `"` for use in HTML attribute values.
+    """
+    let result = recover iso String(s.size()) end
+    for byte in s.values() do
+      match byte
+      | '&' => result.append("&amp;")
+      | '<' => result.append("&lt;")
+      | '>' => result.append("&gt;")
+      | '"' => result.append("&quot;")
+      else
+        result.push(byte)
+      end
+    end
+    consume result

--- a/tools/pony-doc/html_link_format.pony
+++ b/tools/pony-doc/html_link_format.pony
@@ -1,0 +1,16 @@
+primitive HtmlLinkFormat is LinkFormat
+  """
+  HTML link format for self-contained HTML documentation output.
+
+  Produces `<a href="tqfn.html">Name</a>` cross-references with both
+  the name and tqfn HTML-escaped. Brackets are plain `[`/`]` since they
+  have no syntactic meaning in HTML.
+  """
+
+  fun link(name: String, tqfn: String): String =>
+    "<a href=\"" + HtmlEscape.attribute(tqfn) + ".html\">" +
+      HtmlEscape.content(name) + "</a>"
+
+  fun open_bracket(): String => "["
+
+  fun close_bracket(): String => "]"

--- a/tools/pony-doc/main.pony
+++ b/tools/pony-doc/main.pony
@@ -13,19 +13,24 @@ use @ponyint_pool_free_size[None](
 actor Main
   """
   CLI entry point for pony-doc. Parses command-line arguments, compiles the
-  target package, extracts the documentation IR, and generates MkDocs output.
+  target package, extracts the documentation IR, and generates documentation
+  output in the selected format (MkDocs or self-contained HTML).
   """
   new create(env: Env) =>
     let cs =
       try
         CommandSpec.leaf(
           "pony-doc",
-          "Generate MkDocs documentation for Pony packages",
+          "Generate documentation for Pony packages",
           [
             OptionSpec.string(
               "output",
               "Output directory"
               where short' = 'o', default' = ".")
+            OptionSpec.string(
+              "format",
+              "Output format: mkdocs or html"
+              where short' = 'f', default' = "mkdocs")
             OptionSpec.bool(
               "include-private",
               "Include private types and methods"
@@ -71,6 +76,15 @@ actor Main
     // Get output directory
     let output_dir_path = cmd.option("output").string()
 
+    let format = cmd.option("format").string()
+    if (format != "mkdocs") and (format != "html") then
+      env.err.print(
+        "error: unknown format '" + format +
+          "' (expected 'mkdocs' or 'html')")
+      env.exitcode(1)
+      return
+    end
+
     // Get include_private flag
     let include_private = cmd.option("include-private").bool()
 
@@ -92,7 +106,13 @@ actor Main
       // Generate output
       let output_fp = FilePath(file_auth, output_dir_path)
       try
-        MkDocsBackend.generate(doc_program, output_fp, include_private)?
+        if format == "html" then
+          HtmlBackend.generate(
+            doc_program, output_fp, include_private)?
+        else
+          MkDocsBackend.generate(
+            doc_program, output_fp, include_private)?
+        end
         env.out.print(
           "Documentation generated in " +
             output_dir_path + "/" + doc_program.name + "-docs/")

--- a/tools/pony-doc/pony_doc.pony
+++ b/tools/pony-doc/pony_doc.pony
@@ -1,13 +1,13 @@
 """
 pony-doc: The documentation generator for Pony source files.
 
-Generates MkDocs-compatible documentation from a compiled Pony program.
-The tool is distributed alongside ponyc and shares its version number.
+Generates documentation from a compiled Pony program. Two output formats are
+available: MkDocs-compatible markdown (default) and self-contained HTML.
 
 **Pipeline:**
 
-1. **Argument parsing** — parse CLI options for output directory, privacy
-   settings, and target package path.
+1. **Argument parsing** — parse CLI options for output directory, format,
+   privacy settings, and target package path.
 2. **Package path setup** — locate the ponyc standard library relative to the
    executable location, then append PONYPATH entries.
 3. **Compilation** — compile the target package through the traits pass via
@@ -15,10 +15,9 @@ The tool is distributed alongside ponyc and shares its version number.
 4. **Extraction** — walk the compiled program AST and build a documentation IR
    (`DocProgram`) containing packages, entities, methods, fields, type
    parameters, and source locations.
-5. **Generation** — pass the IR to the MkDocs backend, which writes mkdocs.yml,
-   package index pages, entity type pages, source code pages, and theme assets.
+5. **Generation** — pass the IR to the selected backend.
 
-**Output structure:**
+**MkDocs output** (`--format mkdocs`, default):
 
 ```
 <program>-docs/
@@ -33,6 +32,20 @@ The tool is distributed alongside ponyc and shares its version number.
       logo.png
 ```
 
-The output is ready for `mkdocs build` or `mkdocs serve` with the Material
-theme installed.
+Ready for `mkdocs build` or `mkdocs serve` with the Material theme installed.
+
+**HTML output** (`--format html`):
+
+```
+<program>-docs/
+  index.html                  (package listing)
+  <tqfn>.html                 (one per type, with member TOC)
+  <tqfn>--index.html          (one per package)
+  src/<package>/<file>.html   (source code with line numbers)
+  assets/
+    style.css
+    logo.png
+```
+
+Open `index.html` directly in a browser — no build step needed.
 """

--- a/tools/pony-doc/test/_test_html_escape.pony
+++ b/tools/pony-doc/test/_test_html_escape.pony
@@ -1,0 +1,96 @@
+use "pony_test"
+use doc = ".."
+
+class \nodoc\ _TestHtmlEscapeContent is UnitTest
+  fun name(): String => "HtmlEscape/content"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String](
+      doc.HtmlEscape.content("hello"),
+      "hello")
+    h.assert_eq[String](
+      doc.HtmlEscape.content("<div>"),
+      "&lt;div&gt;")
+    h.assert_eq[String](
+      doc.HtmlEscape.content("a & b"),
+      "a &amp; b")
+    h.assert_eq[String](
+      doc.HtmlEscape.content(""),
+      "")
+
+class \nodoc\ _TestHtmlEscapeContentNoDoubleEscape is UnitTest
+  fun name(): String => "HtmlEscape/content-no-double-escape"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String](
+      doc.HtmlEscape.content("&amp;"),
+      "&amp;amp;")
+
+class \nodoc\ _TestHtmlEscapeAttribute is UnitTest
+  fun name(): String => "HtmlEscape/attribute"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String](
+      doc.HtmlEscape.attribute("hello"),
+      "hello")
+    h.assert_eq[String](
+      doc.HtmlEscape.attribute("a\"b"),
+      "a&quot;b")
+    h.assert_eq[String](
+      doc.HtmlEscape.attribute("<a&b>"),
+      "&lt;a&amp;b&gt;")
+    h.assert_eq[String](
+      doc.HtmlEscape.attribute("it's"),
+      "it's")
+
+class \nodoc\ _TestHtmlLinkFormatMethods is UnitTest
+  fun name(): String => "HtmlLinkFormat/methods"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String](
+      doc.HtmlLinkFormat.link("Array", "builtin-Array"),
+      "<a href=\"builtin-Array.html\">Array</a>")
+    h.assert_eq[String](
+      doc.HtmlLinkFormat.open_bracket(),
+      "[")
+    h.assert_eq[String](
+      doc.HtmlLinkFormat.close_bracket(),
+      "]")
+
+class \nodoc\ _TestHtmlLinkFormatEscaping is UnitTest
+  fun name(): String => "HtmlLinkFormat/escaping"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String](
+      doc.HtmlLinkFormat.link("A<B>", "pkg-A\"B"),
+      "<a href=\"pkg-A&quot;B.html\">A&lt;B&gt;</a>")
+
+class \nodoc\ _TestHtmlLinkFormatTypeRenderer is UnitTest
+  fun name(): String => "HtmlLinkFormat/type-renderer"
+
+  fun apply(h: TestHelper) =>
+    let string_t =
+      doc.DocNominal(
+        "String",
+        "builtin-String",
+        recover val Array[doc.DocType] end,
+        None,
+        None,
+        false,
+        false)
+    let type_args: Array[doc.DocType] val =
+      recover val [as doc.DocType: string_t] end
+    let t =
+      doc.DocNominal(
+        "Array",
+        "builtin-Array",
+        type_args,
+        None,
+        None,
+        false,
+        false)
+
+    h.assert_eq[String](
+      doc.TypeRenderer.render(t, doc.HtmlLinkFormat, false, false),
+      "<a href=\"builtin-Array.html\">Array</a>" +
+        "[<a href=\"builtin-String.html\">String</a>]")

--- a/tools/pony-doc/test/main.pony
+++ b/tools/pony-doc/test/main.pony
@@ -58,3 +58,13 @@ actor \nodoc\ Main is TestList
     test(_TestRenderProvides)
     test(_TestMkDocsLinkFormatMethods)
     test(_TestRenderCustomLinkFormat)
+
+    // HtmlEscape tests
+    test(_TestHtmlEscapeContent)
+    test(_TestHtmlEscapeContentNoDoubleEscape)
+    test(_TestHtmlEscapeAttribute)
+
+    // HtmlLinkFormat tests
+    test(_TestHtmlLinkFormatMethods)
+    test(_TestHtmlLinkFormatEscaping)
+    test(_TestHtmlLinkFormatTypeRenderer)


### PR DESCRIPTION
Adds an HTML backend to pony-doc so documentation can be browsed locally without MkDocs or any external tools. Each entity page includes a table of contents listing members with their full signatures — the feature requested in #2086.

Usage: `pony-doc -f html <package-dir>` (default remains `mkdocs`).

The output is a flat directory of static HTML files with embedded CSS, dark mode support, and source-file pages with line-number anchors. No JavaScript, no external dependencies.

New files:
- `html_backend.pony` — `HtmlBackend` implementing the `Backend` trait
- `html_escape.pony` — `HtmlEscape` primitive (content and attribute context)
- `html_link_format.pony` — `HtmlLinkFormat` implementing `LinkFormat` for HTML cross-references
- `_html_assets.pony` — embedded CSS
- `test/_test_html_escape.pony` — 7 unit tests for escaping and link rendering

Modified:
- `main.pony` — `--format` / `-f` option and backend dispatch
- `pony_doc.pony` — package docstring updated

Closes #2086
