### PR TITLE
Fix incorrect `#read->trn` viewpoint adaptation bounds

### DIFF
--- a/.release-notes/fix-read-trn-viewpoint-bounds.md
+++ b/.release-notes/fix-read-trn-viewpoint-bounds.md
@@ -1,0 +1,3 @@
+## Fix incorrect `#read->trn` viewpoint adaptation bounds
+
+The compiler computed wrong upper and lower bounds when adapting `trn` through the `#read` generic capability. The upper bound was `box` instead of `trn`, and the lower bound was `trn` instead of `box`. This affected type checking of `this->trn` fields in classes and actors whose receiver capability is generic, and any other code path where the compiler needs the bounds of `#read->trn`.

--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -933,12 +933,40 @@ bool cap_view_upper(token_id left_cap, token_id left_eph,
     }
 
     case TK_BOX:
+    {
+      switch(*right_cap)
+      {
+        case TK_ISO:
+          *right_cap = TK_TAG;
+          break;
+
+        case TK_VAL:
+        case TK_CAP_SHARE:
+          break;
+
+        case TK_CAP_SEND:
+        case TK_CAP_ALIAS:
+        case TK_CAP_ANY:
+          *right_cap = TK_TAG;
+          break;
+
+        default:
+          *right_cap = TK_BOX;
+      }
+
+      *right_eph = TK_NONE;
+      break;
+    }
+
     case TK_CAP_READ:
     {
       switch(*right_cap)
       {
         case TK_ISO:
           *right_cap = TK_TAG;
+          break;
+
+        case TK_TRN:
           break;
 
         case TK_VAL:
@@ -1146,6 +1174,10 @@ bool cap_view_lower(token_id left_cap, token_id left_eph,
       {
         case TK_ISO:
           *right_cap = TK_CAP_SEND;
+          break;
+
+        case TK_TRN:
+          *right_cap = TK_BOX;
           break;
 
         case TK_REF:

--- a/test/libponyc/cap.cc
+++ b/test/libponyc/cap.cc
@@ -904,3 +904,25 @@ TEST_F(CapTest, ViewpointLowerFull)
   EXPECT_VP_UNDEF(lower_viewpoint_full, tag, none, box, none);
   EXPECT_VP_UNDEF(lower_viewpoint_full, tag, none, tag, none);
 }
+
+TEST_F(CapTest, ViewpointUpperRead)
+{
+  // #read = {ref, val, box}
+  ASSERT_EQ(upper_viewpoint(read, iso), tag);   // {iso, val, tag}
+  ASSERT_EQ(upper_viewpoint(read, trn), trn);   // {trn, val, box}
+  ASSERT_EQ(upper_viewpoint(read, ref), box);   // {ref, val, box}
+  ASSERT_EQ(upper_viewpoint(read, val), val);   // {val, val, val}
+  ASSERT_EQ(upper_viewpoint(read, box), box);   // {box, val, box}
+  ASSERT_EQ(upper_viewpoint(read, tag), tag);   // {tag, tag, tag}
+}
+
+TEST_F(CapTest, ViewpointLowerRead)
+{
+  // #read = {ref, val, box}
+  ASSERT_EQ(lower_viewpoint(read, iso), send);  // {iso, val, tag} = #send
+  ASSERT_EQ(lower_viewpoint(read, trn), box);   // {trn, val, box}
+  ASSERT_EQ(lower_viewpoint(read, ref), read);  // {ref, val, box} = #read
+  ASSERT_EQ(lower_viewpoint(read, val), val);   // {val}
+  ASSERT_EQ(lower_viewpoint(read, box), val);   // {val, box}
+  ASSERT_EQ(lower_viewpoint(read, tag), tag);   // {tag}
+}


### PR DESCRIPTION
`cap_view_upper` and `cap_view_lower` returned wrong bounds for `#read->trn`. The `TK_CAP_READ` case in `cap_view_upper` fell through into `TK_BOX`, so trn was treated like box (returned box instead of trn). In `cap_view_lower`, the `TK_CAP_READ` switch had no `TK_TRN` arm, so trn fell to the default no-op (left as trn instead of box).

Both have existed since the original implementation — `#read` and box shared their case from the start.

Closes #5920
