### PR TITLE
Fix PropertyRunner double completion on assert-and-error

### DIFF
--- a/.release-notes/fix-property-runner-double-completion.md
+++ b/.release-notes/fix-property-runner-double-completion.md
@@ -1,0 +1,3 @@
+## Fix PropertyRunner double completion on assert-and-error
+
+In rare cases where a property test failed an assertion and raised an error, the runner sent two completion notifications instead of one, causing the test harness to fall out of sync. The completion notification is now sent exactly once.

--- a/packages/pony_check/property_result_notify.pony
+++ b/packages/pony_check/property_result_notify.pony
@@ -158,6 +158,7 @@ actor PropertyRunner[T]
       // found a bad example, try to shrink it
       if not _shrinker.has_next() then
         _logger.log("no shrinks available")
+        _prepare_next_round()
         fail(_sample_repr, 0)
       else
         // prepare next round
@@ -231,6 +232,7 @@ actor PropertyRunner[T]
     try
       _prop1.property(consume sample, helper)?
     else
+      _prepare_next_round()
       fail(_sample_repr, 0 where err=true)
       return
     end
@@ -313,6 +315,7 @@ actor PropertyRunner[T]
     try
       _prop1.property(consume shrink, helper)?
     else
+      _prepare_next_round()
       fail(current_repr, round_num where err=true)
       return
     end


### PR DESCRIPTION
PropertyRunner processes property test results through async behaviors. When a property body fails an assertion, the helper sends a `complete_run(round, false)` behavior message to the runner. If the body then also raises an error, the `else` clause in `run()` handles it synchronously and calls `fail()`, which sends `_notify.complete(false)`. The queued `complete_run` runs later, and because the round was never advanced, it passes the round check and sends `_notify.complete(false)` a second time.

The runner already guards against stale work with a round counter: `_prepare_next_round()` advances it, and behaviors check it on entry, doing nothing if the round has moved on. Three failure paths called `fail()` without advancing the round first. The fix adds `_prepare_next_round()` before `fail()` in each path.

Closes #5927
