### PR TITLE
Fix stack overflow in itertools Iter methods

### DIFF
--- a/.release-notes/fix-itertools-unbounded-recursion.md
+++ b/.release-notes/fix-itertools-unbounded-recursion.md
@@ -1,0 +1,3 @@
+## Fix stack overflow in itertools Iter methods
+
+Several methods on `Iter` in the `itertools` package used unbounded recursion internally and could crash on larger iterators. This has been fixed.

--- a/packages/itertools/_test.pony
+++ b/packages/itertools/_test.pony
@@ -1,4 +1,5 @@
 use "collections"
+use "pony_check"
 use "pony_test"
 use "time"
 
@@ -11,15 +12,28 @@ actor \nodoc\ Main is TestList
     test(_TestIterAll)
     test(_TestIterAny)
     test(_TestIterChain)
+    test(Property1UnitTest[Array[USize]](_IterChainProperty))
+    test(_TestIterChainDeepPath)
     test(_TestIterCollect)
     test(_TestIterCount)
     test(_TestIterCycle)
     test(_TestIterDedup)
+    test(Property1UnitTest[Array[USize]](_IterDedupProperty))
+    test(_TestIterDedupDeepPath)
+    test(_TestIterDedupEdgeCases)
     test(_TestIterEnum)
     test(_TestIterFilter)
+    test(Property1UnitTest[Array[USize]](_IterFilterProperty))
+    test(_TestIterFilterDeepPath)
+    test(_TestIterFilterEdgeCases)
     test(_TestIterFilterMap)
+    test(Property1UnitTest[Array[USize]](_IterFilterMapProperty))
+    test(_TestIterFilterMapDeepPath)
+    test(_TestIterFilterMapEdgeCases)
     test(_TestIterFind)
     test(_TestIterFlatMap)
+    test(Property1UnitTest[Array[USize]](_IterFlatMapProperty))
+    test(_TestIterFlatMapDeepPath)
     test(_TestIterFold)
     test(_TestIterInterleave)
     test(_TestIterInterleaveShortest)
@@ -30,12 +44,16 @@ actor \nodoc\ Main is TestList
     test(_TestIterNth)
     test(_TestIterRepeatValue)
     test(_TestIterRun)
+    test(_TestIterRunDeepPath)
     test(_TestIterSkip)
     test(_TestIterSkipWhile)
     test(_TestIterStepBy)
     test(_TestIterTake)
     test(_TestIterTakeWhile)
     test(_TestIterUnique)
+    test(Property1UnitTest[Array[USize]](_IterUniqueProperty))
+    test(_TestIterUniqueDeepPath)
+    test(_TestIterUniqueEdgeCases)
     test(_TestIterZip)
 
 class \nodoc\ iso _TestIterChain is UnitTest
@@ -639,3 +657,323 @@ class \nodoc\ iso _TestIterZip is UnitTest
     h.assert_array_eq[F32](expected3, actual3)
     h.assert_array_eq[I32](expected4, actual4)
     h.assert_array_eq[USize](expected5, actual5)
+
+class \nodoc\ iso _IterChainProperty is Property1[Array[USize]]
+  fun name(): String => "itertools/Iter.chain (property)"
+
+  fun gen(): Generator[Array[USize]] =>
+    Generators.array_of[USize](Generators.usize(0, 99))
+
+  fun ref property(input: Array[USize], h: PropertyHelper) =>
+    let third = input.size() / 3
+    let a = Array[USize]
+    let b = Array[USize]
+    let c = Array[USize]
+    for (i, v) in input.pairs() do
+      if i < third then a.push(v)
+      elseif i < (third * 2) then b.push(v)
+      else c.push(v)
+      end
+    end
+    let result =
+      Iter[USize].chain(
+        [a.values(); b.values(); c.values()].values())
+        .collect(Array[USize])
+    h.assert_array_eq[USize](input, result)
+
+class \nodoc\ iso _IterDedupProperty is Property1[Array[USize]]
+  fun name(): String => "itertools/Iter.dedup (property)"
+
+  fun gen(): Generator[Array[USize]] =>
+    Generators.array_of[USize](Generators.usize(0, 5))
+
+  fun ref property(input: Array[USize], h: PropertyHelper) =>
+    let expected = Array[USize]
+    var prev: (USize | None) = None
+    for v in input.values() do
+      let is_dup =
+        match prev
+        | let p: USize => p == v
+        else false
+        end
+      if not is_dup then
+        expected.push(v)
+      end
+      prev = v
+    end
+    let actual =
+      Iter[USize](input.values()).dedup().collect(Array[USize])
+    h.assert_array_eq[USize](expected, actual)
+
+    var last: (USize | None) = None
+    for v in actual.values() do
+      match last
+      | let l: USize =>
+        h.assert_true(v != l, "consecutive duplicate in dedup output")
+      end
+      last = v
+    end
+
+class \nodoc\ iso _IterFilterProperty is Property1[Array[USize]]
+  fun name(): String => "itertools/Iter.filter (property)"
+
+  fun gen(): Generator[Array[USize]] =>
+    Generators.array_of[USize](Generators.usize(0, 99))
+
+  fun ref property(input: Array[USize], h: PropertyHelper) =>
+    let expected = Array[USize]
+    for v in input.values() do
+      if (v % 3) == 0 then expected.push(v) end
+    end
+    let actual =
+      Iter[USize](input.values())
+        .filter({(x: USize): Bool => (x % 3) == 0 })
+        .collect(Array[USize])
+    h.assert_array_eq[USize](expected, actual)
+
+class \nodoc\ iso _IterFilterMapProperty is Property1[Array[USize]]
+  fun name(): String => "itertools/Iter.filter_map (property)"
+
+  fun gen(): Generator[Array[USize]] =>
+    Generators.array_of[USize](Generators.usize(0, 99))
+
+  fun ref property(input: Array[USize], h: PropertyHelper) =>
+    let expected = Array[USize]
+    for v in input.values() do
+      if (v % 2) == 0 then expected.push(v * 2) end
+    end
+    let actual =
+      Iter[USize](input.values())
+        .filter_map[USize]({(x: USize): (USize | None) =>
+          if (x % 2) == 0 then x * 2 end
+        })
+        .collect(Array[USize])
+    h.assert_array_eq[USize](expected, actual)
+
+class \nodoc\ iso _IterFlatMapProperty is Property1[Array[USize]]
+  fun name(): String => "itertools/Iter.flat_map (property)"
+
+  fun gen(): Generator[Array[USize]] =>
+    Generators.array_of[USize](Generators.usize(0, 4))
+
+  fun ref property(input: Array[USize], h: PropertyHelper) =>
+    let expected = Array[USize]
+    for v in input.values() do
+      for i in Range(0, v) do expected.push(i) end
+    end
+    let actual =
+      Iter[USize](input.values())
+        .flat_map[USize]({(x: USize): Iterator[USize] => Range(0, x) })
+        .collect(Array[USize])
+    h.assert_array_eq[USize](expected, actual)
+
+class \nodoc\ iso _IterUniqueProperty is Property1[Array[USize]]
+  fun name(): String => "itertools/Iter.unique (property)"
+
+  fun gen(): Generator[Array[USize]] =>
+    Generators.array_of[USize](Generators.usize(0, 20))
+
+  fun ref property(input: Array[USize], h: PropertyHelper) =>
+    let expected = Array[USize]
+    let seen = HashSet[USize, HashIs[USize]]
+    for v in input.values() do
+      if not seen.contains(v) then
+        expected.push(v)
+        seen.set(v)
+      end
+    end
+    let actual =
+      Iter[USize](input.values()).unique().collect(Array[USize])
+    h.assert_array_eq[USize](expected, actual)
+
+class \nodoc\ iso _TestIterChainDeepPath is UnitTest
+  fun name(): String => "itertools/Iter.chain (deep path)"
+
+  fun apply(h: TestHelper) =>
+    let n: USize = 1_000_000
+    let outers = Array[Iterator[USize]](n + 1)
+    for _ in Range(0, n) do
+      outers.push(Array[USize].create().values())
+    end
+    outers.push([as USize: 42].values())
+    let result =
+      Iter[USize].chain(outers.values()).collect(Array[USize])
+    h.assert_eq[USize](1, result.size())
+    h.assert_eq[USize](42, try result(0)? else 0 end)
+
+class \nodoc\ iso _TestIterDedupDeepPath is UnitTest
+  fun name(): String => "itertools/Iter.dedup (deep path)"
+
+  fun apply(h: TestHelper) =>
+    let n: USize = 1_000_000
+    let input = Array[USize](n + 1)
+    for _ in Range(0, n) do input.push(0) end
+    input.push(1)
+    let result =
+      Iter[USize](input.values()).dedup().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 0; 1], result)
+
+class \nodoc\ iso _TestIterFilterDeepPath is UnitTest
+  fun name(): String => "itertools/Iter.filter (deep path)"
+
+  fun apply(h: TestHelper) =>
+    let n: USize = 1_000_000
+    let result =
+      Iter[USize](Range(0, n + 1))
+        .filter({(x: USize): Bool => x == n })
+        .collect(Array[USize])
+    h.assert_eq[USize](1, result.size())
+    h.assert_eq[USize](n, try result(0)? else 0 end)
+
+class \nodoc\ iso _TestIterFilterMapDeepPath is UnitTest
+  fun name(): String => "itertools/Iter.filter_map (deep path)"
+
+  fun apply(h: TestHelper) =>
+    let n: USize = 1_000_000
+    let result =
+      Iter[USize](Range(0, n + 1))
+        .filter_map[USize]({(x: USize): (USize | None) =>
+          if x == n then x end
+        })
+        .collect(Array[USize])
+    h.assert_eq[USize](1, result.size())
+    h.assert_eq[USize](n, try result(0)? else 0 end)
+
+class \nodoc\ iso _TestIterFlatMapDeepPath is UnitTest
+  fun name(): String => "itertools/Iter.flat_map (deep path)"
+
+  fun apply(h: TestHelper) =>
+    let n: USize = 1_000_000
+    let result =
+      Iter[USize](Range(0, n + 1))
+        .flat_map[USize]({(x: USize): Iterator[USize] =>
+          if x == n then Range[USize](0, 3)
+          else Range[USize](0, 0)
+          end
+        })
+        .collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 0; 1; 2], result)
+
+class \nodoc\ iso _TestIterUniqueDeepPath is UnitTest
+  fun name(): String => "itertools/Iter.unique (deep path)"
+
+  fun apply(h: TestHelper) =>
+    let n: USize = 1_000_000
+    let input = Array[USize](n + 1)
+    for _ in Range(0, n) do input.push(0) end
+    input.push(1)
+    let result =
+      Iter[USize](input.values()).unique().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 0; 1], result)
+
+class \nodoc\ iso _TestIterRunDeepPath is UnitTest
+  fun name(): String => "itertools/Iter.run (deep path)"
+
+  fun apply(h: TestHelper) =>
+    let n: USize = 1_000_000
+    let iter = Iter[USize](Range(0, n))
+    iter.run()
+    h.assert_false(iter.has_next())
+
+class \nodoc\ iso _TestIterDedupEdgeCases is UnitTest
+  fun name(): String => "itertools/Iter.dedup (edge cases)"
+
+  fun apply(h: TestHelper) =>
+    var result = Iter[USize](Array[USize].create().values())
+      .dedup().collect(Array[USize])
+    h.assert_eq[USize](0, result.size())
+
+    result = Iter[USize]([as USize: 1].values())
+      .dedup().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1], result)
+
+    result = Iter[USize]([as USize: 1; 1; 1; 1; 1].values())
+      .dedup().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1], result)
+
+    result = Iter[USize]([as USize: 1; 2; 3; 4; 5].values())
+      .dedup().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1; 2; 3; 4; 5], result)
+
+    result = Iter[USize]([as USize: 1; 2; 1; 2; 1].values())
+      .dedup().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1; 2; 1; 2; 1], result)
+
+class \nodoc\ iso _TestIterFilterEdgeCases is UnitTest
+  fun name(): String => "itertools/Iter.filter (edge cases)"
+
+  fun apply(h: TestHelper) =>
+    var result = Iter[USize](Array[USize].create().values())
+      .filter({(x: USize): Bool => true })
+      .collect(Array[USize])
+    h.assert_eq[USize](0, result.size())
+
+    result = Iter[USize]([as USize: 1].values())
+      .filter({(x: USize): Bool => true })
+      .collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1], result)
+
+    result = Iter[USize]([as USize: 1].values())
+      .filter({(x: USize): Bool => false })
+      .collect(Array[USize])
+    h.assert_eq[USize](0, result.size())
+
+    result = Iter[USize]([as USize: 1; 2; 3; 4; 5].values())
+      .filter({(x: USize): Bool => true })
+      .collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1; 2; 3; 4; 5], result)
+
+    result = Iter[USize]([as USize: 1; 2; 3; 4; 5].values())
+      .filter({(x: USize): Bool => false })
+      .collect(Array[USize])
+    h.assert_eq[USize](0, result.size())
+
+class \nodoc\ iso _TestIterFilterMapEdgeCases is UnitTest
+  fun name(): String => "itertools/Iter.filter_map (edge cases)"
+
+  fun apply(h: TestHelper) =>
+    var result = Iter[USize](Array[USize].create().values())
+      .filter_map[USize]({(x: USize): (USize | None) => x })
+      .collect(Array[USize])
+    h.assert_eq[USize](0, result.size())
+
+    result = Iter[USize]([as USize: 1; 2; 3].values())
+      .filter_map[USize]({(x: USize): (USize | None) => x * 2 })
+      .collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 2; 4; 6], result)
+
+    result = Iter[USize]([as USize: 1; 2; 3].values())
+      .filter_map[USize]({(x: USize): (USize | None) => None })
+      .collect(Array[USize])
+    h.assert_eq[USize](0, result.size())
+
+    result = Iter[USize]([as USize: 0; 1; 2; 3; 4].values())
+      .filter_map[USize]({(x: USize): (USize | None) =>
+        if (x % 2) == 0 then x end
+      })
+      .collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 0; 2; 4], result)
+
+class \nodoc\ iso _TestIterUniqueEdgeCases is UnitTest
+  fun name(): String => "itertools/Iter.unique (edge cases)"
+
+  fun apply(h: TestHelper) =>
+    var result = Iter[USize](Array[USize].create().values())
+      .unique().collect(Array[USize])
+    h.assert_eq[USize](0, result.size())
+
+    result = Iter[USize]([as USize: 1].values())
+      .unique().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1], result)
+
+    result = Iter[USize]([as USize: 1; 1; 1; 1; 1].values())
+      .unique().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1], result)
+
+    result = Iter[USize]([as USize: 1; 2; 3; 4; 5].values())
+      .unique().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1; 2; 3; 4; 5], result)
+
+    result = Iter[USize]([as USize: 1; 2; 3; 1; 2; 3].values())
+      .unique().collect(Array[USize])
+    h.assert_array_eq[USize]([as USize: 1; 2; 3], result)

--- a/packages/itertools/iter.pony
+++ b/packages/itertools/iter.pony
@@ -44,38 +44,44 @@ class Iter[A] is Iterator[A]
         var inner_iterator: (Iterator[A] | None) = None
 
         fun ref has_next(): Bool =>
-          if inner_iterator isnt None then
-            try
-              let iter = inner_iterator as Iterator[A]
-              if iter.has_next() then
-                return true
+          while true do
+            if inner_iterator isnt None then
+              try
+                let iter = inner_iterator as Iterator[A]
+                if iter.has_next() then
+                  return true
+                end
               end
             end
-          end
 
-          if outer_iterator.has_next() then
-            try
-              inner_iterator = outer_iterator.next()?
-              return has_next()
+            if outer_iterator.has_next() then
+              try
+                inner_iterator = outer_iterator.next()?
+              else
+                return false
+              end
+            else
+              return false
             end
           end
-
           false
 
         fun ref next(): A ? =>
-          if inner_iterator isnt None then
-            let iter = inner_iterator as Iterator[A]
+          while true do
+            if inner_iterator isnt None then
+              let iter = inner_iterator as Iterator[A]
 
-            if iter.has_next() then
-              return iter.next()?
+              if iter.has_next() then
+                return iter.next()?
+              end
+            end
+
+            if outer_iterator.has_next() then
+              inner_iterator = outer_iterator.next()?
+            else
+              error
             end
           end
-
-          if outer_iterator.has_next() then
-            inner_iterator = outer_iterator.next()?
-            return next()?
-          end
-
           error
       end
 
@@ -141,15 +147,14 @@ class Iter[A] is Iterator[A]
         var _next: (A! | _None) = _None
 
         fun ref _find_next() =>
-          try
-            match _next
-            | _None =>
-              if _iter.has_next() then
+          match _next
+          | _None =>
+            try
+              while _iter.has_next() do
                 let a = _iter.next()?
                 if try f(a)? else false end then
                   _next = a
-                else
-                  _find_next()
+                  return
                 end
               end
             end
@@ -191,13 +196,15 @@ class Iter[A] is Iterator[A]
         var _next: (B | _None) = _None
 
         fun ref _find_next() =>
-          try
-            match _next
-            | _None =>
-              if _iter.has_next() then
+          match _next
+          | _None =>
+            try
+              while _iter.has_next() do
                 match \exhaustive\ f(_iter.next()?)?
-                | let b: B => _next = consume b
-                | None => _find_next()
+                | let b: B =>
+                  _next = consume b
+                  return
+                | None => None
                 end
               end
             end
@@ -382,22 +389,27 @@ class Iter[A] is Iterator[A]
           _iter.has_next()
 
         fun ref next(): A! ? =>
-          let cur_value: A! = _iter.next()?
-          let cur_hash: USize = H.hash(cur_value)
-          match \exhaustive\ _prev_value
-          | let prev_value: A! =>
-            if (_prev_hash == cur_hash) and H.eq(prev_value, cur_value) then
-              this.next()?
-            else
+          while true do
+            let cur_value: A! = _iter.next()?
+            let cur_hash: USize = H.hash(cur_value)
+            match \exhaustive\ _prev_value
+            | let prev_value: A! =>
+              if (_prev_hash == cur_hash) and
+                H.eq(prev_value, cur_value)
+              then
+                None
+              else
+                _prev_value = cur_value
+                _prev_hash = cur_hash
+                return cur_value
+              end
+            | None =>
               _prev_value = cur_value
               _prev_hash = cur_hash
-              cur_value
+              return cur_value
             end
-          | None =>
-            _prev_value = cur_value
-            _prev_hash = cur_hash
-            cur_value
           end
+          error
       end)
 
   fun ref enum[B: (Real[B] val & Number) = USize](): Iter[(B, A)]^ =>
@@ -503,27 +515,28 @@ class Iter[A] is Iterator[A]
           try f(_iter.next()?)? else _EmptyIter[B] end
 
         fun ref has_next(): Bool =>
-          if _iterb.has_next() then true
-          else
+          while true do
+            if _iterb.has_next() then return true end
             if _iter.has_next() then
               try
                 _iterb = f(_iter.next()?)?
-                has_next()
               else
-                false
+                return false
               end
             else
-              false
+              return false
             end
           end
+          false
 
         fun ref next(): B ? =>
-          if _iterb.has_next() then
-            _iterb.next()?
-          else
+          while true do
+            if _iterb.has_next() then
+              return _iterb.next()?
+            end
             _iterb = f(_iter.next()?)?
-            next()?
           end
+          error
       end)
 
   fun ref fold[B](acc: B, f: {(B, A!): B^} box): B^ =>
@@ -738,12 +751,13 @@ class Iter[A] is Iterator[A]
     3
     ```
     """
-    if not _iter.has_next() then return end
-    try
-      _iter.next()?
-      run(on_error)
-    else
-      on_error()
+    while _iter.has_next() do
+      try
+        _iter.next()?
+      else
+        on_error()
+        return
+      end
     end
 
   fun ref skip(n: USize): Iter[A]^ =>
@@ -924,13 +938,14 @@ class Iter[A] is Iterator[A]
           _iter.has_next()
 
         fun ref next(): A! ? =>
-          let v = _iter.next()?
-          if _set.contains(v) then
-            next()?
-          else
-            _set.set(v)
-            v
+          while true do
+            let v = _iter.next()?
+            if not _set.contains(v) then
+              _set.set(v)
+              return v
+            end
           end
+          error
       end)
 
   fun ref zip[B](i2: Iterator[B]): Iter[(A, B)]^ =>


### PR DESCRIPTION
Seven `Iter` methods recursed once per rejected, empty, or duplicate element (or, for `run`, once per element): `chain`, `dedup`, `filter`, `filter_map`, `flat_map`, `run`, and `unique`. With enough consecutive rejections the call stack overflowed or, under tail-call optimization, the program hung.

Replaced each recursive call with a `while` loop. Added property tests, edge-case tests, and deep-path stress tests (1,000,000 consecutive rejections/empties/duplicates per combinator).

Closes #5934
