### PR TITLE
Fix safe_field_move to reject ephemeral viewpoint lower bounds

### DIFF
--- a/src/libponyc/type/safeto.c
+++ b/src/libponyc/type/safeto.c
@@ -31,15 +31,45 @@ static bool safe_field_move(token_id cap, ast_t* type, direction direction,
     case TK_ARROW:
     {
       // Safe to write if the lower bounds is safe to write.
-      ast_t* upper = viewpoint_lower(type, opt);
+      ast_t* lower = viewpoint_lower(type, opt);
 
-      if(upper == NULL)
+      if(lower == NULL)
         return false;
 
-      bool ok = safe_field_move(cap, upper, direction, opt);
+      // An ephemeral lower bound marks a generic-cap approximation
+      // (e.g. lower(trn, #read) = trn^).  Some concrete members of the
+      // generic cap are less permissive than the bound — box is in #read
+      // but cap_safetomove(trn, box, WRITE) = false — and cap_safetomove
+      // is not monotonic under cap subtyping, so the bound passing does
+      // not imply all members pass.  Reject conservatively.
+      if(ast_id(lower) == TK_NOMINAL || ast_id(lower) == TK_TYPEPARAMREF)
+      {
+        ast_t* eph = ast_sibling(cap_fetch(lower));
 
-      if(upper != type)
-        ast_free_unattached(upper);
+        if(ast_id(eph) == TK_EPHEMERAL)
+        {
+          token_id lcap = ast_id(cap_fetch(lower));
+
+          // Only reject when cap_aliasing preserves the ephemeral —
+          // iso, trn, #send, #any.  For other caps (#read, #alias,
+          // #share, ref, val, box, tag), cap_aliasing strips the
+          // ephemeral, so the AST ephemeral is inert and the bound
+          // is concrete.
+          if(lcap == TK_ISO || lcap == TK_TRN ||
+            lcap == TK_CAP_SEND || lcap == TK_CAP_ANY)
+          {
+            if(lower != type)
+              ast_free_unattached(lower);
+
+            return false;
+          }
+        }
+      }
+
+      bool ok = safe_field_move(cap, lower, direction, opt);
+
+      if(lower != type)
+        ast_free_unattached(lower);
 
       return ok;
     }

--- a/test/libponyc/cap_safety.cc
+++ b/test/libponyc/cap_safety.cc
@@ -195,6 +195,77 @@ TEST_F(CapSafetyTest, NoWriteArrow)
   TEST_ERROR(src);
 }
 
+// Auto-recovery of a trn receiver with a generic-cap arrow argument must be
+// rejected when the generic cap includes members unsafe for trn.  The subtype
+// check catches these cases before safe_field_move runs; these tests verify
+// the compiler rejects the programs regardless of which check fires first.
+//
+// #read: lower(trn, #read) = trn^, but #read includes box and
+// cap_safetomove(trn, box, WRITE) = false.
+TEST_F(CapSafetyTest, NoAutorecoverTrnWithGenericReadArrowArg)
+{
+  const char* src =
+    "class Holder[A: Any #read]\n"
+    "  var data: A\n"
+    "  new create(d: A) => data = d\n"
+    "  fun ref replace(v: A) => data = v\n"
+    "\n"
+    "primitive Helper\n"
+    "  fun apply[B: Any #read](h: Holder[B] trn, other: Holder[B] trn) =>\n"
+    "    h.replace(other.data)\n";
+
+  TEST_ERROR(src);
+}
+
+// #alias: lower(trn, #alias) = trn^, but #alias includes ref and box.
+TEST_F(CapSafetyTest, NoAutorecoverTrnWithGenericAliasArrowArg)
+{
+  const char* src =
+    "class Holder[A: Any #alias]\n"
+    "  var data: A\n"
+    "  new create(d: A) => data = d\n"
+    "  fun ref replace(v: A) => data = v\n"
+    "\n"
+    "primitive Helper\n"
+    "  fun apply[B: Any #alias](h: Holder[B] trn, other: Holder[B] trn) =>\n"
+    "    h.replace(other.data)\n";
+
+  TEST_ERROR(src);
+}
+
+// #any (default): lower(trn, #any) = iso^, but #any includes ref and box.
+TEST_F(CapSafetyTest, NoAutorecoverTrnWithGenericAnyArrowArg)
+{
+  const char* src =
+    "class Holder[A]\n"
+    "  var data: A\n"
+    "  new create(d: A) => data = d\n"
+    "  fun ref replace(v: A) => data = v\n"
+    "\n"
+    "primitive Helper\n"
+    "  fun apply[B](h: Holder[B] trn, other: Holder[B] trn) =>\n"
+    "    h.replace(other.data)\n";
+
+  TEST_ERROR(src);
+}
+
+// #share: all members (val, tag) are safe to move into a trn, so this
+// should compile.
+TEST_F(CapSafetyTest, AutorecoverTrnWithGenericShareArrowArg)
+{
+  const char* src =
+    "class Holder[A: Any #share]\n"
+    "  var data: A\n"
+    "  new create(d: A) => data = d\n"
+    "  fun ref replace(v: A) => data = v\n"
+    "\n"
+    "primitive Helper\n"
+    "  fun apply[B: Any #share](h: Holder[B] trn, other: Holder[B] trn) =>\n"
+    "    h.replace(other.data)\n";
+
+  TEST_COMPILE(src);
+}
+
 // When a 'this->' viewpoint parameter can't accept the argument because the
 // receiver's capability reduces it to a generic cap (here #read), the error is
 // accompanied by two explanatory frames: one describing the 'this->' viewpoint


### PR DESCRIPTION
PR #5939 changed `cap_view_lower` so that `lower(trn, #read)` returns `trn^` instead of UNDEF. In `safe_field_move`, the TK_ARROW case calls `viewpoint_lower` and then recurses to the leaf, where `cap_single` strips the ephemeral — making `trn^` look like `trn`. `cap_safetomove(trn, trn, WRITE)` returns true, but `#read` includes `box`, and `cap_safetomove(trn, box, WRITE)` returns false.

The fix checks for ephemeral on the `viewpoint_lower` result before recursing. When the lower bound's cap is one where `cap_aliasing` preserves the ephemeral (iso, trn, #send, #any), the result is rejected conservatively. This is defense-in-depth: the subtype check at call sites catches all currently-reachable cases before `safe_field_move` runs, but `safe_field_move`'s contract should be correct regardless.

Also renames the local variable from `upper` to `lower` — `viewpoint_lower` returns a lower bound, and the old name was wrong.

Closes #5940
