### PR TITLE
Fix lambda type inference failure with generic #share constraints

### DIFF
--- a/.release-notes/fix-lambda-inferred-share-constraint.md
+++ b/.release-notes/fix-lambda-inferred-share-constraint.md
@@ -1,0 +1,3 @@
+## Fix lambda type inference failure with generic #share constraints
+
+A generic class with a `#share`-constrained type parameter that passed a lambda with inferred parameter types to a generic method like `Iter.map` would fail to compile with "the type parameter has no lower bounds." Explicitly annotating the lambda's parameter types worked around the issue. Inferred parameter types now compile correctly.

--- a/src/libponyc/type/viewpoint.c
+++ b/src/libponyc/type/viewpoint.c
@@ -4,6 +4,7 @@
 #include "cap.h"
 #include "type_assume.h"
 #include "typealias.h"
+#include "typeparam.h"
 #include "../ast/astbuild.h"
 #include "ponyassert.h"
 
@@ -534,7 +535,8 @@ static ast_t* find_typeparamref_in(ast_t* ast, ast_t* target)
 {
   if(ast_id(ast) == TK_TYPEPARAMREF)
   {
-    if(ast_data(ast) == ast_data(target))
+    if(typeparam_root((ast_t*)ast_data(ast)) ==
+      typeparam_root((ast_t*)ast_data(target)))
       return ast;
     return NULL;
   }
@@ -695,7 +697,8 @@ bool viewpoint_reifypair(ast_t* a, ast_t* b, ast_t** r_a, ast_t** r_b, pass_opt_
         {
           ast_t* candidate = ast_child(test_b);
           if((ast_id(candidate) == TK_TYPEPARAMREF) &&
-            (ast_data(candidate) == ast_data(left_a)))
+            (typeparam_root((ast_t*)ast_data(candidate)) ==
+              typeparam_root((ast_t*)ast_data(left_a))))
             left_b = candidate;
         }
 
@@ -724,7 +727,8 @@ bool viewpoint_reifypair(ast_t* a, ast_t* b, ast_t** r_a, ast_t** r_b, pass_opt_
     // refers to the same type parameter.
     ast_t* tp_b = test_a;
     if((ast_id(test_b) == TK_TYPEPARAMREF) &&
-      (ast_data(test_b) == ast_data(test_a)))
+      (typeparam_root((ast_t*)ast_data(test_b)) ==
+        typeparam_root((ast_t*)ast_data(test_a))))
       tp_b = test_b;
 
     *r_b = viewpoint_reifytypeparam(b, tp_b, opt);

--- a/test/full-program-tests/regression-2820/main.pony
+++ b/test/full-program-tests/regression-2820/main.pony
@@ -1,0 +1,26 @@
+// Regression test for https://github.com/ponylang/ponyc/issues/2820
+//
+// A generic class with a constrained type parameter that passes a lambda with
+// inferred parameter types to a generic method like Iter.map. The lambda's
+// inferred parameter type references the enclosing class's type parameter, but
+// the lifted lambda class has its own copy. If the compiler compares these by
+// identity rather than equivalence, the type parameter goes unrecognized and
+// compilation fails with "the type parameter has no lower bounds."
+
+use "collections"
+use "itertools"
+
+class Outer[Info: Any #share]
+  let _data: Map[String, Map[String, Info]] =
+    Map[String, Map[String, Info]]
+
+  fun test() =>
+    Iter[(String, Map[String, Info] box!)](_data.pairs())
+      .map[Iter[(String, Info)]]({
+        (k_m) =>
+          Iter[(String, Info)](k_m._2.pairs())
+      })
+
+actor Main
+  new create(env: Env) =>
+    None


### PR DESCRIPTION
When a generic class with a `#share`-constrained type parameter passes a lambda with inferred parameter types to a generic method like `Iter.map`, the compiler lifts the lambda to an anonymous class whose type parameters are copies of the enclosing class's. The inferred parameter type still references the outer class's type parameter definition, while the anonymous class's method signatures reference the copy.

`find_typeparamref_in` and two comparison sites in `viewpoint_reifypair` compared type parameter definition-node pointers directly, so the outer and copied definitions didn't match, the arrow type was left unreduced, and compilation failed with "the type parameter has no lower bounds." Explicitly annotating the lambda's parameter types worked around the problem because the annotation resolved in the lambda's own scope, where both sides used the copy.

The fix uses `typeparam_root()` — which follows each definition's chain to its original — so copies that root to the same source compare equal. This is the same function already used for this purpose in `matchtype.c`, `reify.c`, `subtype.c`, and `flatten.c`.

Closes #2820
