### PR TITLE
Fix lambda capture types for fields accessed through non-ref receivers

### DIFF
--- a/.release-notes/fix-lambda-capture-field-types.md
+++ b/.release-notes/fix-lambda-capture-field-types.md
@@ -1,0 +1,20 @@
+## Fix lambda capture types for fields accessed through non-ref receivers
+
+Capturing a field in a lambda or object literal inside a method with a non-`ref` receiver (most commonly the default `box` receiver of `fun`) produced a spurious type error. The compiler typed the capture with the field's declared capability instead of adapting it through the method's receiver, so a `ref` field captured in a `fun box` method was typed as `ref` when it should have been `box`.
+
+Before this fix, the workaround was to specify the capture type explicitly:
+
+```pony
+class Foo
+  let _data: Array[U64]
+  new create() => _data = Array[U64]
+
+  fun box example() =>
+    // This failed: "box is not a subtype of ref"
+    {()(_data) => _data.size() }
+
+    // Workaround: specify the type manually
+    {()(x: Array[U64] box = _data) => x.size() }
+```
+
+Both the explicit capture syntax (`{()(field_name) => ...}`) and implicit captures in object literals are fixed.

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -15,8 +15,43 @@
 #include "../type/sanitise.h"
 #include "../type/subtype.h"
 #include "../type/typealias.h"
+#include "../type/viewpoint.h"
 #include "../pkg/package.h"
 #include "ponyassert.h"
+
+
+// For a field definition, return the aliased type as seen through `this` in
+// the current method (viewpoint-adapted). For a local/parameter, return the
+// aliased type directly.
+static ast_t* capture_type(pass_opt_t* opt, ast_t* def)
+{
+  switch(ast_id(def))
+  {
+    case TK_FVAR:
+    case TK_FLET:
+    case TK_EMBED:
+    {
+      token_id cap = cap_for_this(&opt->check);
+      ast_t* f_type = ast_type(def);
+      BUILD(cap_ast, f_type, NODE(cap));
+      ast_t* adapted = viewpoint_type(cap_ast, f_type, opt);
+      ast_free_unattached(cap_ast);
+
+      if(adapted == NULL)
+        return NULL;
+
+      ast_t* result = alias(adapted, opt);
+
+      if(result != adapted)
+        ast_free_unattached(adapted);
+
+      return result;
+    }
+
+    default:
+      return alias(ast_type(def), opt);
+  }
+}
 
 
 // Process the given capture and create the AST for the corresponding field.
@@ -107,7 +142,7 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
 
     BUILD(capture_rhs, id_node, NODE(TK_REFERENCE, ID(name)));
 
-    type = alias(ast_type(def), opt);
+    type = capture_type(opt, def);
     value = capture_rhs;
   } else if(ast_id(type) == TK_NONE) {
     // No type specified, use type of the captured expression
@@ -628,7 +663,7 @@ static bool capture_from_reference(pass_opt_t* opt, ast_t* ctx, ast_t* ast,
       return true;
   }
 
-  ast_t* type = alias(ast_type(refdef), opt);
+  ast_t* type = capture_type(opt, refdef);
 
   if(is_typecheck_error(type))
     return false;

--- a/test/libponyc/lambda.cc
+++ b/test/libponyc/lambda.cc
@@ -657,3 +657,134 @@ TEST_F(LambdaTest, TraitDefaultBodyWithImplicitLambdaCaptureParam)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(LambdaTest, LambdaCaptureFieldInBoxMethod)
+{
+  // From issue #1441 — explicit field capture in a box method should
+  // viewpoint-adapt the field type through `this`.
+  const char* src =
+    "class Bar\n"
+    "  fun val_method(): USize => 0\n"
+    "class Foo\n"
+    "  let _data: Bar\n"
+    "  new create() => _data = Bar\n"
+    "  fun box _test(): {(): USize} =>\n"
+    "    {()(_data): USize => _data.val_method()}";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(LambdaTest, LambdaCaptureFieldVarInBoxMethod)
+{
+  // From issue #1441 — var field capture in a box method.
+  const char* src =
+    "class Bar\n"
+    "  fun val_method(): USize => 0\n"
+    "class Foo\n"
+    "  var _data: Bar\n"
+    "  new create() => _data = Bar\n"
+    "  fun box _test(): {(): USize} =>\n"
+    "    {()(_data): USize => _data.val_method()}";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(LambdaTest, LambdaCaptureFieldInRefMethod)
+{
+  // Field capture in a ref method should still work (ref->ref = ref).
+  const char* src =
+    "class Bar\n"
+    "  fun val_method(): USize => 0\n"
+    "class Foo\n"
+    "  let _data: Bar\n"
+    "  new create() => _data = Bar\n"
+    "  fun ref _test(): {(): USize} =>\n"
+    "    {()(_data): USize => _data.val_method()}";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(LambdaTest, LambdaCaptureFieldEmbedInBoxMethod)
+{
+  // Embed field capture in a box method.
+  const char* src =
+    "class Bar\n"
+    "  fun val_method(): USize => 0\n"
+    "class Foo\n"
+    "  embed _data: Bar\n"
+    "  new create() => _data = Bar\n"
+    "  fun box _test(): {(): USize} =>\n"
+    "    {()(_data): USize => _data.val_method()}";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(LambdaTest, LambdaCaptureFieldInValMethod)
+{
+  // Field capture in a val method: val->ref = val.
+  const char* src =
+    "class Bar\n"
+    "  fun val_method(): USize => 0\n"
+    "class Foo\n"
+    "  let _data: Bar\n"
+    "  new create() => _data = Bar\n"
+    "  fun val _test(): {(): USize} =>\n"
+    "    {()(_data): USize => _data.val_method()}";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(LambdaTest, ObjectImplicitCaptureFieldInBoxMethod)
+{
+  // From issue #1441 — implicit field capture via object literal
+  // in a box method should viewpoint-adapt through `this`.
+  const char* src =
+    "interface Sizable\n"
+    "  fun size_of(): USize\n"
+    "class Bar\n"
+    "  fun val_method(): USize => 0\n"
+    "class Foo\n"
+    "  let _data: Bar\n"
+    "  new create() => _data = Bar\n"
+    "  fun box _test(): Sizable =>\n"
+    "    object is Sizable\n"
+    "      fun size_of(): USize => _data.val_method()\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(LambdaTest, ObjectImplicitCaptureFieldVarInBoxMethod)
+{
+  // Implicit var field capture via object literal in a box method.
+  const char* src =
+    "interface Sizable\n"
+    "  fun size_of(): USize\n"
+    "class Bar\n"
+    "  fun val_method(): USize => 0\n"
+    "class Foo\n"
+    "  var _data: Bar\n"
+    "  new create() => _data = Bar\n"
+    "  fun box _test(): Sizable =>\n"
+    "    object is Sizable\n"
+    "      fun size_of(): USize => _data.val_method()\n"
+    "    end";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(LambdaTest, LambdaCaptureFieldInBoxMethodRejectsRefCall)
+{
+  // A field captured through box this should be box-typed, so calling
+  // a ref method on it must fail.
+  const char* src =
+    "class Bar\n"
+    "  fun ref mut_method(): USize => 0\n"
+    "class Foo\n"
+    "  let _data: Bar\n"
+    "  new create() => _data = Bar\n"
+    "  fun box _test(): {(): USize} =>\n"
+    "    {()(_data): USize => _data.mut_method()}";
+
+  TEST_ERRORS_1(src, "receiver type is not a subtype of target type");
+}


### PR DESCRIPTION
When a lambda or object literal captures a field inside a method whose receiver isn't `ref` — most commonly the default `box` receiver of `fun` — the compiler typed the capture with the field's declared capability rather than adapting it through the receiver. A `ref` field captured in a `fun box` method was typed as `ref` when it should have been `box`, producing "box is not a subcap of ref^".

The two code paths that compute capture types — explicit lambda captures and implicit object literal captures — now viewpoint-adapt field types through the method's receiver capability, matching what `expr_fieldref` already does for normal field access.

Closes #1441
