### PR TITLE
Fix soundness bug with aliased type parameter constraints

### DIFF
--- a/.release-notes/fix-typeparam-constraint-aliased.md
+++ b/.release-notes/fix-typeparam-constraint-aliased.md
@@ -1,0 +1,23 @@
+## Fix soundness bug with aliased type parameter constraints
+
+When a type parameter's constraint used `!` on another type parameter, the compiler ignored the `!` modifier. This was a soundness hole: the compiler accepted code that violated reference capability guarantees.
+
+The `!` modifier aliases a capability — `iso` becomes `tag`, `trn` becomes `box`. In this example, X should be constrained to `A tag` (because `Y!` where `Y: A iso` means "the aliased form of `A iso`," which is `A tag`). Before this fix, the compiler treated X as `A iso`, allowing code like this to compile:
+
+```pony
+class A
+  var data: String = "hello"
+
+actor Main
+  new create(env: Env) =>
+    let opaque: A tag = A
+    // This should not compile — opaque is tag, not iso
+    let stolen: A iso = reveal[A tag, A iso](opaque)
+
+  fun reveal[X: Y!, Y: A iso](x: X): A iso^ =>
+    consume x
+```
+
+The compiler now correctly rejects this code because `consume x` produces `A tag^`, not `A iso^`.
+
+If your code stops compiling after this fix, look for type parameters constrained with `!` through another type parameter — the `!` is now enforced, so the constraint is tighter than it was before. The compiler error will show the actual capability. Adjust your code to work with the aliased capability (e.g. `tag` instead of `iso`, `box` instead of `trn`).

--- a/src/libponyc/pass/syntax.c
+++ b/src/libponyc/pass/syntax.c
@@ -888,10 +888,52 @@ static ast_result_t syntax_embed(pass_opt_t* opt, ast_t* ast)
 }
 
 
+static bool check_constraint_ephemeral(pass_opt_t* opt, ast_t* type)
+{
+  if(type == NULL || ast_id(type) == TK_NONE)
+    return true;
+
+  switch(ast_id(type))
+  {
+    case TK_NOMINAL:
+    {
+      AST_GET_CHILDREN(type, ign0, ign1, ign2, ign3, ephemeral);
+
+      if(ast_id(ephemeral) == TK_EPHEMERAL)
+      {
+        ast_error(opt->check.errors, ephemeral,
+          "can't specify ephemeral (^) in a type parameter constraint");
+        return false;
+      }
+
+      return true;
+    }
+
+    case TK_UNIONTYPE:
+    case TK_ISECTTYPE:
+    case TK_TUPLETYPE:
+      for(ast_t* p = ast_child(type); p != NULL; p = ast_sibling(p))
+      {
+        if(!check_constraint_ephemeral(opt, p))
+          return false;
+      }
+
+      return true;
+
+    default:
+      return true;
+  }
+}
+
+
 static ast_result_t syntax_type_param(pass_opt_t* opt, ast_t* ast)
 {
-
   if(!check_id_type_param(opt, ast_child(ast)))
+    return AST_ERROR;
+
+  ast_t* constraint = ast_childidx(ast, 1);
+
+  if(!check_constraint_ephemeral(opt, constraint))
     return AST_ERROR;
 
   return AST_OK;

--- a/src/libponyc/type/typeparam.c
+++ b/src/libponyc/type/typeparam.c
@@ -664,16 +664,68 @@ static bool apply_cap(ast_t* type, token_id tcap, token_id teph)
   return false;
 }
 
+static token_id combine_ephemerals(token_id a, token_id b)
+{
+  if(a == TK_NONE)
+    return b;
+
+  if(b == TK_NONE)
+    return a;
+
+  if(a == b)
+    return a;
+
+  // TK_EPHEMERAL + TK_ALIASED cancel out (and vice versa).
+  return TK_NONE;
+}
+
+static ast_t* typeparam_constraint_with_eph(ast_t* typeparamref,
+  token_id* chain_eph)
+{
+  pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
+  ast_t* def = (ast_t*)ast_data(typeparamref);
+  ast_t* constraint = ast_childidx(def, 1);
+  token_id accumulated_eph = TK_NONE;
+  astlist_t* def_list = astlist_push(NULL, def);
+
+  while(ast_id(constraint) == TK_TYPEPARAMREF)
+  {
+    ast_t* constraint_def = (ast_t*)ast_data(constraint);
+
+    if(astlist_find(def_list, constraint_def))
+    {
+      constraint = NULL;
+      break;
+    }
+
+    // When a constraint is written as Y!, the ! must be applied to the
+    // terminal constraint's capability.
+    ast_t* c_eph = ast_childidx(constraint, 2);
+    accumulated_eph = combine_ephemerals(accumulated_eph, ast_id(c_eph));
+
+    def_list = astlist_push(def_list, constraint_def);
+    constraint = ast_childidx(constraint_def, 1);
+  }
+
+  astlist_free(def_list);
+
+  if(chain_eph != NULL)
+    *chain_eph = accumulated_eph;
+
+  return constraint;
+}
+
 static ast_t* constraint_cap(ast_t* typeparamref)
 {
-  ast_t* constraint = typeparam_constraint(typeparamref);
+  token_id chain_eph = TK_NONE;
+  ast_t* constraint = typeparam_constraint_with_eph(typeparamref, &chain_eph);
 
   if(constraint == NULL)
     return NULL;
 
   AST_GET_CHILDREN(typeparamref, id, cap, eph);
   token_id tcap = ast_id(cap);
-  token_id teph = ast_id(eph);
+  token_id teph = combine_ephemerals(ast_id(eph), chain_eph);
 
   ast_t* r_constraint;
 
@@ -697,27 +749,7 @@ static ast_t* constraint_cap(ast_t* typeparamref)
 
 ast_t* typeparam_constraint(ast_t* typeparamref)
 {
-  pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
-  ast_t* def = (ast_t*)ast_data(typeparamref);
-  ast_t* constraint = ast_childidx(def, 1);
-  astlist_t* def_list = astlist_push(NULL, def);
-
-  while(ast_id(constraint) == TK_TYPEPARAMREF)
-  {
-    ast_t* constraint_def = (ast_t*)ast_data(constraint);
-
-    if(astlist_find(def_list, constraint_def))
-    {
-      constraint = NULL;
-      break;
-    }
-
-    def_list = astlist_push(def_list, constraint_def);
-    constraint = ast_childidx(constraint_def, 1);
-  }
-
-  astlist_free(def_list);
-  return constraint;
+  return typeparam_constraint_with_eph(typeparamref, NULL);
 }
 
 ast_t* typeparam_root(ast_t* def)
@@ -752,8 +784,14 @@ void typeparam_set_cap(ast_t* typeparamref)
 {
   pony_assert(ast_id(typeparamref) == TK_TYPEPARAMREF);
   AST_GET_CHILDREN(typeparamref, id, cap, eph);
-  ast_t* constraint = typeparam_constraint(typeparamref);
+  token_id chain_eph = TK_NONE;
+  ast_t* constraint = typeparam_constraint_with_eph(typeparamref, &chain_eph);
   token_id tcap = cap_from_constraint(constraint);
+
+  // When a constraint is written as Y! (aliased), the effective capability
+  // must reflect that aliasing — e.g. iso aliased becomes tag.
+  cap_aliasing(&tcap, &chain_eph);
+
   ast_setid(cap, tcap);
 }
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -3773,3 +3773,97 @@ TEST_F(BadPonyTest, ExportAnnotationOnInterfaceTypeAlias)
     "must refer to a class, primitive, struct, or actor, not an interface");
 }
 
+TEST_F(BadPonyTest, AliasedConstraintOnTypeParamRef)
+{
+  // From issue #1889
+  // The ! modifier in X: Y! should alias Y's capability. When Y is A iso,
+  // Y! is A tag, so X can only be A tag — not A iso.
+  const char* src =
+    "class A\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let opaque : A tag = A\n"
+    "    let not_opaque : A iso = reveal[A tag, A iso](opaque)\n"
+    "  fun reveal[X: Y!, Y: A iso](x: X) : A iso^ =>\n"
+    "    consume x\n";
+
+  TEST_ERRORS_1(src, "function body isn't the result type");
+}
+
+TEST_F(BadPonyTest, AliasedConstraintOnTypeParamRefChain)
+{
+  // From issue #1889 — 3-type-param chain
+  // X: Y!, Y: Z, Z: A iso should give X the capability A tag because ! aliases
+  // the terminal constraint's iso to tag.
+  const char* src =
+    "class A\n"
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun reveal[X: Y!, Y: Z, Z: A iso](x: X) : A iso^ =>\n"
+    "    consume x\n";
+
+  TEST_ERRORS_1(src, "function body isn't the result type");
+}
+
+TEST_F(BadPonyTest, EphemeralOnTypeParamConstraint)
+{
+  // ^ on a type parameter constraint has no defined semantics and is rejected.
+  const char* src =
+    "class A\n"
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun reveal[X: A iso^](x: X): None =>\n"
+    "    None\n";
+
+  TEST_ERRORS_1(src,
+    "can't specify ephemeral (^) in a type parameter constraint");
+}
+
+TEST_F(BadPonyTest, EphemeralOnTypeParamConstraintChain)
+{
+  // ^ on a constraint in a chain would allow ^ and ! to cancel, bypassing
+  // the aliased constraint. The syntax pass rejects ^ on any constraint.
+  const char* src =
+    "class A\n"
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun reveal[X: Y^, Y: Z!, Z: A iso](x: X): A iso^ =>\n"
+    "    consume x\n";
+
+  TEST_ERRORS_1(src,
+    "can't specify ephemeral (^) in a type parameter constraint");
+}
+
+TEST_F(BadPonyTest, EphemeralOnTypeParamConstraintExploit)
+{
+  // Regression test for the soundness exploit: without the ^ rejection,
+  // X: Y^, Y: Z!, Z: A iso would allow converting A tag to A iso^.
+  const char* src =
+    "class A\n"
+    "  var data: String = \"hello\"\n"
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let opaque: A tag = A\n"
+    "    let stolen: A iso = reveal[A tag, A tag, A iso](opaque)\n"
+    "    stolen.data = \"pwned\"\n"
+    "  fun reveal[X: Y^, Y: Z!, Z: A iso](x: X): A iso^ =>\n"
+    "    consume x\n";
+
+  TEST_ERRORS_1(src,
+    "can't specify ephemeral (^) in a type parameter constraint");
+}
+
+TEST_F(BadPonyTest, AliasedConstraintOnTypeParamRefTrn)
+{
+  // From issue #1889 — trn variant
+  // Y! where Y is A trn gives A box, so consuming X should not satisfy A trn^.
+  const char* src =
+    "class A\n"
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun reveal[X: Y!, Y: A trn](x: X) : A trn^ =>\n"
+    "    consume x\n";
+
+  TEST_ERRORS_1(src, "function body isn't the result type");
+}
+


### PR DESCRIPTION
`typeparam_constraint()` follows a chain of type parameter constraints (X→Y→A iso) and returns the terminal constraint, but it discards the `!` (aliased) modifier on intermediate TYPEPARAMREFs. When `X: Y!` where `Y: A iso`, the compiler treated X as `A iso` instead of `A tag` — a soundness hole that allowed converting a `tag` reference to `iso^`.

The constraint chain walker now accumulates ephemeral modifiers from intermediate TYPEPARAMREFs. Both the subtyping bound computation (`constraint_cap`) and the capability assignment in the flatten pass (`typeparam_set_cap`) apply the accumulated ephemeral.

Also rejects `^` (ephemeral) on type parameter constraints. `^` on a constraint has no defined semantics, and would allow `^` and `!` to cancel each other in a chain (`X: Y^, Y: Z!, Z: A iso`), bypassing the aliased constraint fix.

Closes #1889
