### PR TITLE
Fix pony-doc displaying default parameter values

### DIFF
--- a/.release-notes/fix-docgen-default-values.md
+++ b/.release-notes/fix-docgen-default-values.md
@@ -1,0 +1,5 @@
+## Fix pony-doc displaying default parameter values
+
+pony-doc displayed internal compiler token names like "call" and "reference" instead of the actual default parameter values written in source. A parameter declared as `fun apply(n: ISize = ISize.max_value())` appeared in the generated documentation with a default of "call" instead of `ISize.max_value()`. Similarly, `-1` appeared as "prefix".
+
+Default values are now extracted from the original source text, so the documentation shows exactly what the user wrote.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,7 +802,7 @@ else()
     add_test(NAME pony-lint-tests
         COMMAND ${PONY_OUTPUT_DIR}/pony-lint-tests${CMAKE_EXECUTABLE_SUFFIX} --sequential
         WORKING_DIRECTORY ${PONY_OUTPUT_DIR})
-    set_tests_properties(pony-lint-tests PROPERTIES
+    set_tests_properties(pony-lint-tests pony-doc-tests PROPERTIES
         ENVIRONMENT "PONYPATH=${CMAKE_SOURCE_DIR}/packages")
     add_test(NAME pony-compiler-tests
         COMMAND ${PONY_OUTPUT_DIR}/pony-compiler-tests${CMAKE_EXECUTABLE_SUFFIX} --sequential

--- a/src/libponyc/ast/ast.c
+++ b/src/libponyc/ast/ast.c
@@ -602,6 +602,12 @@ source_t* ast_source(ast_t* ast)
   return token_source(ast->t);
 }
 
+size_t ast_len(ast_t* ast)
+{
+  pony_assert(ast != NULL);
+  return token_length(ast->t);
+}
+
 void* ast_data(ast_t* ast)
 {
   if(ast == NULL)

--- a/src/libponyc/ast/ast.h
+++ b/src/libponyc/ast/ast.h
@@ -73,6 +73,7 @@ void ast_setpos(ast_t* ast, source_t* source, size_t line, size_t pos);
 token_id ast_id(ast_t* ast);
 size_t ast_line(ast_t* ast);
 size_t ast_pos(ast_t* ast);
+size_t ast_len(ast_t* ast);
 source_t* ast_source(ast_t* ast);
 
 void* ast_data(ast_t* ast);

--- a/src/libponyc/ast/lexer.c
+++ b/src/libponyc/ast/lexer.c
@@ -36,6 +36,7 @@ struct lexer_t
   // Position of current token
   size_t token_line;
   size_t token_pos;
+  size_t token_ptr;
 
   // Buffer containing current token text
   char* buffer;
@@ -376,6 +377,7 @@ static token_t* make_token(lexer_t* lexer, token_id id)
 {
   token_t* t = token_new(id);
   token_set_pos(t, lexer->source, lexer->token_line, lexer->token_pos);
+  token_set_length(t, lexer->ptr - lexer->token_ptr);
   token_set_newline(t, lexer->token_newline);
   return t;
 }
@@ -1319,6 +1321,7 @@ token_t* lexer_next(lexer_t* lexer)
   {
     lexer->token_line = lexer->line;
     lexer->token_pos = lexer->pos;
+    lexer->token_ptr = lexer->ptr;
     lexer->buflen = 0;
 
     if(is_eof(lexer))

--- a/src/libponyc/ast/token.c
+++ b/src/libponyc/ast/token.c
@@ -13,6 +13,7 @@ struct token_t
   source_t* source;
   size_t line;
   size_t pos;
+  size_t len;
   char* printed;
   bool newline;
 
@@ -281,6 +282,13 @@ size_t token_line_position(token_t* token)
 }
 
 
+size_t token_length(token_t* token)
+{
+  pony_assert(token != NULL);
+  return token->len;
+}
+
+
 // Write accessors
 
 void token_set_id(token_t* token, token_id id)
@@ -345,6 +353,16 @@ void token_set_pos(token_t* token, source_t* source, size_t line, size_t pos)
 
   token->line = line;
   token->pos = pos;
+}
+
+
+void token_set_length(token_t* token, size_t length)
+{
+  pony_assert(token != NULL);
+#ifndef PONY_NDEBUG
+  pony_assert(!token->frozen);
+#endif
+  token->len = length;
 }
 
 

--- a/src/libponyc/ast/token.h
+++ b/src/libponyc/ast/token.h
@@ -351,6 +351,11 @@ size_t token_line_number(token_t* token);
 /// Report the position within the line that the given token was found at
 size_t token_line_position(token_t* token);
 
+/// Report the source-text length of the given token in bytes.
+/// Zero for tokens whose length was not recorded (e.g. abstract/compound
+/// tokens created by the parser).
+size_t token_length(token_t* token);
+
 /// Report whether a real newline character separated this token from the
 /// previously emitted one. Set by the lexer; used by the parser to detect
 /// statement separators.
@@ -387,6 +392,9 @@ void token_set_int(token_t* token, lexint_t* value);
 /// source file.
 /// Set source to NULL to keep current file.
 void token_set_pos(token_t* token, source_t* source, size_t line, size_t pos);
+
+/// Set the source-text length of the given token in bytes.
+void token_set_length(token_t* token, size_t length);
 
 /// Set whether a real newline character separated this token from the
 /// previously emitted one.

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/ast.pony
@@ -11,6 +11,7 @@ use @ast_id[TokenId](ast: Pointer[_AST] box)
 use @ast_source[NullablePointer[_Source]](ast: Pointer[_AST] box)
 use @ast_line[USize](ast: Pointer[_AST] box)
 use @ast_pos[USize](ast: Pointer[_AST] box)
+use @ast_len[USize](ast: Pointer[_AST] box)
 use @ast_has_scope[Bool](ast: Pointer[_AST] box)
 use @ast_get_symtab[Pointer[_Symtab]](ast: Pointer[_AST] box)
 
@@ -82,6 +83,13 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
 
   fun box pos(): USize =>
     @ast_pos(raw)
+
+  fun box token_len(): USize =>
+    """
+    Source-text byte length of this node's token, as recorded by the
+    lexer. Zero for parser-created nodes that have no source text.
+    """
+    @ast_len(raw)
 
   fun box position(): Position =>
     Position(line(), pos())
@@ -569,8 +577,8 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
     """
     Return the position of the last character of the given AST node.
 
-    For some nodes we know the actual size, so we can provide its
-    exact end position.
+    When the token carries a source-text length from the lexer, use it
+    directly. Otherwise fall back to per-token-kind width tables.
     """
     let l = line()
     let col = pos()
@@ -798,6 +806,84 @@ class val AST is (Stringable & Hashable & Equatable[AST box])
       end
     visit(visitor)
     (visitor.min(), visitor.max())
+
+  fun box source_span(): (Position, Position) =>
+    """
+    Like `span()` but walks all children including TK_NONE, so closing
+    delimiters whose positions are carried by placeholder children are
+    included. Uses token length for accurate end positions.
+
+    Uses a stack-based walk instead of the visitor pattern to avoid
+    the TK_NONE filtering in `visit()`.
+    """
+    var min_pos = Position.max()
+    var max_pos = Position.min()
+    let stack = Array[AST box]
+    stack.push(this)
+    while stack.size() > 0 do
+      try
+        let node = stack.pop()?
+        let cur_pos = node.position()
+        let tlen = node.token_len()
+        let cur_end =
+          if tlen > 0 then
+            _token_end_position(node, tlen)
+          else
+            cur_pos
+          end
+        if cur_end > max_pos then
+          max_pos = cur_end
+        end
+        if cur_pos < min_pos then
+          min_pos = cur_pos
+        end
+        for child' in node.children() do
+          stack.push(child')
+        end
+      end
+    end
+    (min_pos, max_pos)
+
+  fun box _token_end_position(node: AST box, tlen: USize): Position =>
+    """
+    Compute the end position of a token that spans `tlen` bytes.
+    Scans the source text to handle multi-line tokens correctly.
+    Falls back to single-line arithmetic when source is unavailable.
+    """
+    try
+      let src = (node.source_contents() as String box)
+      let start_line = node.line()
+      let start_col = node.pos()
+
+      // Find byte offset of token start
+      var offset: USize = 0
+      if start_line > 1 then
+        var lines_left = start_line - 1
+        while (offset < src.size()) and (lines_left > 0) do
+          if src(offset)? == '\n' then
+            lines_left = lines_left - 1
+          end
+          offset = offset + 1
+        end
+      end
+      offset = offset + (start_col - 1)
+
+      // Scan tlen bytes to find end line/col
+      let end_byte = (offset + tlen) - 1
+      var cur_line = start_line
+      var line_start = offset - (start_col - 1)
+      var i = offset
+      while i <= end_byte do
+        if (i < src.size()) and (src(i)? == '\n') then
+          cur_line = cur_line + 1
+          line_start = i + 1
+        end
+        i = i + 1
+      end
+      Position(cur_line, (end_byte - line_start) + 1)
+    else
+      Position(node.line(), (node.pos() + tlen) - 1)
+    end
 
   fun box definitions(): Array[AST] =>
     """

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/token.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/token.pony
@@ -21,6 +21,7 @@ struct _Token
   var source: NullablePointer[_Source] = source.none()
   var line: USize = 0
   var pos: USize = 0
+  var len: USize = 0
   var printed: Pointer[U8] ref = printed.create()
   var opaque_value_1: U64 = 0
   var opaque_value_2: U64 = 0

--- a/tools/pony-doc/_type_extractor.pony
+++ b/tools/pony-doc/_type_extractor.pony
@@ -295,19 +295,172 @@ primitive _TypeExtractor
 
   fun get_default_value(def_val: ast.AST box): (String | None) =>
     """
-    Extracts the default value string from a parameter's default AST node.
+    Extracts the default value source text from a parameter's default
+    AST node by reading it from the original source. This preserves
+    the user's spelling (e.g. `ISize.max_value()`, `-1`) regardless of
+    how the compiler transforms the AST.
 
-    TK_STRING defaults are wrapped in explicit double quotes, all
-    others use raw `get_print()`.
+    Block constructs (`recover`, `if`, `object`, etc.) have a closing
+    `end` keyword that the parser consumes without leaving an AST node.
+    After extracting via `source_span()`, any unmatched block openers
+    are balanced by scanning forward for matching `end` keywords.
     """
     if def_val.id() != ast.TokenIds.tk_none() then
       try
-        let child = def_val(0)?
-        let print_val = child.get_print()
-        if child.id() == ast.TokenIds.tk_string() then
-          "\"" + print_val + "\""
-        else
-          print_val
+        let src = (def_val.source_contents() as String box)
+        (let start_pos, let end_pos') = def_val.source_span()
+        let start_offset = _pos_to_offset(src, start_pos)?
+        var end_offset = _pos_to_offset(src, end_pos')?
+        if end_offset >= start_offset then
+          var extracted: String val =
+            recover val
+              src.substring(
+                ISize.from[USize](start_offset),
+                ISize.from[USize](end_offset + 1))
+                .> strip()
+            end
+
+          // Block constructs lose their closing `end` in the AST.
+          // Count unmatched openers and scan forward for each.
+          var missing_ends = _count_unmatched_ends(extracted)
+          while missing_ends > 0 do
+            end_offset = _scan_to_next_end(src, end_offset + 1)?
+            missing_ends = missing_ends - 1
+          end
+
+          if missing_ends == 0 then
+            extracted =
+              recover val
+                src.substring(
+                  ISize.from[USize](start_offset),
+                  ISize.from[USize](end_offset + 1))
+                  .> strip()
+              end
+          end
+          extracted
         end
       end
+    end
+
+  fun _count_unmatched_ends(text: String val): USize =>
+    """
+    Count block-opening keywords minus `end` keywords. Returns the
+    number of `end` keywords missing from the extracted text.
+    """
+    let openers =
+      [ as String:
+        "recover"; "if"; "ifdef"; "iftype"; "match"; "while"; "for"
+        "repeat"; "object"; "lambda"; "try"]
+    var opens: USize = 0
+    var ends: USize = 0
+
+    // Split on whitespace and count keyword tokens
+    var i: USize = 0
+    let size = text.size()
+    while i < size do
+      // Skip non-word characters
+      try
+        while (i < size) and not _is_word_char(text(i)?) do
+          // Skip string literals
+          if text(i)? == '"' then
+            i = i + 1
+            if ((i + 1) < size) and (text(i)? == '"') and
+              (text(i + 1)? == '"')
+            then
+              // Triple-quoted string
+              i = i + 2
+              while (i + 2) < size do
+                if (text(i)? == '"') and (text(i + 1)? == '"') and
+                  (text(i + 2)? == '"')
+                then
+                  i = i + 3
+                  break
+                end
+                i = i + 1
+              end
+            else
+              while (i < size) and (text(i)? != '"') do
+                i = i + 1
+              end
+              if i < size then i = i + 1 end
+            end
+          else
+            i = i + 1
+          end
+        end
+      end
+
+      // Extract word
+      let word_start = i
+      try
+        while (i < size) and _is_word_char(text(i)?) do
+          i = i + 1
+        end
+      end
+
+      if i > word_start then
+        let word: String val =
+          text.substring(
+            ISize.from[USize](word_start),
+            ISize.from[USize](i))
+        if word == "end" then
+          ends = ends + 1
+        else
+          for opener in openers.values() do
+            if word == opener then
+              opens = opens + 1
+              break
+            end
+          end
+        end
+      end
+    end
+
+    if opens > ends then opens - ends else 0 end
+
+  fun _is_word_char(c: U8): Bool =>
+    ((c >= 'a') and (c <= 'z')) or
+    ((c >= 'A') and (c <= 'Z')) or
+    ((c >= '0') and (c <= '9')) or
+    (c == '_')
+
+  fun _scan_to_next_end(
+    src: String box,
+    from: USize)
+    : USize ?
+  =>
+    """
+    Scan forward from byte offset `from` to find the next `end` keyword
+    (a standalone word, not a substring of another identifier). Returns
+    the byte offset of the last character of that `end` token.
+    """
+    var i = from
+    let size = src.size()
+    while i < size do
+      if not _is_word_char(src(i)?) then
+        i = i + 1
+      else
+        let word_start = i
+        while (i < size) and _is_word_char(src(i)?) do
+          i = i + 1
+        end
+        if (src.substring(
+          ISize.from[USize](word_start), ISize.from[USize](i)) == "end")
+        then
+          return i - 1
+        end
+      end
+    end
+    error
+
+  fun _pos_to_offset(
+    src: String box,
+    p: ast.Position)
+    : USize ?
+  =>
+    if p.line() == 1 then
+      p.column() - 1
+    else
+      let line_idx = src.find("\n" where nth = p.line() - 2)?
+      line_idx.usize() + p.column()
     end

--- a/tools/pony-doc/test/_test_default_value.pony
+++ b/tools/pony-doc/test/_test_default_value.pony
@@ -1,0 +1,434 @@
+use "collections"
+use "files"
+use "pony_test"
+use ast = "pony_compiler"
+
+class \nodoc\ _TestDefaultValueCallExpr is UnitTest
+  """
+  Verifies that `ISize.max_value()` is extracted as source text, not as
+  the internal token keyword "call".
+  """
+  fun name(): String => "DefaultValue/call-expr"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n  fun apply(n: ISize = ISize.max_value()): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 1)
+      h.assert_eq[String](defaults(0)?, "ISize.max_value()")
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueIntLiteral is UnitTest
+  fun name(): String => "DefaultValue/int-literal"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n  fun apply(n: USize = 42): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 1)
+      h.assert_eq[String](defaults(0)?, "42")
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueStringLiteral is UnitTest
+  fun name(): String => "DefaultValue/string-literal"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n  fun apply(s: String = \"hi\"): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 1)
+      h.assert_eq[String](defaults(0)?, "\"hi\"")
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueNegation is UnitTest
+  """
+  The sugar pass transforms `-1` to `1.neg()`, but source extraction
+  should return the original `-1`.
+  """
+  fun name(): String => "DefaultValue/negation"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n  fun apply(x: ISize = -1): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 1)
+      h.assert_eq[String](defaults(0)?, "-1")
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueMultipleParams is UnitTest
+  fun name(): String => "DefaultValue/multiple-params"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n" +
+      "  fun apply(a: USize = 1, b: String = \"x\"," +
+      " c: ISize = ISize.max_value()): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 3)
+      h.assert_eq[String](defaults(0)?, "1")
+      h.assert_eq[String](defaults(1)?, "\"x\"")
+      h.assert_eq[String](defaults(2)?, "ISize.max_value()")
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueBoolLiteral is UnitTest
+  fun name(): String => "DefaultValue/bool-literal"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n  fun apply(x: Bool = true): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 1)
+      h.assert_eq[String](defaults(0)?, "true")
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueFloatLiteral is UnitTest
+  fun name(): String => "DefaultValue/float-literal"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n  fun apply(x: F64 = 3.14): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 1)
+      h.assert_eq[String](defaults(0)?, "3.14")
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueNoneValue is UnitTest
+  fun name(): String => "DefaultValue/none-value"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n" +
+      "  fun apply(x: (String | None) = None): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 1)
+      h.assert_eq[String](defaults(0)?, "None")
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueRecoverBlock is UnitTest
+  """
+  A `recover` block default spans multiple tokens. This is the case
+  from issue #1262 where the old docgen showed just "recover".
+  """
+  fun name(): String => "DefaultValue/recover-block"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n" +
+      "  fun apply(s: String val =" +
+      " recover val String end): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 1)
+      h.assert_eq[String](defaults(0)?, "recover val String end")
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueMultiLine is UnitTest
+  """
+  A triple-quoted string default spans multiple lines. The source
+  extraction must track newlines within the token to find the correct
+  end position.
+  """
+  fun name(): String => "DefaultValue/multi-line"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n" +
+      "  fun apply(s: String = \"\"\"\n" +
+      "    hello\n" +
+      "    \"\"\"): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 1)
+      let extracted = defaults(0)?
+      h.assert_true(
+        extracted.contains("hello"),
+        "extracted should contain 'hello', got: " + extracted)
+    else
+      h.fail("extraction failed")
+    end
+
+class \nodoc\ _TestDefaultValueNone is UnitTest
+  """
+  Parameters without a default should produce None, not appear in results.
+  """
+  fun name(): String => "DefaultValue/no-default"
+
+  fun apply(h: TestHelper) =>
+    let source =
+      "primitive Foo\n  fun apply(n: USize): None => None\n"
+    try
+      let defaults = _DefaultValueTestHelper.extract_defaults(h, source)?
+      h.assert_eq[USize](defaults.size(), 0)
+    else
+      h.fail("extraction failed")
+    end
+
+primitive \nodoc\ _DefaultValueTestHelper
+  """
+  Compiles Pony source through PassTraits and extracts default parameter
+  values from the original source text via `source_span()`.
+  """
+  fun extract_defaults(
+    h: TestHelper,
+    source: String val)
+    : Array[String val] ?
+  =>
+    let program = _compile(h, source)?
+    let defaults = Array[String val]
+    let pkgs = program.packages()
+    if pkgs.has_next() then
+      try
+        let pkg = pkgs.next()?
+        for module in pkg.modules() do
+          for entity in module.ast.children() do
+            if ast.TokenIds.is_entity(entity.id()) then
+              try
+                let members = entity(4)?
+                for member in members.children() do
+                  match member.id()
+                  | ast.TokenIds.tk_fun()
+                  | ast.TokenIds.tk_new()
+                  | ast.TokenIds.tk_be() =>
+                    try
+                      let params = member(3)?
+                      for param in params.children() do
+                        if param.id() == ast.TokenIds.tk_none() then
+                          continue
+                        end
+                        try
+                          let def_val = param(2)?
+                          match _extract_one(def_val)
+                          | let s: String val => defaults.push(s)
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+    defaults
+
+  fun _extract_one(def_val: ast.AST box): (String | None) =>
+    if def_val.id() != ast.TokenIds.tk_none() then
+      try
+        let src = (def_val.source_contents() as String box)
+        (let start_pos, let end_pos') = def_val.source_span()
+        let start_offset = _pos_to_offset(src, start_pos)?
+        var end_offset = _pos_to_offset(src, end_pos')?
+        if end_offset >= start_offset then
+          var extracted: String val =
+            recover val
+              src.substring(
+                ISize.from[USize](start_offset),
+                ISize.from[USize](end_offset + 1))
+                .> strip()
+            end
+
+          var missing_ends = _count_unmatched_ends(extracted)
+          while missing_ends > 0 do
+            end_offset = _scan_to_next_end(src, end_offset + 1)?
+            missing_ends = missing_ends - 1
+          end
+
+          if missing_ends == 0 then
+            extracted =
+              recover val
+                src.substring(
+                  ISize.from[USize](start_offset),
+                  ISize.from[USize](end_offset + 1))
+                  .> strip()
+              end
+          end
+          extracted
+        end
+      end
+    end
+
+  fun _count_unmatched_ends(text: String val): USize =>
+    let openers =
+      [ as String:
+        "recover"; "if"; "ifdef"; "iftype"; "match"; "while"; "for"
+        "repeat"; "object"; "lambda"; "try"]
+    var opens: USize = 0
+    var ends: USize = 0
+    var i: USize = 0
+    let size = text.size()
+    while i < size do
+      try
+        while (i < size) and not _is_word_char(text(i)?) do
+          if text(i)? == '"' then
+            i = i + 1
+            if ((i + 1) < size) and (text(i)? == '"') and
+              (text(i + 1)? == '"')
+            then
+              i = i + 2
+              while (i + 2) < size do
+                if (text(i)? == '"') and (text(i + 1)? == '"') and
+                  (text(i + 2)? == '"')
+                then
+                  i = i + 3
+                  break
+                end
+                i = i + 1
+              end
+            else
+              while (i < size) and (text(i)? != '"') do
+                i = i + 1
+              end
+              if i < size then i = i + 1 end
+            end
+          else
+            i = i + 1
+          end
+        end
+      end
+      let word_start = i
+      try
+        while (i < size) and _is_word_char(text(i)?) do
+          i = i + 1
+        end
+      end
+      if i > word_start then
+        let word: String val =
+          text.substring(
+            ISize.from[USize](word_start),
+            ISize.from[USize](i))
+        if word == "end" then
+          ends = ends + 1
+        else
+          for opener in openers.values() do
+            if word == opener then
+              opens = opens + 1
+              break
+            end
+          end
+        end
+      end
+    end
+    if opens > ends then opens - ends else 0 end
+
+  fun _is_word_char(c: U8): Bool =>
+    ((c >= 'a') and (c <= 'z')) or
+    ((c >= 'A') and (c <= 'Z')) or
+    ((c >= '0') and (c <= '9')) or
+    (c == '_')
+
+  fun _scan_to_next_end(
+    src: String box,
+    from: USize)
+    : USize ?
+  =>
+    var i = from
+    let size = src.size()
+    while i < size do
+      if not _is_word_char(src(i)?) then
+        i = i + 1
+      else
+        let word_start = i
+        while (i < size) and _is_word_char(src(i)?) do
+          i = i + 1
+        end
+        if (src.substring(
+          ISize.from[USize](word_start), ISize.from[USize](i)) == "end")
+        then
+          return i - 1
+        end
+      end
+    end
+    error
+
+  fun _pos_to_offset(
+    src: String box,
+    p: ast.Position)
+    : USize ?
+  =>
+    if p.line() == 1 then
+      p.column() - 1
+    else
+      let line_idx = src.find("\n" where nth = p.line() - 2)?
+      line_idx.usize() + p.column()
+    end
+
+  fun _get_ponypath(vars: Array[String val] val): String val =>
+    for pair in vars.values() do
+      if pair.at("PONYPATH=") then
+        return pair.substring(ISize(9))
+      end
+    end
+    ""
+
+  fun _compile(
+    h: TestHelper,
+    source: String val)
+    : ast.Program val ?
+  =>
+    let auth = h.env.root
+    let tmp =
+      FilePath.mkdtemp(
+        FileAuth(auth), "pony-doc-test")?
+    let pony_file =
+      FilePath(
+        FileAuth(auth), Path.join(tmp.path, "test.pony"))
+    let file = File(pony_file)
+    file.write(source)
+    file.dispose()
+
+    let pony_path = _get_ponypath(h.env.vars)
+
+    let session =
+      ast.CompileSession(
+        tmp where package_search_paths = pony_path,
+        limit = ast.PassParse)
+    let result =
+      try
+        match session.program()
+        | let program: ast.Program val =>
+          if not session.continue_to(ast.PassTraits) then
+            session.dispose()
+            h.fail("compilation failed past parse")
+            error
+          end
+          session.dispose()
+          program
+        else
+          session.dispose()
+          h.fail("compilation failed")
+          error
+        end
+      else
+        h.assert_true(tmp.remove(), "tmpdir cleanup failed")
+        error
+      end
+    h.assert_true(tmp.remove(), "tmpdir cleanup failed")
+    result

--- a/tools/pony-doc/test/main.pony
+++ b/tools/pony-doc/test/main.pony
@@ -32,6 +32,19 @@ actor \nodoc\ Main is TestList
     test(_TestMethodKindStrings)
     test(_TestFieldKindStrings)
 
+    // DefaultValue tests
+    test(_TestDefaultValueCallExpr)
+    test(_TestDefaultValueIntLiteral)
+    test(_TestDefaultValueStringLiteral)
+    test(_TestDefaultValueNegation)
+    test(_TestDefaultValueMultipleParams)
+    test(_TestDefaultValueBoolLiteral)
+    test(_TestDefaultValueFloatLiteral)
+    test(_TestDefaultValueNoneValue)
+    test(_TestDefaultValueRecoverBlock)
+    test(_TestDefaultValueMultiLine)
+    test(_TestDefaultValueNone)
+
     // TypeRenderer tests
     test(_TestRenderNominalNoLink)
     test(_TestRenderNominalWithLink)


### PR DESCRIPTION
pony-doc called `get_print()` on default-value AST nodes, which returns the token keyword ("call", "reference", "prefix") rather than the source text a user wrote (`ISize.max_value()`, `-1`).

The lexer now records each token's byte length. pony-doc uses it to compute accurate source spans and extract the original text directly. Multi-line tokens (triple-quoted strings) are handled by scanning the source for newlines within the token span. Block constructs (`recover ... end`, `if ... end`, etc.) whose closing `end` keyword isn't in the AST are balanced by scanning forward for matching `end` keywords.

Closes #3323
Closes #1262
