### PR TITLE
Fix compiler crash when instantiating a generic with a union type argument that calls a constructor

### DIFF
--- a/.release-notes/fix-union-constructor-crash.md
+++ b/.release-notes/fix-union-constructor-crash.md
@@ -1,0 +1,25 @@
+## Fix compiler crash when instantiating a generic with a union type argument that calls a constructor
+
+Previously, instantiating a generic class that calls `T.create()` with a union type argument crashed the compiler with an assertion failure:
+
+```pony
+interface val Default
+  new val create()
+
+primitive A
+primitive B
+
+class Generic[T: (Default val | None val)]
+  let x: T = T.create()
+  fun get(): T => x
+
+actor Main
+  new create(env: Env) =>
+    Generic[(A | B)].get()
+```
+
+```
+src/libponyc/ast/error.c:73: ast_error_frame: Assertion `ast != NULL` failed.
+```
+
+The compiler now reports a proper error instead of crashing.

--- a/src/libponyc/codegen/codegen.c
+++ b/src/libponyc/codegen/codegen.c
@@ -10,6 +10,7 @@
 #include "../pkg/package.h"
 #include "../reach/paint.h"
 #include "../type/assemble.h"
+#include "../ast/error.h"
 #include "../type/lookup.h"
 #include "../../libponyrt/actor/actor.h"
 #include "../../libponyrt/mem/heap.h"
@@ -902,10 +903,10 @@ bool codegen_gen_test(compile_t* c, ast_t* program, pass_opt_t* opt,
     deferred_reify_free(main_create);
   }
 
-  // reach() can't signal failure through its void return. If it aborted on an
-  // over-large generic instantiation it already reported the error and left
-  // stub types behind, so fail before painting/codegen would touch them.
-  if(reach_limit_exceeded(c->reach))
+  // Bail before painting/codegen if reachability hit a limit or emitted
+  // errors (e.g. a method lookup failed on a union type).
+  if(reach_limit_exceeded(c->reach) ||
+    errors_get_count(opt->check.errors) > 0)
     return false;
 
   if(opt->limit == PASS_REACH)

--- a/src/libponyc/codegen/genexe.cc
+++ b/src/libponyc/codegen/genexe.cc
@@ -17,6 +17,7 @@ LLD_HAS_DRIVER(wasm)
 #include "genprim.h"
 #include "../reach/paint.h"
 #include "../reach/reach.h"
+#include "../ast/error.h"
 #include "../ast/printbuf.h"
 #include "../ast/stringtab.h"
 #include "../pkg/package.h"
@@ -2622,8 +2623,10 @@ bool genexe(compile_t* c, ast_t* program)
   // reach() can't signal failure through its void return. If it aborted on an
   // over-large generic instantiation it left stub types behind and already
   // reported the error, so fail now — before painting/codegen, which would
-  // touch those stubs.
-  if(reach_limit_exceeded(c->reach))
+  // touch those stubs. The same applies when reachability emits errors (e.g. a
+  // method lookup failed on a union type).
+  if(reach_limit_exceeded(c->reach) ||
+    errors_get_count(c->opt->check.errors) > 0)
   {
     ast_free(main_ast);
     ast_free(env_ast);

--- a/src/libponyc/reach/reach.c
+++ b/src/libponyc/reach/reach.c
@@ -297,7 +297,22 @@ static reach_method_name_t* add_method_name(reach_type_t* t, const char* name,
       n->cap = TK_BOX;
       n->internal = true;
     } else {
-      deferred_reification_t* fun = lookup(opt, NULL, t->ast, name);
+      deferred_reification_t* fun = lookup_try(opt, NULL, t->ast, name,
+        true);
+
+      if(fun == NULL)
+      {
+        ast_error(opt->check.errors, t->ast,
+          "can't find a compatible '%s' method on type '%s'",
+          name, ast_print_type(t->ast, opt->strtab));
+
+        reach_method_names_remove(&t->methods, n);
+        reach_methods_destroy(&n->r_methods);
+        reach_mangled_destroy(&n->r_mangled);
+        POOL_FREE(reach_method_name_t, n);
+        return NULL;
+      }
+
       ast_t* fun_ast = fun->ast;
       n->id = ast_id(fun_ast);
       n->cap = ast_id(ast_child(fun_ast));
@@ -539,6 +554,10 @@ static void add_rmethod_to_subtype(reach_t* r, reach_type_t* t,
 {
   // Add the method to the type if it isn't already there.
   reach_method_name_t* n2 = add_method_name(t, n->name, false, opt);
+
+  if(n2 == NULL)
+    return;
+
   add_rmethod(r, t, n2, m->cap, m->typeargs, opt, false);
 
   // Add this mangling to the type if it isn't already there.
@@ -1745,6 +1764,10 @@ static void reachable_method(reach_t* r, deferred_reification_t* reify,
   }
 
   reach_method_name_t* n = add_method_name(t, name, false, opt);
+
+  if(n == NULL)
+    return;
+
   reach_method_t* m = add_rmethod(r, t, n, n->cap, typeargs, opt, false);
 
   if((n->id == TK_FUN) && ((n->cap == TK_BOX) || (n->cap == TK_TAG)))


### PR DESCRIPTION
The reach pass called `lookup()` with `from=NULL` on union types, which hit an assertion failure in `ast_error_frame` when the lookup failed. Switching to `lookup_try()` suppresses the internal error machinery and lets `add_method_name` emit a proper diagnostic instead.

The compiler also needs to check for accumulated errors after `reach()` returns — without that, a failed lookup would emit the error but continue into painting and codegen with incomplete reach data.

No automated test — the C++ test framework's package processing simplifies the union constraint before the reach pass runs, so it exercises a different error path. The full-program test runner doesn't support expected compile errors. The fix was verified by manual test.

Closes #4096
