### PR TITLE
Fix I128 and U128 divrem_unsafe on native128 platforms

### DIFF
--- a/.release-notes/fix-128-divrem-unsafe.md
+++ b/.release-notes/fix-128-divrem-unsafe.md
@@ -1,0 +1,5 @@
+## Fix I128 and U128 divrem_unsafe on native128 platforms
+
+`I128.divrem_unsafe` and `U128.divrem_unsafe` returned the product and quotient instead of the quotient and remainder on platforms with native 128-bit integer support (64-bit Linux, macOS, and BSD). For example, `U128(10).divrem_unsafe(U128(3))` returned `(30, 3)` instead of `(3, 1)`.
+
+The non-native128 fallback (Windows MSVC and 32-bit platforms) was not affected.

--- a/packages/builtin/signed.pony
+++ b/packages/builtin/signed.pony
@@ -812,7 +812,7 @@ primitive I128 is SignedInteger[I128, U128]
     If the operation overflows, the result is undefined.
     """
     ifdef native128 then
-      (this *~ y, this /~ y)
+      (this /~ y, this %~ y)
     else
       divrem(y)
     end

--- a/packages/builtin/unsigned.pony
+++ b/packages/builtin/unsigned.pony
@@ -769,7 +769,7 @@ primitive U128 is UnsignedInteger[U128]
     If the operation overflows, the result is undefined.
     """
     ifdef native128 then
-      (this *~ y, this /~ y)
+      (this /~ y, this %~ y)
     else
       divrem(y)
     end

--- a/packages/builtin_test/_test.pony
+++ b/packages/builtin_test/_test.pony
@@ -46,6 +46,7 @@ actor \nodoc\ Main is TestList
     test(_TestArrayPairsRewind)
     test(_TestDiv)
     test(_TestDivc)
+    test(_TestDivrem)
     test(_TestFld)
     test(_TestFldc)
     test(_TestFloatToString)
@@ -2267,6 +2268,64 @@ class \nodoc\ iso _TestMath128 is UnitTest
 
     h.assert_eq[I128](-5, I128(-13) %% -8)
     h.assert_eq[I128](-28, I128(-40_000_000_028) %% -10_000_000_000)
+
+class \nodoc\ iso _TestDivrem is UnitTest
+  fun name(): String => "builtin/Divrem"
+
+  fun test_divrem_signed[T: (Integer[T] val & Signed)](
+    h: TestHelper,
+    type_name: String)
+  =>
+    (let q1, let r1) = T(11).divrem(T(3))
+    h.assert_eq[T](3, q1, "[" + type_name + "] 11 divrem 3 quotient")
+    h.assert_eq[T](2, r1, "[" + type_name + "] 11 divrem 3 remainder")
+
+    (let q2, let r2) = T(-10).divrem(T(3))
+    h.assert_eq[T](-3, q2, "[" + type_name + "] -10 divrem 3 quotient")
+    h.assert_eq[T](-1, r2, "[" + type_name + "] -10 divrem 3 remainder")
+
+    // divrem_unsafe
+    (let q3, let r3) = T(11).divrem_unsafe(T(3))
+    h.assert_eq[T](3, q3, "[" + type_name + "] 11 divrem_unsafe 3 quotient")
+    h.assert_eq[T](2, r3, "[" + type_name + "] 11 divrem_unsafe 3 remainder")
+
+    (let q4, let r4) = T(-10).divrem_unsafe(T(3))
+    h.assert_eq[T](-3, q4,
+      "[" + type_name + "] -10 divrem_unsafe 3 quotient")
+    h.assert_eq[T](-1, r4,
+      "[" + type_name + "] -10 divrem_unsafe 3 remainder")
+
+  fun test_divrem_unsigned[T: (Integer[T] val & Unsigned)](
+    h: TestHelper,
+    type_name: String)
+  =>
+    (let q1, let r1) = T(11).divrem(T(3))
+    h.assert_eq[T](3, q1, "[" + type_name + "] 11 divrem 3 quotient")
+    h.assert_eq[T](2, r1, "[" + type_name + "] 11 divrem 3 remainder")
+
+    // divrem_unsafe
+    (let q2, let r2) = T(11).divrem_unsafe(T(3))
+    h.assert_eq[T](3, q2,
+      "[" + type_name + "] 11 divrem_unsafe 3 quotient")
+    h.assert_eq[T](2, r2,
+      "[" + type_name + "] 11 divrem_unsafe 3 remainder")
+
+  fun apply(h: TestHelper) =>
+    test_divrem_signed[I8](h, "I8")
+    test_divrem_signed[I16](h, "I16")
+    test_divrem_signed[I32](h, "I32")
+    test_divrem_signed[I64](h, "I64")
+    test_divrem_signed[ILong](h, "ILong")
+    test_divrem_signed[ISize](h, "ISize")
+    test_divrem_signed[I128](h, "I128")
+
+    test_divrem_unsigned[U8](h, "U8")
+    test_divrem_unsigned[U16](h, "U16")
+    test_divrem_unsigned[U32](h, "U32")
+    test_divrem_unsigned[U64](h, "U64")
+    test_divrem_unsigned[ULong](h, "ULong")
+    test_divrem_unsigned[USize](h, "USize")
+    test_divrem_unsigned[U128](h, "U128")
 
 class \nodoc\ iso _TestDiv is UnitTest
   fun name(): String => "builtin/Div"


### PR DESCRIPTION
`I128.divrem_unsafe` and `U128.divrem_unsafe` used multiply and divide operators (`*~`, `/~`) instead of divide and remainder (`/~`, `%~`) in their `native128` code path. This returned wrong values on all 64-bit non-MSVC platforms.

Also adds regression tests for `divrem` and `divrem_unsafe` across all integer types.

Closes #5919
