### PR TITLE
Fix misleading error for bare lambda captures in tag methods

### DIFF
--- a/.release-notes/fix-bare-lambda-capture-tag-error.md
+++ b/.release-notes/fix-bare-lambda-capture-tag-error.md
@@ -1,0 +1,24 @@
+## Fix misleading error for bare lambda captures in tag methods
+
+Capturing a field by name in a lambda inside a `fun tag` method reported the wrong receiver in the error message:
+
+```pony
+class Holder
+  let _data: String ref
+  new create() => _data = String
+
+  fun tag example() =>
+    {()(_data) => None }
+```
+
+```
+can't read a field through {()} ref
+```
+
+The error now correctly names the enclosing type:
+
+```
+can't read a field through Holder tag
+```
+
+The equivalent explicit capture form (`{()(x = _data) => None}`) already reported the correct error. Both forms now produce the same message.

--- a/src/libponyc/expr/lambda.c
+++ b/src/libponyc/expr/lambda.c
@@ -23,7 +23,7 @@
 // For a field definition, return the aliased type as seen through `this` in
 // the current method (viewpoint-adapted). For a local/parameter, return the
 // aliased type directly.
-static ast_t* capture_type(pass_opt_t* opt, ast_t* def)
+static ast_t* capture_type(pass_opt_t* opt, ast_t* capture, ast_t* def)
 {
   switch(ast_id(def))
   {
@@ -39,6 +39,24 @@ static ast_t* capture_type(pass_opt_t* opt, ast_t* def)
 
       if(adapted == NULL)
         return NULL;
+
+      if(ast_id(adapted) == TK_ARROW)
+      {
+        ast_t* upper = viewpoint_upper(adapted, opt);
+
+        if(upper == NULL)
+        {
+          ast_t* this_type = type_for_this(opt, capture, cap, TK_NONE);
+          ast_error(opt->check.errors, capture,
+            "can't read a field through %s",
+            ast_print_type(this_type, opt->strtab));
+          ast_free_unattached(this_type);
+          ast_free_unattached(adapted);
+          return NULL;
+        }
+
+        ast_free_unattached(upper);
+      }
 
       ast_t* result = alias(adapted, opt);
 
@@ -142,7 +160,7 @@ static bool make_capture_field(pass_opt_t* opt, ast_t* capture,
 
     BUILD(capture_rhs, id_node, NODE(TK_REFERENCE, ID(name)));
 
-    type = capture_type(opt, def);
+    type = capture_type(opt, capture, def);
     value = capture_rhs;
   } else if(ast_id(type) == TK_NONE) {
     // No type specified, use type of the captured expression
@@ -663,7 +681,7 @@ static bool capture_from_reference(pass_opt_t* opt, ast_t* ctx, ast_t* ast,
       return true;
   }
 
-  ast_t* type = capture_type(opt, refdef);
+  ast_t* type = capture_type(opt, ast, refdef);
 
   if(is_typecheck_error(type))
     return false;

--- a/test/libponyc/lambda.cc
+++ b/test/libponyc/lambda.cc
@@ -10,6 +10,10 @@
   { const char* errs[] = {err1, NULL}; \
     DO(test_expected_errors(src, "expr", errs)); }
 
+#define TEST_ERRORS_2(src, err1, err2) \
+  { const char* errs[] = {err1, err2, NULL}; \
+    DO(test_expected_errors(src, "expr", errs)); }
+
 
 class LambdaTest : public PassTest
 {};
@@ -787,4 +791,51 @@ TEST_F(LambdaTest, LambdaCaptureFieldInBoxMethodRejectsRefCall)
     "    {()(_data): USize => _data.mut_method()}";
 
   TEST_ERRORS_1(src, "receiver type is not a subtype of target type");
+}
+
+TEST_F(LambdaTest, LambdaBareCaptureFieldInTagMethod)
+{
+  // From issue #5947 — bare field capture in a tag method must report
+  // the enclosing type, not the lambda's own receiver.
+  const char* src =
+    "class Foo\n"
+    "  let _data: String ref\n"
+    "  new create() => _data = String\n"
+    "  fun tag _test() =>\n"
+    "    {()(_data) => None }";
+
+  TEST_ERRORS_1(src, "can't read a field through Foo tag");
+}
+
+TEST_F(LambdaTest, LambdaBareCaptureFieldVarInTagMethod)
+{
+  // From issue #5947 — var field capture in a tag method.
+  const char* src =
+    "class Foo\n"
+    "  var _data: String ref\n"
+    "  new create() => _data = String\n"
+    "  fun tag _test() =>\n"
+    "    {()(_data) => None }";
+
+  TEST_ERRORS_1(src, "can't read a field through Foo tag");
+}
+
+TEST_F(LambdaTest, ObjectImplicitCaptureFieldInTagMethod)
+{
+  // From issue #5947 — implicit field capture via object literal
+  // in a tag method must report the enclosing type.
+  const char* src =
+    "interface Runnable\n"
+    "  fun apply(): None\n"
+    "class Foo\n"
+    "  let _data: String ref\n"
+    "  new create() => _data = String\n"
+    "  fun tag _test(): Runnable =>\n"
+    "    object is Runnable\n"
+    "      fun apply() => let x = _data\n"
+    "    end";
+
+  TEST_ERRORS_2(src,
+    "can't read a field through Foo tag",
+    "can't find declaration of '_data'");
 }


### PR DESCRIPTION
`capture_type()` in `lambda.c` did not check for an unresolvable arrow type after viewpoint adaptation. For a `tag->ref` viewpoint, `viewpoint_type` returns an unresolved arrow that became the generated lambda class's field type. When the lambda's constructor read this field, `expr_fieldref` blamed the lambda's own `ref` receiver instead of the enclosing `tag` method.

Added the same `viewpoint_upper` check that `expr_fieldref` uses: if the adapted type is an arrow and `viewpoint_upper` returns NULL, report the error naming the enclosing type. Covers both explicit lambda captures and implicit object literal captures.

Closes #5947
