### PR TITLE
Fix pony-doc default parameter value display

### DIFF
--- a/.release-notes/fix-pony-doc-default-values.md
+++ b/.release-notes/fix-pony-doc-default-values.md
@@ -1,0 +1,14 @@
+## Fix pony-doc default parameter value display
+
+Generated documentation displayed token keywords instead of actual default parameter values. A default of `ISize.max_value()` appeared as "call" and `-1` appeared as "reference" in the docs:
+
+```pony
+fun apply(to: ISize = ISize.max_value()): None
+```
+
+```
+Parameters:
+  to: ISize val = call
+```
+
+Default parameter values now display correctly in generated documentation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -796,6 +796,8 @@ else()
     add_test(NAME pony-doc-tests
         COMMAND ${PONY_OUTPUT_DIR}/pony-doc-tests${CMAKE_EXECUTABLE_SUFFIX} --sequential
         WORKING_DIRECTORY ${PONY_OUTPUT_DIR})
+    set_tests_properties(pony-doc-tests PROPERTIES
+        ENVIRONMENT "PONYPATH=${CMAKE_SOURCE_DIR}/packages")
     add_test(NAME pony-lsp-tests
         COMMAND ${PONY_OUTPUT_DIR}/pony-lsp-tests${CMAKE_EXECUTABLE_SUFFIX} --sequential
         WORKING_DIRECTORY ${PONY_OUTPUT_DIR})

--- a/tools/pony-doc/_type_extractor.pony
+++ b/tools/pony-doc/_type_extractor.pony
@@ -295,19 +295,296 @@ primitive _TypeExtractor
 
   fun get_default_value(def_val: ast.AST box): (String | None) =>
     """
-    Extracts the default value string from a parameter's default AST node.
-
-    TK_STRING defaults are wrapped in explicit double quotes, all
-    others use raw `get_print()`.
+    Extracts the default value string from a parameter's default AST
+    node.
     """
     if def_val.id() != ast.TokenIds.tk_none() then
-      try
-        let child = def_val(0)?
-        let print_val = child.get_print()
-        if child.id() == ast.TokenIds.tk_string() then
-          "\"" + print_val + "\""
-        else
-          print_val
+      try _unparse_expr(def_val(0)?) end
+    end
+
+  fun _unparse_expr(node: ast.AST box): (String | None) =>
+    """
+    Converts an expression AST node into its source-level string
+    representation.
+    """
+    let id = node.id()
+    if id == ast.TokenIds.tk_int() then
+      node.get_print()
+    elseif id == ast.TokenIds.tk_float() then
+      node.get_print()
+    elseif id == ast.TokenIds.tk_string() then
+      "\"" + node.get_print() + "\""
+    elseif id == ast.TokenIds.tk_true() then
+      "true"
+    elseif id == ast.TokenIds.tk_false() then
+      "false"
+    elseif id == ast.TokenIds.tk_this() then
+      "this"
+    elseif id == ast.TokenIds.tk_location() then
+      "__loc"
+    elseif id == ast.TokenIds.tk_reference() then
+      _unparse_reference(node)
+    elseif id == ast.TokenIds.tk_typeref() then
+      _unparse_typeref(node)
+    elseif id == ast.TokenIds.tk_dot() then
+      _unparse_dot(node)
+    elseif id == ast.TokenIds.tk_call() then
+      _unparse_call(node)
+    elseif id == ast.TokenIds.tk_qualify() then
+      _unparse_qualify(node)
+    elseif (id == ast.TokenIds.tk_minus_new()) or
+      (id == ast.TokenIds.tk_unary_minus())
+    then
+      _unparse_unary_minus(node)
+    elseif id == ast.TokenIds.tk_seq() then
+      try _unparse_expr(node(0)?) end
+    elseif (id == ast.TokenIds.tk_funref()) or
+      (id == ast.TokenIds.tk_newref()) or
+      (id == ast.TokenIds.tk_beref())
+    then
+      _unparse_member_ref(node)
+    elseif id == ast.TokenIds.tk_nominal() then
+      _unparse_nominal(node)
+    elseif id == ast.TokenIds.tk_typeparamref() then
+      try node(0)?.nice_name() end
+    elseif id == ast.TokenIds.tk_typealiasref() then
+      _unparse_type_alias_ref(node)
+    elseif id == ast.TokenIds.tk_tuple() then
+      _unparse_tuple(node)
+    else
+      node.get_print()
+    end
+
+  fun _unparse_reference(node: ast.AST box): (String | None) =>
+    try (node(0)?.token_value() as String) end
+
+  fun _unparse_typeref(node: ast.AST box): (String | None) =>
+    """
+    TK_TYPEREF children: [0] package, [1] id, [2] type_args.
+    """
+    try
+      let name = node(1)?.nice_name()
+      let targs = node(2)?
+      if targs.id() != ast.TokenIds.tk_none() then
+        let result = recover iso String end
+        result.append(name)
+        result.append("[")
+        var first = true
+        for child in targs.children() do
+          if not first then result.append(", ") end
+          first = false
+          match _unparse_expr(child)
+          | let s: String => result.append(s)
+          end
         end
+        result.append("]")
+        consume result
+      else
+        name
       end
     end
+
+  fun _unparse_dot(node: ast.AST box): (String | None) =>
+    try
+      let left = _unparse_expr(node(0)?) as String
+      let right = (node(1)?.token_value() as String)
+      left + "." + right
+    end
+
+  fun _unparse_call(node: ast.AST box): (String | None) =>
+    """
+    TK_CALL children: [0] receiver, [1] positional_args,
+    [2] named_args, [3] partial.
+
+    The sugar pass transforms `-literal` into `literal.neg()`, so
+    this reconstructs the original form for neg calls on literals.
+    """
+    try
+      let recv = node(0)?
+      let pos_args_node = node(1)?
+      if _is_desugared_neg(recv, pos_args_node) then
+        let lit = recv(0)?
+        let lit_str = _unparse_expr(lit) as String
+        return "-" + lit_str
+      end
+
+      let receiver = _unparse_expr(node(0)?) as String
+      let result = recover iso String end
+      result.append(receiver)
+      result.append("(")
+      let pos_args = node(1)?
+      if pos_args.id() != ast.TokenIds.tk_none() then
+        var first = true
+        for arg in pos_args.children() do
+          if not first then result.append(", ") end
+          first = false
+          match _unparse_expr(arg)
+          | let s: String => result.append(s)
+          end
+        end
+      end
+      let named_args = node(2)?
+      if named_args.id() != ast.TokenIds.tk_none() then
+        var first_named = true
+        for narg in named_args.children() do
+          if not first_named then
+            result.append(", ")
+          elseif pos_args.id() != ast.TokenIds.tk_none() then
+            result.append(" where ")
+          else
+            result.append("where ")
+          end
+          first_named = false
+          try
+            let arg_name =
+              (narg(0)?.token_value() as String)
+            result.append(arg_name)
+            result.append(" = ")
+            match _unparse_expr(narg(1)?)
+            | let s: String => result.append(s)
+            end
+          end
+        end
+      end
+      result.append(")")
+      if node(3)?.id() == ast.TokenIds.tk_question() then
+        result.append("?")
+      end
+      consume result
+    end
+
+  fun _is_desugared_neg(
+    recv: ast.AST box,
+    pos_args: ast.AST box)
+    : Bool
+  =>
+    """
+    Returns true when the call is `literal.neg()` with no
+    arguments — the form the sugar pass produces from `-literal`.
+    """
+    if pos_args.id() != ast.TokenIds.tk_none() then
+      return false
+    end
+    if recv.id() != ast.TokenIds.tk_dot() then
+      return false
+    end
+    try
+      let method_name =
+        (recv(1)?.token_value() as String)
+      if method_name != "neg" then return false end
+      let operand = recv(0)?
+      (operand.id() == ast.TokenIds.tk_int()) or
+        (operand.id() == ast.TokenIds.tk_float())
+    else
+      false
+    end
+
+  fun _unparse_qualify(node: ast.AST box): (String | None) =>
+    """
+    TK_QUALIFY children: [0] receiver, [1] type_args.
+    """
+    try
+      let receiver = _unparse_expr(node(0)?) as String
+      let targs = node(1)?
+      let result = recover iso String end
+      result.append(receiver)
+      result.append("[")
+      var first = true
+      for child in targs.children() do
+        if not first then result.append(", ") end
+        first = false
+        match _unparse_expr(child)
+        | let s: String => result.append(s)
+        end
+      end
+      result.append("]")
+      consume result
+    end
+
+  fun _unparse_unary_minus(node: ast.AST box): (String | None) =>
+    try
+      let operand = _unparse_expr(node(0)?) as String
+      "-" + operand
+    end
+
+  fun _unparse_member_ref(node: ast.AST box): (String | None) =>
+    """
+    TK_FUNREF/TK_NEWREF/TK_BEREF children: [0] receiver, [1] name.
+    After PassRefer these replace TK_DOT.
+    """
+    try
+      let left = _unparse_expr(node(0)?) as String
+      let right = (node(1)?.token_value() as String)
+      left + "." + right
+    end
+
+  fun _unparse_nominal(node: ast.AST box): (String | None) =>
+    """
+    TK_NOMINAL children: [0] package, [1] id, [2] type_args,
+    [3] cap, [4] ephemeral.
+    """
+    try
+      let name = node(1)?.nice_name()
+      let targs = node(2)?
+      if targs.id() != ast.TokenIds.tk_none() then
+        let result = recover iso String end
+        result.append(name)
+        result.append("[")
+        var first = true
+        for child in targs.children() do
+          if not first then result.append(", ") end
+          first = false
+          match _unparse_expr(child)
+          | let s: String => result.append(s)
+          end
+        end
+        result.append("]")
+        consume result
+      else
+        name
+      end
+    end
+
+  fun _unparse_type_alias_ref(node: ast.AST box): (String | None) =>
+    """
+    TK_TYPEALIASREF children: [0] id, [1] type_args, [2] cap,
+    [3] ephemeral.
+    """
+    try
+      let name = node(0)?.nice_name()
+      let targs = node(1)?
+      if targs.id() != ast.TokenIds.tk_none() then
+        let result = recover iso String end
+        result.append(name)
+        result.append("[")
+        var first = true
+        for child in targs.children() do
+          if not first then result.append(", ") end
+          first = false
+          match _unparse_expr(child)
+          | let s: String => result.append(s)
+          end
+        end
+        result.append("]")
+        consume result
+      else
+        name
+      end
+    end
+
+  fun _unparse_tuple(node: ast.AST box): (String | None) =>
+    """
+    TK_TUPLE children: sequence of elements.
+    """
+    let result = recover iso String end
+    result.append("(")
+    var first = true
+    for child in node.children() do
+      if not first then result.append(", ") end
+      first = false
+      match _unparse_expr(child)
+      | let s: String => result.append(s)
+      end
+    end
+    result.append(")")
+    consume result

--- a/tools/pony-doc/test/_ast_test_helper.pony
+++ b/tools/pony-doc/test/_ast_test_helper.pony
@@ -1,0 +1,81 @@
+use "files"
+use "pony_test"
+use ast = "pony_compiler"
+use doc = ".."
+
+primitive \nodoc\ _ASTTestHelper
+  """
+  Compiles a Pony source string through PassTraits and returns the
+  extracted DocProgram for use in default-value tests.
+  """
+  fun extract(
+    h: TestHelper,
+    source: String val)
+    : doc.DocProgram ?
+  =>
+    let auth = h.env.root
+    let tmp =
+      FilePath.mkdtemp(
+        FileAuth(auth), "pony-doc-ast-test")?
+    let pony_file =
+      FilePath(
+        FileAuth(auth), Path.join(tmp.path, "test.pony"))
+    let file = File(pony_file)
+    file.write(source)
+    file.dispose()
+
+    let pony_path = _get_ponypath(h.env.vars)
+
+    let result =
+      try
+        let session =
+          ast.CompileSession(
+            tmp where package_search_paths = pony_path,
+            limit = ast.PassParse)
+        match session.program()
+        | let program: ast.Program val =>
+          if not session.continue_to(ast.PassTraits) then
+            let err_msg = _format_errors(session.errors())
+            session.dispose()
+            h.fail(err_msg)
+            error
+          end
+          session.dispose()
+          doc.Extractor(program, true)
+        else
+          let err_msg = _format_errors(session.errors())
+          session.dispose()
+          h.fail(err_msg)
+          error
+        end
+      else
+        h.assert_true(tmp.remove(), "tmpdir cleanup failed")
+        error
+      end
+    h.assert_true(tmp.remove(), "tmpdir cleanup failed")
+    result
+
+  fun _format_errors(errors: Array[ast.Error] val): String val =>
+    recover val
+      let s = String
+      s.append("AST compilation failed:")
+      for err in errors.values() do
+        s.append("\n  ")
+        s.append(err.msg)
+      end
+      s
+    end
+
+  fun _get_ponypath(
+    vars: (Array[String val] val | None))
+    : String val
+  =>
+    match vars
+    | let env_vars: Array[String val] val =>
+      for pair in env_vars.values() do
+        if pair.at("PONYPATH=") then
+          return pair.substring(ISize(9))
+        end
+      end
+    end
+    ""

--- a/tools/pony-doc/test/_test_default_value.pony
+++ b/tools/pony-doc/test/_test_default_value.pony
@@ -1,0 +1,134 @@
+use "pony_test"
+use doc = ".."
+
+primitive \nodoc\ _DefaultValueTestHelper
+  fun find_default(
+    prog: doc.DocProgram,
+    method_name: String)
+    : (String | None)
+  =>
+    """
+    Finds the first parameter's default_value on the named public
+    function in the first public type of the root package.
+    """
+    try
+      let entity = prog.packages(0)?.public_types(0)?
+      for m in entity.public_functions.values() do
+        if m.name == method_name then
+          return m.params(0)?.default_value
+        end
+      end
+    end
+    None
+
+class \nodoc\ _TestDefaultValueIntLiteral is UnitTest
+  fun name(): String => "DefaultValue/int-literal"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(n: USize = 42): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "42")
+
+class \nodoc\ _TestDefaultValueNegativeInt is UnitTest
+  fun name(): String => "DefaultValue/negative-int"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(n: ISize = -1): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "-1")
+
+class \nodoc\ _TestDefaultValueStringLiteral is UnitTest
+  fun name(): String => "DefaultValue/string-literal"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(s: String = "hello"): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "\"hello\"")
+
+class \nodoc\ _TestDefaultValueBoolLiteral is UnitTest
+  fun name(): String => "DefaultValue/bool-literal"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(b: Bool = true): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "true")
+
+class \nodoc\ _TestDefaultValueReference is UnitTest
+  fun name(): String => "DefaultValue/reference"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(x: (String | None) = None): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "None")
+
+class \nodoc\ _TestDefaultValueMethodCall is UnitTest
+  fun name(): String => "DefaultValue/method-call"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(n: ISize = ISize.max_value()): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "ISize.max_value()")
+
+class \nodoc\ _TestDefaultValueConstructorCall is UnitTest
+  fun name(): String => "DefaultValue/constructor-call"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(x: I64 = I64(42)): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "I64(42)")
+
+class \nodoc\ _TestDefaultValueNone is UnitTest
+  fun name(): String => "DefaultValue/no-default"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(n: USize): None => None
+      """)?
+    h.assert_is[None](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as None,
+      None)

--- a/tools/pony-doc/test/main.pony
+++ b/tools/pony-doc/test/main.pony
@@ -58,3 +58,13 @@ actor \nodoc\ Main is TestList
     test(_TestRenderProvides)
     test(_TestMkDocsLinkFormatMethods)
     test(_TestRenderCustomLinkFormat)
+
+    // DefaultValue tests
+    test(_TestDefaultValueIntLiteral)
+    test(_TestDefaultValueNegativeInt)
+    test(_TestDefaultValueStringLiteral)
+    test(_TestDefaultValueBoolLiteral)
+    test(_TestDefaultValueReference)
+    test(_TestDefaultValueMethodCall)
+    test(_TestDefaultValueConstructorCall)
+    test(_TestDefaultValueNone)


### PR DESCRIPTION
pony-doc used `get_print()` on default-value AST nodes, which returns
the token keyword — `ISize.max_value()` rendered as "call", `-1` as
"reference". Replace with a recursive unparser that reconstructs
source-level strings from the expression tree.

The sugar pass desugars `-literal` to `literal.neg()` before
PassTraits, so the unparser detects that pattern and reconstructs the
minus form.

Also adds integration tests that compile Pony source through
PassTraits and assert on extracted `DocParam.default_value` strings.

Closes #3323
