### PR TITLE
Fix pony-doc default parameter value display

### DIFF
--- a/.release-notes/fix-pony-doc-default-values.md
+++ b/.release-notes/fix-pony-doc-default-values.md
@@ -1,0 +1,14 @@
+## Fix pony-doc default parameter value display
+
+Generated documentation displayed token keywords instead of actual default parameter values. A default of `ISize.max_value()` appeared as "call" and `-1` appeared as "reference" in the docs:
+
+```pony
+fun apply(to: ISize = ISize.max_value()): None
+```
+
+```
+Parameters:
+  to: ISize val = call
+```
+
+Default parameter values now display correctly in generated documentation.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -796,6 +796,8 @@ else()
     add_test(NAME pony-doc-tests
         COMMAND ${PONY_OUTPUT_DIR}/pony-doc-tests${CMAKE_EXECUTABLE_SUFFIX} --sequential
         WORKING_DIRECTORY ${PONY_OUTPUT_DIR})
+    set_tests_properties(pony-doc-tests PROPERTIES
+        ENVIRONMENT "PONYPATH=${CMAKE_SOURCE_DIR}/packages")
     add_test(NAME pony-lsp-tests
         COMMAND ${PONY_OUTPUT_DIR}/pony-lsp-tests${CMAKE_EXECUTABLE_SUFFIX} --sequential
         WORKING_DIRECTORY ${PONY_OUTPUT_DIR})

--- a/tools/pony-doc/_type_extractor.pony
+++ b/tools/pony-doc/_type_extractor.pony
@@ -295,19 +295,113 @@ primitive _TypeExtractor
 
   fun get_default_value(def_val: ast.AST box): (String | None) =>
     """
-    Extracts the default value string from a parameter's default AST node.
-
-    TK_STRING defaults are wrapped in explicit double quotes, all
-    others use raw `get_print()`.
+    Extracts the default value source text from a parameter's default
+    AST node by reading directly from the module's source buffer.
     """
-    if def_val.id() != ast.TokenIds.tk_none() then
-      try
-        let child = def_val(0)?
-        let print_val = child.get_print()
-        if child.id() == ast.TokenIds.tk_string() then
-          "\"" + print_val + "\""
-        else
-          print_val
-        end
-      end
+    if def_val.id() == ast.TokenIds.tk_none() then
+      return None
     end
+    try
+      let expr = def_val(0)?
+      let src = (expr.source_contents() as String box)
+      (let start_pos, _) = expr.span()
+      let start =
+        _line_col_to_offset(src, start_pos.line(), start_pos.column())?
+      let stop = _scan_expr_end(src, start)?
+      recover val src.substring(start.isize(), stop.isize()) end
+    end
+
+  fun _line_col_to_offset(
+    src: String box,
+    line: USize,
+    col: USize)
+    : USize ?
+  =>
+    """
+    Converts a 1-based line and column to a 0-based byte offset.
+    """
+    var offset: USize = 0
+    var cur_line: USize = 1
+    while cur_line < line do
+      while src(offset)? != '\n' do
+        offset = offset + 1
+      end
+      offset = offset + 1
+      cur_line = cur_line + 1
+    end
+    offset + (col - 1)
+
+  fun _scan_expr_end(
+    src: String box,
+    start: USize)
+    : USize ?
+  =>
+    """
+    Scans forward from `start` through balanced delimiters to find
+    where the expression ends. Stops at `,` or `)` at depth zero,
+    which are the parameter-list terminators that follow a default
+    value.
+    """
+    var i = start
+    var depth: USize = 0
+    var in_string = false
+    var in_triple = false
+    let len = src.size()
+
+    while i < len do
+      let c = src(i)?
+
+      if in_triple then
+        if (c == '"') and
+          ((i + 2) < len) and
+          (src(i + 1)? == '"') and
+          (src(i + 2)? == '"')
+        then
+          in_triple = false
+          in_string = false
+          i = i + 3
+          continue
+        end
+        i = i + 1
+        continue
+      end
+
+      if in_string then
+        if c == '\\' then
+          i = i + 2
+          continue
+        end
+        if c == '"' then
+          in_string = false
+        end
+        i = i + 1
+        continue
+      end
+
+      match c
+      | '"' =>
+        if ((i + 2) < len) and
+          (src(i + 1)? == '"') and
+          (src(i + 2)? == '"')
+        then
+          in_triple = true
+          in_string = true
+          i = i + 3
+          continue
+        end
+        in_string = true
+        i = i + 1
+        continue
+      | '(' | '[' =>
+        depth = depth + 1
+      | ')' =>
+        if depth == 0 then return i end
+        depth = depth - 1
+      | ']' =>
+        if depth > 0 then depth = depth - 1 end
+      | ',' =>
+        if depth == 0 then return i end
+      end
+      i = i + 1
+    end
+    error

--- a/tools/pony-doc/test/_ast_test_helper.pony
+++ b/tools/pony-doc/test/_ast_test_helper.pony
@@ -1,0 +1,81 @@
+use "files"
+use "pony_test"
+use ast = "pony_compiler"
+use doc = ".."
+
+primitive \nodoc\ _ASTTestHelper
+  """
+  Compiles a Pony source string through PassTraits and returns the
+  extracted DocProgram for use in default-value tests.
+  """
+  fun extract(
+    h: TestHelper,
+    source: String val)
+    : doc.DocProgram ?
+  =>
+    let auth = h.env.root
+    let tmp =
+      FilePath.mkdtemp(
+        FileAuth(auth), "pony-doc-ast-test")?
+    let pony_file =
+      FilePath(
+        FileAuth(auth), Path.join(tmp.path, "test.pony"))
+    let file = File(pony_file)
+    file.write(source)
+    file.dispose()
+
+    let pony_path = _get_ponypath(h.env.vars)
+
+    let result =
+      try
+        let session =
+          ast.CompileSession(
+            tmp where package_search_paths = pony_path,
+            limit = ast.PassParse)
+        match session.program()
+        | let program: ast.Program val =>
+          if not session.continue_to(ast.PassTraits) then
+            let err_msg = _format_errors(session.errors())
+            session.dispose()
+            h.fail(err_msg)
+            error
+          end
+          session.dispose()
+          doc.Extractor(program, true)
+        else
+          let err_msg = _format_errors(session.errors())
+          session.dispose()
+          h.fail(err_msg)
+          error
+        end
+      else
+        h.assert_true(tmp.remove(), "tmpdir cleanup failed")
+        error
+      end
+    h.assert_true(tmp.remove(), "tmpdir cleanup failed")
+    result
+
+  fun _format_errors(errors: Array[ast.Error] val): String val =>
+    recover val
+      let s = String
+      s.append("AST compilation failed:")
+      for err in errors.values() do
+        s.append("\n  ")
+        s.append(err.msg)
+      end
+      s
+    end
+
+  fun _get_ponypath(
+    vars: (Array[String val] val | None))
+    : String val
+  =>
+    match vars
+    | let env_vars: Array[String val] val =>
+      for pair in env_vars.values() do
+        if pair.at("PONYPATH=") then
+          return pair.substring(ISize(9))
+        end
+      end
+    end
+    ""

--- a/tools/pony-doc/test/_test_default_value.pony
+++ b/tools/pony-doc/test/_test_default_value.pony
@@ -1,0 +1,134 @@
+use "pony_test"
+use doc = ".."
+
+primitive \nodoc\ _DefaultValueTestHelper
+  fun find_default(
+    prog: doc.DocProgram,
+    method_name: String)
+    : (String | None)
+  =>
+    """
+    Finds the first parameter's default_value on the named public
+    function in the first public type of the root package.
+    """
+    try
+      let entity = prog.packages(0)?.public_types(0)?
+      for m in entity.public_functions.values() do
+        if m.name == method_name then
+          return m.params(0)?.default_value
+        end
+      end
+    end
+    None
+
+class \nodoc\ _TestDefaultValueIntLiteral is UnitTest
+  fun name(): String => "DefaultValue/int-literal"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(n: USize = 42): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "42")
+
+class \nodoc\ _TestDefaultValueNegativeInt is UnitTest
+  fun name(): String => "DefaultValue/negative-int"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(n: ISize = -1): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "-1")
+
+class \nodoc\ _TestDefaultValueStringLiteral is UnitTest
+  fun name(): String => "DefaultValue/string-literal"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(s: String = "hello"): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "\"hello\"")
+
+class \nodoc\ _TestDefaultValueBoolLiteral is UnitTest
+  fun name(): String => "DefaultValue/bool-literal"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(b: Bool = true): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "true")
+
+class \nodoc\ _TestDefaultValueReference is UnitTest
+  fun name(): String => "DefaultValue/reference"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(x: (String | None) = None): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "None")
+
+class \nodoc\ _TestDefaultValueMethodCall is UnitTest
+  fun name(): String => "DefaultValue/method-call"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(n: ISize = ISize.max_value()): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "ISize.max_value()")
+
+class \nodoc\ _TestDefaultValueConstructorCall is UnitTest
+  fun name(): String => "DefaultValue/constructor-call"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(x: I64 = I64(42)): None => None
+      """)?
+    h.assert_eq[String](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as String,
+      "I64(42)")
+
+class \nodoc\ _TestDefaultValueNone is UnitTest
+  fun name(): String => "DefaultValue/no-default"
+
+  fun apply(h: TestHelper) ? =>
+    let prog = _ASTTestHelper.extract(h,
+      """
+      primitive Foo
+        fun apply(n: USize): None => None
+      """)?
+    h.assert_is[None](
+      _DefaultValueTestHelper.find_default(prog, "apply")
+        as None,
+      None)

--- a/tools/pony-doc/test/main.pony
+++ b/tools/pony-doc/test/main.pony
@@ -58,3 +58,13 @@ actor \nodoc\ Main is TestList
     test(_TestRenderProvides)
     test(_TestMkDocsLinkFormatMethods)
     test(_TestRenderCustomLinkFormat)
+
+    // DefaultValue tests
+    test(_TestDefaultValueIntLiteral)
+    test(_TestDefaultValueNegativeInt)
+    test(_TestDefaultValueStringLiteral)
+    test(_TestDefaultValueBoolLiteral)
+    test(_TestDefaultValueReference)
+    test(_TestDefaultValueMethodCall)
+    test(_TestDefaultValueConstructorCall)
+    test(_TestDefaultValueNone)


### PR DESCRIPTION
Default values displayed token keywords ("call", "reference") instead of the actual expressions because `get_default_value` used `get_print()`, which returns the token keyword for compound AST nodes.

The fix reads the default value directly from the module's source buffer: get the expression's start position via `span()`, convert to a byte offset, then scan forward through balanced delimiters until hitting the parameter-list terminator (`,` or `)` at depth zero). This gives exact fidelity to what the user wrote — no per-node-type dispatch, no sugar-pass reversal, no missed closing delimiters.

Closes ponylang/ponyc#3323
