### PR TITLE
Fix incorrect viewpoint adaptation bounds for generic capability parameters

### DIFF
--- a/.release-notes/fix-generic-cap-viewpoint-bounds.md
+++ b/.release-notes/fix-generic-cap-viewpoint-bounds.md
@@ -1,0 +1,5 @@
+## Fix incorrect viewpoint adaptation bounds for generic capability parameters
+
+When accessing a field through a `trn` reference, and the field's type used a generic capability constraint (`#read`, `#alias`, or `#any`), the compiler computed incorrect capability bounds for the viewpoint-adapted type. Programs with unsound capability usage in these combinations could pass type checking without error.
+
+Programs that relied on the incorrect bounds will now be correctly rejected by the compiler.

--- a/src/libponyc/type/cap.c
+++ b/src/libponyc/type/cap.c
@@ -966,9 +966,6 @@ bool cap_view_upper(token_id left_cap, token_id left_eph,
           *right_cap = TK_TAG;
           break;
 
-        case TK_TRN:
-          break;
-
         case TK_VAL:
         case TK_CAP_SHARE:
           break;
@@ -1098,16 +1095,8 @@ bool cap_view_lower(token_id left_cap, token_id left_eph,
 
         case TK_CAP_READ:
         case TK_CAP_ALIAS:
-          *right_cap = TK_VAL;
-          *right_eph = TK_NONE;
-          break;
-
         case TK_CAP_ANY:
-          *right_cap = TK_ISO;
-
-          if(left_eph == TK_EPHEMERAL)
-            *right_eph = TK_EPHEMERAL;
-          break;
+          return false;
 
         default:
           *right_cap = TK_BOX;
@@ -1177,8 +1166,7 @@ bool cap_view_lower(token_id left_cap, token_id left_eph,
           break;
 
         case TK_TRN:
-          *right_cap = TK_BOX;
-          break;
+          return false;
 
         case TK_REF:
           *right_cap = TK_CAP_READ;

--- a/test/libponyc/cap.cc
+++ b/test/libponyc/cap.cc
@@ -909,7 +909,7 @@ TEST_F(CapTest, ViewpointUpperRead)
 {
   // #read = {ref, val, box}
   ASSERT_EQ(upper_viewpoint(read, iso), tag);   // {iso, val, tag}
-  ASSERT_EQ(upper_viewpoint(read, trn), trn);   // {trn, val, box}
+  ASSERT_EQ(upper_viewpoint(read, trn), box);   // {trn, val, box}
   ASSERT_EQ(upper_viewpoint(read, ref), box);   // {ref, val, box}
   ASSERT_EQ(upper_viewpoint(read, val), val);   // {val, val, val}
   ASSERT_EQ(upper_viewpoint(read, box), box);   // {box, val, box}
@@ -920,9 +920,145 @@ TEST_F(CapTest, ViewpointLowerRead)
 {
   // #read = {ref, val, box}
   ASSERT_EQ(lower_viewpoint(read, iso), send);  // {iso, val, tag} = #send
-  ASSERT_EQ(lower_viewpoint(read, trn), box);   // {trn, val, box}
+  EXPECT_VP_UNDEF(lower_viewpoint_full, read, none, trn, none); // {trn, val, box}: no valid lower
   ASSERT_EQ(lower_viewpoint(read, ref), read);  // {ref, val, box} = #read
   ASSERT_EQ(lower_viewpoint(read, val), val);   // {val}
   ASSERT_EQ(lower_viewpoint(read, box), val);   // {val, box}
   ASSERT_EQ(lower_viewpoint(read, tag), tag);   // {tag}
+}
+
+TEST_F(CapTest, ViewpointUpperGenericField)
+{
+  // iso origin: all generic fields produce result set {iso,val,tag} or subsets
+  EXPECT_VP(upper_viewpoint_full, iso, none, read, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, iso, none, send, none, send, none);
+  EXPECT_VP(upper_viewpoint_full, iso, none, share, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, iso, none, alias, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, iso, none, any, none, tag, none);
+
+  // iso^ origin
+  EXPECT_VP(upper_viewpoint_full, iso, hat, read, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, iso, hat, send, none, send, hat);
+  EXPECT_VP(upper_viewpoint_full, iso, hat, share, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, iso, hat, alias, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, iso, hat, any, none, tag, none);
+
+  // trn origin
+  EXPECT_VP(upper_viewpoint_full, trn, none, read, none, box, none);
+  EXPECT_VP(upper_viewpoint_full, trn, none, send, none, send, none);
+  EXPECT_VP(upper_viewpoint_full, trn, none, share, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, trn, none, alias, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, trn, none, any, none, tag, none);
+
+  // trn^ origin
+  EXPECT_VP(upper_viewpoint_full, trn, hat, read, none, box, none);
+  EXPECT_VP(upper_viewpoint_full, trn, hat, send, none, send, hat);
+  EXPECT_VP(upper_viewpoint_full, trn, hat, share, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, trn, hat, alias, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, trn, hat, any, none, tag, none);
+
+  // ref origin: identity
+  EXPECT_VP(upper_viewpoint_full, ref, none, read, none, read, none);
+  EXPECT_VP(upper_viewpoint_full, ref, none, send, none, send, none);
+  EXPECT_VP(upper_viewpoint_full, ref, none, share, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, ref, none, alias, none, alias, none);
+  EXPECT_VP(upper_viewpoint_full, ref, none, any, none, any, none);
+
+  // val origin: all generic fields collapse to #share or val
+  EXPECT_VP(upper_viewpoint_full, val, none, read, none, val, none);
+  EXPECT_VP(upper_viewpoint_full, val, none, send, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, val, none, share, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, val, none, alias, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, val, none, any, none, share, none);
+
+  // box origin
+  EXPECT_VP(upper_viewpoint_full, box, none, read, none, box, none);
+  EXPECT_VP(upper_viewpoint_full, box, none, send, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, box, none, share, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, box, none, alias, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, box, none, any, none, tag, none);
+
+  // tag origin: no viewpoint through tag
+  EXPECT_VP_UNDEF(upper_viewpoint_full, tag, none, read, none);
+  EXPECT_VP_UNDEF(upper_viewpoint_full, tag, none, send, none);
+  EXPECT_VP_UNDEF(upper_viewpoint_full, tag, none, share, none);
+  EXPECT_VP_UNDEF(upper_viewpoint_full, tag, none, alias, none);
+  EXPECT_VP_UNDEF(upper_viewpoint_full, tag, none, any, none);
+}
+
+TEST_F(CapTest, ViewpointLowerGenericField)
+{
+  // iso origin: result sets match #send or #share
+  EXPECT_VP(lower_viewpoint_full, iso, none, read, none, send, none);
+  EXPECT_VP(lower_viewpoint_full, iso, none, send, none, send, none);
+  EXPECT_VP(lower_viewpoint_full, iso, none, share, none, share, none);
+  EXPECT_VP(lower_viewpoint_full, iso, none, alias, none, send, none);
+  EXPECT_VP(lower_viewpoint_full, iso, none, any, none, send, none);
+
+  // iso^ origin
+  EXPECT_VP(lower_viewpoint_full, iso, hat, read, none, send, hat);
+  EXPECT_VP(lower_viewpoint_full, iso, hat, send, none, send, hat);
+  EXPECT_VP(lower_viewpoint_full, iso, hat, share, none, share, none);
+  EXPECT_VP(lower_viewpoint_full, iso, hat, alias, none, send, hat);
+  EXPECT_VP(lower_viewpoint_full, iso, hat, any, none, send, hat);
+
+  // trn origin: #read/#alias/#any have no valid lower bound
+  EXPECT_VP_UNDEF(lower_viewpoint_full, trn, none, read, none);
+  EXPECT_VP(lower_viewpoint_full, trn, none, send, none, send, none);
+  EXPECT_VP(lower_viewpoint_full, trn, none, share, none, share, none);
+  EXPECT_VP_UNDEF(lower_viewpoint_full, trn, none, alias, none);
+  EXPECT_VP_UNDEF(lower_viewpoint_full, trn, none, any, none);
+
+  // trn^ origin: #read/#alias/#any have no valid lower bound
+  EXPECT_VP_UNDEF(lower_viewpoint_full, trn, hat, read, none);
+  EXPECT_VP(lower_viewpoint_full, trn, hat, send, none, send, hat);
+  EXPECT_VP(lower_viewpoint_full, trn, hat, share, none, share, none);
+  EXPECT_VP_UNDEF(lower_viewpoint_full, trn, hat, alias, none);
+  EXPECT_VP_UNDEF(lower_viewpoint_full, trn, hat, any, none);
+
+  // ref origin: identity
+  EXPECT_VP(lower_viewpoint_full, ref, none, read, none, read, none);
+  EXPECT_VP(lower_viewpoint_full, ref, none, send, none, send, none);
+  EXPECT_VP(lower_viewpoint_full, ref, none, share, none, share, none);
+  EXPECT_VP(lower_viewpoint_full, ref, none, alias, none, alias, none);
+  EXPECT_VP(lower_viewpoint_full, ref, none, any, none, any, none);
+
+  // val origin: all generic fields collapse to #share or val
+  EXPECT_VP(lower_viewpoint_full, val, none, read, none, val, none);
+  EXPECT_VP(lower_viewpoint_full, val, none, send, none, share, none);
+  EXPECT_VP(lower_viewpoint_full, val, none, share, none, share, none);
+  EXPECT_VP(lower_viewpoint_full, val, none, alias, none, share, none);
+  EXPECT_VP(lower_viewpoint_full, val, none, any, none, share, none);
+
+  // box origin
+  EXPECT_VP(lower_viewpoint_full, box, none, read, none, val, none);
+  EXPECT_VP(lower_viewpoint_full, box, none, send, none, share, none);
+  EXPECT_VP(lower_viewpoint_full, box, none, share, none, share, none);
+  EXPECT_VP(lower_viewpoint_full, box, none, alias, none, val, none);
+  EXPECT_VP(lower_viewpoint_full, box, none, any, none, val, none);
+
+  // tag origin: no viewpoint through tag
+  EXPECT_VP_UNDEF(lower_viewpoint_full, tag, none, read, none);
+  EXPECT_VP_UNDEF(lower_viewpoint_full, tag, none, send, none);
+  EXPECT_VP_UNDEF(lower_viewpoint_full, tag, none, share, none);
+  EXPECT_VP_UNDEF(lower_viewpoint_full, tag, none, alias, none);
+  EXPECT_VP_UNDEF(lower_viewpoint_full, tag, none, any, none);
+}
+
+TEST_F(CapTest, ViewpointUpperReadGenericField)
+{
+  EXPECT_VP(upper_viewpoint_full, read, none, read, none, box, none);
+  EXPECT_VP(upper_viewpoint_full, read, none, send, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, read, none, share, none, share, none);
+  EXPECT_VP(upper_viewpoint_full, read, none, alias, none, tag, none);
+  EXPECT_VP(upper_viewpoint_full, read, none, any, none, tag, none);
+}
+
+TEST_F(CapTest, ViewpointLowerReadGenericField)
+{
+  EXPECT_VP(lower_viewpoint_full, read, none, read, none, read, none);
+  EXPECT_VP(lower_viewpoint_full, read, none, send, none, send, none);
+  EXPECT_VP(lower_viewpoint_full, read, none, share, none, share, none);
+  EXPECT_VP(lower_viewpoint_full, read, none, alias, none, alias, none);
+  EXPECT_VP(lower_viewpoint_full, read, none, any, none, any, none);
 }


### PR DESCRIPTION
Phase 0.1 of the viewpoint adaptation corrections (discussion #5868). Audits every generic-cap entry in `cap_view_upper` and `cap_view_lower` against the concrete-cap table from RFC 0059.

The soundness criterion for upper bounds: `upset(U) ⊆ ∩(upset(concrete_k))` for each concrete cap in the generic cap's expansion. For lower bounds: `downset(L) ⊆ ∩(downset(concrete_k))`. Both use `is_cap_sub_cap`. When the intersection is empty, no valid bound exists and the function returns false.

Eight entries fail these criteria:

Six trn-origin lower bounds (`trn→#read`, `trn→#alias`, `trn→#any`, and their ephemeral variants) returned concrete caps, but the result sets contain both trn and val, whose downsets have empty intersection. Now return false.

Two #read-origin entries, both introduced by #5925: `upper(#read, trn)` was changed from box to trn, but `upset(trn) ⊄ ∩(upsets of {trn, val, box})`. Reverted to box. `lower(#read, trn)` was changed from trn to box, but `downset(box)` is non-empty while the intersection is empty. Now returns false.

Design: #5868
