### PR TITLE
Use screendump-based boot detection for DragonFly VM

### DIFF
--- a/.ci-scripts/bsd/dfly_configure_vm.py
+++ b/.ci-scripts/bsd/dfly_configure_vm.py
@@ -6,19 +6,21 @@ Typing every command blind via VGA sendkey fails when boot is slow enough that
 keystrokes arrive before the login prompt.  This script uses a two-phase
 approach:
 
-  Phase 1 (sendkey bootstrap): After waiting for the boot loader to pass, type
-  the root login and a command that starts a /bin/sh on the serial port, all via
-  QEMU sendkey into the VGA console.  A retry loop handles the variable boot
-  time — each attempt clears the console, logs in, and starts the serial shell,
-  checking for a shell prompt on the serial socket before moving on.
+  Phase 1 (sendkey bootstrap): Wait for the boot to finish by taking periodic
+  VGA screendumps and detecting when the screen stabilizes (consecutive
+  identical frames).  Once stable — the login prompt is showing — type the root
+  login and a command that starts a /bin/sh on the serial port, all via QEMU
+  sendkey into the VGA console.  A retry loop handles the case where the first
+  attempt doesn't produce a serial shell.
 
   Phase 2 (serial setup): Run all setup commands (network, sshd, ssh key)
   through the serial console with prompt detection, so each command is confirmed
   before the next is sent.
 
-Reads PUB_KEY, DFLY_MONITOR_SOCK, and DFLY_SERIAL_SOCK from the environment.
-Called by dragonfly-provision.bash.
+Reads PUB_KEY, DFLY_MONITOR_SOCK, DFLY_SERIAL_SOCK, and (optionally)
+DFLY_ARTIFACTS_DIR from the environment.  Called by dragonfly-provision.bash.
 """
+import hashlib
 import os
 import socket
 import sys
@@ -38,9 +40,12 @@ KEYMAP = {
     '(': 'shift-9', ')': 'shift-0',
 }
 
-BOOT_LOADER_WAIT = 30
-BOOT_TIMEOUT = 300
+BIOS_WAIT = 5
+BOOT_TIMEOUT = 360
+STABLE_SECONDS = 10
+SCREENDUMP_INTERVAL = 5
 COMMAND_TIMEOUT = 60
+LOGIN_TIMEOUT = 300
 MAX_BOOTSTRAP_ATTEMPTS = 20
 SERIAL_DEVICE = '/dev/cuaa0'
 
@@ -107,22 +112,101 @@ def serial_cmd(sock, cmd, timeout=COMMAND_TIMEOUT):
         remaining = deadline - time.time()
         chunk = serial_recv(sock, timeout=min(2, max(0.1, remaining)))
         output += chunk
-        # The serial shell is /bin/sh running as root, whose default prompt
-        # ends with '#'.  None of the commands this script runs produce
-        # output ending with '#'.
         if output.rstrip().endswith('#'):
             return output
     raise RuntimeError(f"serial_cmd timed out after {timeout}s: {cmd!r}")
 
 
-def bootstrap_serial_shell(monitor, serial):
-    """Type login + serial shell start via sendkey; retry until serial responds.
+def screendump(monitor, path):
+    """Capture a VGA screendump to a file, return the raw bytes (or None)."""
+    send_hmp(monitor, f'screendump {path}')
+    time.sleep(0.5)
+    try:
+        with open(path, 'rb') as f:
+            return f.read()
+    except OSError:
+        return None
+
+
+def _ppm_pixel_hash(data):
+    """Hash just the pixel data of a PPM file, ignoring the header."""
+    if not data or not data.startswith(b'P6'):
+        return hashlib.sha1(data or b'').hexdigest()
+    pos = data.find(b'\n', 3)
+    if pos < 0:
+        return hashlib.sha1(data).hexdigest()
+    pos = data.find(b'\n', pos + 1)
+    if pos < 0:
+        return hashlib.sha1(data).hexdigest()
+    return hashlib.sha1(data[pos + 1:]).hexdigest()
+
+
+def wait_for_boot(monitor, artifacts_dir):
+    """Wait until the VGA console stabilizes, indicating boot is complete.
+
+    Takes periodic screendumps and compares their hashes.  Returns True once
+    the screen has been identical for STABLE_SECONDS, or False on timeout.
+    Saves the last screendump as 'last-console.ppm' in artifacts_dir.
+    """
+    time.sleep(BIOS_WAIT)
+
+    dump_path = os.path.join(artifacts_dir, 'console-check.ppm') \
+        if artifacts_dir else None
+    last_path = os.path.join(artifacts_dir, 'last-console.ppm') \
+        if artifacts_dir else None
+
+    prev_hash = None
+    stable_since = None
+    deadline = time.time() + BOOT_TIMEOUT
+
+    while time.time() < deadline:
+        if dump_path:
+            try:
+                os.remove(dump_path)
+            except OSError:
+                pass
+            data = screendump(monitor, dump_path)
+            if last_path and data:
+                try:
+                    with open(last_path, 'wb') as f:
+                        f.write(data)
+                except OSError:
+                    pass
+        else:
+            data = None
+
+        if data:
+            h = _ppm_pixel_hash(data)
+            if h == prev_hash:
+                if stable_since is None:
+                    stable_since = time.time()
+                elif time.time() - stable_since >= STABLE_SECONDS:
+                    print(f"  screen stable for {STABLE_SECONDS}s — boot done")
+                    return True
+            else:
+                prev_hash = h
+                stable_since = None
+        else:
+            stable_since = None
+
+        time.sleep(SCREENDUMP_INTERVAL)
+
+    return False
+
+
+def bootstrap_serial_shell(monitor, serial, artifacts_dir):
+    """Log in via VGA sendkey and start a serial shell; retry until it works.
 
     Returns True once a shell prompt appears on the serial socket.
     """
-    time.sleep(BOOT_LOADER_WAIT)
+    print("Waiting for boot to finish (screendump stability)...")
+    boot_ok = wait_for_boot(monitor, artifacts_dir)
 
-    deadline = time.time() + BOOT_TIMEOUT
+    if not boot_ok:
+        print("  WARNING: boot did not stabilize within timeout; "
+              "trying login anyway")
+
+    deadline = time.time() + LOGIN_TIMEOUT
     for attempt in range(1, MAX_BOOTSTRAP_ATTEMPTS + 1):
         if time.time() > deadline:
             break
@@ -137,8 +221,6 @@ def bootstrap_serial_shell(monitor, serial):
         send_line(monitor, 'root')
         time.sleep(2)
 
-        # Kill stale serial shells, then start a fresh one.
-        # Root's login shell is csh, so wrap sh-specific redirects in /bin/sh -c.
         send_line(monitor, 'pkill -f cuaa0')
         time.sleep(1)
         cmd = f"/bin/sh -c '/bin/sh <{SERIAL_DEVICE} >{SERIAL_DEVICE} 2>&1 &'"
@@ -161,6 +243,7 @@ def main():
     pub_key = os.environ["PUB_KEY"]
     monitor_sock = os.environ.get("DFLY_MONITOR_SOCK", "dfly-monitor.sock")
     serial_sock = os.environ.get("DFLY_SERIAL_SOCK", "dfly-serial.sock")
+    artifacts_dir = os.environ.get("DFLY_ARTIFACTS_DIR", "")
 
     monitor = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     monitor.connect(monitor_sock)
@@ -173,8 +256,14 @@ def main():
 
     try:
         print("Bootstrapping serial shell via sendkey...")
-        if not bootstrap_serial_shell(monitor, serial):
+        if not bootstrap_serial_shell(monitor, serial, artifacts_dir):
             print("ERROR: serial shell never came up", file=sys.stderr)
+            if artifacts_dir:
+                last = os.path.join(artifacts_dir, 'last-console.ppm')
+                if os.path.exists(last):
+                    sz = os.path.getsize(last)
+                    print(f"  diagnostic screendump saved: {last} ({sz} bytes)",
+                          file=sys.stderr)
             return 1
 
         serial_drain(serial)

--- a/.ci-scripts/bsd/dfly_configure_vm_test.py
+++ b/.ci-scripts/bsd/dfly_configure_vm_test.py
@@ -3,12 +3,14 @@
 
 Guards the KEYMAP de-escaping (backslash, backtick, dollar were shell-escaped in
 the original heredoc), send_line key mapping, the socket-path contract with
-dragonfly-provision.bash (DFLY_MONITOR_SOCK / DFLY_SERIAL_SOCK), and the
-two-phase bootstrap + serial setup flow.  No VM required.
+dragonfly-provision.bash (DFLY_MONITOR_SOCK / DFLY_SERIAL_SOCK), the two-phase
+bootstrap + serial setup flow, screendump-based boot detection, and the PPM
+pixel hash helper.  No VM required.
 """
 import os
 import socket
 import sys
+import tempfile
 
 import dfly_configure_vm as d
 
@@ -64,6 +66,36 @@ class MonitorSock:
 
     def close(self):
         pass
+
+
+class ScreendumpMonitorSock(MonitorSock):
+    """Monitor socket that writes fake PPM files on screendump commands.
+
+    Writes a different image for the first N screendumps (simulating boot),
+    then a stable image for the rest (simulating the login prompt).
+    """
+
+    def __init__(self, unstable_count=2):
+        super().__init__()
+        self._dump_count = 0
+        self._unstable_count = unstable_count
+
+    def sendall(self, data):
+        text = data.decode().strip()
+        self.sent.append(text)
+        if text.startswith('screendump '):
+            path = text.split(' ', 1)[1]
+            self._dump_count += 1
+            if self._dump_count <= self._unstable_count:
+                pixel = bytes([self._dump_count] * 30)
+            else:
+                pixel = bytes([0xFF] * 30)
+            ppm = b'P6\n10 1\n255\n' + pixel
+            try:
+                with open(path, 'wb') as f:
+                    f.write(ppm)
+            except OSError:
+                pass
 
 
 class SerialSock:
@@ -154,7 +186,7 @@ class TimeoutSerialSock:
         raise socket.timeout
 
 
-def run_main(env, serial_cls=None):
+def run_main(env, serial_cls=None, monitor_cls=None):
     """Run main() with stubbed sockets.
 
     Returns (exit_code, monitor, serial, typed_lines).
@@ -162,12 +194,21 @@ def run_main(env, serial_cls=None):
     saved_env = dict(os.environ)
     saved_socket = d.socket.socket
     saved_send_line = d.send_line
-    saved_boot_wait = d.BOOT_LOADER_WAIT
+    saved_bios_wait = d.BIOS_WAIT
+    saved_boot_timeout = d.BOOT_TIMEOUT
+    saved_stable = d.STABLE_SECONDS
+    saved_interval = d.SCREENDUMP_INTERVAL
+    saved_login_timeout = d.LOGIN_TIMEOUT
     saved_max_attempts = d.MAX_BOOTSTRAP_ATTEMPTS
 
-    d.BOOT_LOADER_WAIT = 0
+    d.BIOS_WAIT = 0
+    d.BOOT_TIMEOUT = 5
+    d.LOGIN_TIMEOUT = 5
+    d.STABLE_SECONDS = 0
+    d.SCREENDUMP_INTERVAL = 0
 
-    monitor = MonitorSock()
+    monitor = (monitor_cls() if monitor_cls else
+               ScreendumpMonitorSock(unstable_count=0))
     serial = serial_cls() if serial_cls else SerialSock()
     call_count = [0]
 
@@ -192,7 +233,11 @@ def run_main(env, serial_cls=None):
     finally:
         d.send_line = saved_send_line
         d.socket.socket = saved_socket
-        d.BOOT_LOADER_WAIT = saved_boot_wait
+        d.BIOS_WAIT = saved_bios_wait
+        d.BOOT_TIMEOUT = saved_boot_timeout
+        d.STABLE_SECONDS = saved_stable
+        d.SCREENDUMP_INTERVAL = saved_interval
+        d.LOGIN_TIMEOUT = saved_login_timeout
         d.MAX_BOOTSTRAP_ATTEMPTS = saved_max_attempts
         os.environ.clear()
         os.environ.update(saved_env)
@@ -221,56 +266,121 @@ def main():
     check("'7' -> 7, ret", keys_for('7') == ['7', 'ret'])
     check("tab is skipped", keys_for('\t') == ['ret'])
 
+    # -- _ppm_pixel_hash --
+    ppm = b'P6\n10 1\n255\n' + bytes(30)
+    h1 = d._ppm_pixel_hash(ppm)
+    h2 = d._ppm_pixel_hash(ppm)
+    check("ppm_pixel_hash: same data same hash", h1 == h2)
+    ppm2 = b'P6\n10 1\n255\n' + bytes([1] * 30)
+    h3 = d._ppm_pixel_hash(ppm2)
+    check("ppm_pixel_hash: different pixels different hash", h1 != h3)
+    ppm_alt_hdr = b'P6\n5 2\n255\n' + bytes(30)
+    check("ppm_pixel_hash: ignores header",
+          d._ppm_pixel_hash(ppm) == d._ppm_pixel_hash(ppm_alt_hdr))
+    check("ppm_pixel_hash: handles None", d._ppm_pixel_hash(None) is not None)
+    check("ppm_pixel_hash: handles non-PPM",
+          d._ppm_pixel_hash(b'not a ppm') is not None)
+
+    # -- wait_for_boot with screendumps --
+    with tempfile.TemporaryDirectory() as tmpdir:
+        saved_bios = d.BIOS_WAIT
+        saved_timeout = d.BOOT_TIMEOUT
+        saved_stable = d.STABLE_SECONDS
+        saved_interval = d.SCREENDUMP_INTERVAL
+        d.BIOS_WAIT = 0
+        d.BOOT_TIMEOUT = 5
+        d.STABLE_SECONDS = 0
+        d.SCREENDUMP_INTERVAL = 0
+        try:
+            mon = ScreendumpMonitorSock(unstable_count=1)
+            result = d.wait_for_boot(mon, tmpdir)
+            check("wait_for_boot: returns True on stable screen", result)
+            last = os.path.join(tmpdir, 'last-console.ppm')
+            check("wait_for_boot: saves last-console.ppm",
+                  os.path.exists(last))
+        finally:
+            d.BIOS_WAIT = saved_bios
+            d.BOOT_TIMEOUT = saved_timeout
+            d.STABLE_SECONDS = saved_stable
+            d.SCREENDUMP_INTERVAL = saved_interval
+
+    # -- wait_for_boot with no artifacts_dir --
+    saved_bios = d.BIOS_WAIT
+    saved_timeout = d.BOOT_TIMEOUT
+    saved_stable = d.STABLE_SECONDS
+    saved_interval = d.SCREENDUMP_INTERVAL
+    d.BIOS_WAIT = 0
+    d.BOOT_TIMEOUT = 0.01
+    d.STABLE_SECONDS = 0
+    d.SCREENDUMP_INTERVAL = 0
+    try:
+        mon_no_dir = ScreendumpMonitorSock(unstable_count=100)
+        result_no_dir = d.wait_for_boot(mon_no_dir, "")
+        check("wait_for_boot: returns False on timeout (no dir)",
+              not result_no_dir)
+    finally:
+        d.BIOS_WAIT = saved_bios
+        d.BOOT_TIMEOUT = saved_timeout
+        d.STABLE_SECONDS = saved_stable
+        d.SCREENDUMP_INTERVAL = saved_interval
+
     # -- full flow via run_main --
-    env = {"PUB_KEY": "k"}
-    rc, monitor, serial, typed = run_main(env)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        env = {"PUB_KEY": "k", "DFLY_ARTIFACTS_DIR": tmpdir}
+        rc, monitor, serial, typed = run_main(env)
 
-    check("main returns 0 on success", rc == 0)
+        check("main returns 0 on success", rc == 0)
 
-    sendkeys = [c.removeprefix('sendkey ')
-                for c in monitor.sent if c.startswith('sendkey ')]
+        sendkeys = [c.removeprefix('sendkey ')
+                    for c in monitor.sent if c.startswith('sendkey ')]
 
-    check(
-        "console is reset (ctrl-c) before login",
-        sendkeys[0] == "ctrl-c",
-    )
-    check(
-        "newfs/mount are not typed into the console",
-        not any("newfs" in line or "mount" in line for line in typed),
-    )
-    check(
-        "sshd is started via serial",
-        any("/usr/sbin/sshd" in s for s in serial.sent),
-    )
-    check(
-        "dhclient is run via serial",
-        any("dhclient" in s for s in serial.sent),
-    )
-    check(
-        "ssh key is installed via serial",
-        any("authorized_keys" in s for s in serial.sent),
-    )
-    check(
-        "ssh-keygen -A is run via serial",
-        any("ssh-keygen -A" in s for s in serial.sent),
-    )
-    check(
-        "PermitRootLogin is configured via serial",
-        any("PermitRootLogin" in s for s in serial.sent),
-    )
-    check(
-        "PermitEmptyPasswords is configured via serial",
-        any("PermitEmptyPasswords" in s for s in serial.sent),
-    )
+        check(
+            "screendump commands are sent",
+            any("screendump" in c for c in monitor.sent),
+        )
+        check(
+            "console is reset (ctrl-c) before login",
+            sendkeys[0] == 'ctrl-c',
+        )
+        check(
+            "newfs/mount are not typed into the console",
+            not any("newfs" in line or "mount" in line for line in typed),
+        )
+        check(
+            "sshd is started via serial",
+            any("/usr/sbin/sshd" in s for s in serial.sent),
+        )
+        check(
+            "dhclient is run via serial",
+            any("dhclient" in s for s in serial.sent),
+        )
+        check(
+            "ssh key is installed via serial",
+            any("authorized_keys" in s for s in serial.sent),
+        )
+        check(
+            "ssh-keygen -A is run via serial",
+            any("ssh-keygen -A" in s for s in serial.sent),
+        )
+        check(
+            "PermitRootLogin is configured via serial",
+            any("PermitRootLogin" in s for s in serial.sent),
+        )
+        check(
+            "PermitEmptyPasswords is configured via serial",
+            any("PermitEmptyPasswords" in s for s in serial.sent),
+        )
 
     # -- socket path defaults --
+    env_default = {"PUB_KEY": "k"}
+    _rc_d, mon_d, ser_d, _typed_d = run_main(env_default)
     check(
         "monitor socket defaults to dfly-monitor.sock",
-        monitor.connected_path == "dfly-monitor.sock",
+        mon_d.connected_path == "dfly-monitor.sock",
     )
     check(
         "serial socket defaults to dfly-serial.sock",
-        serial.connected_path == "dfly-serial.sock",
+        ser_d.connected_path == "dfly-serial.sock",
     )
 
     # -- socket path overrides --
@@ -320,7 +430,7 @@ def main():
         d.COMMAND_TIMEOUT = saved_timeout
     check("serial_cmd raises RuntimeError on timeout", got_error)
 
-    total = 28
+    total = 37
     if failures:
         print(f"dfly_configure_vm_test: FAIL ({len(failures)}): "
               f"{', '.join(failures)}")

--- a/.ci-scripts/bsd/dragonfly-provision.bash
+++ b/.ci-scripts/bsd/dragonfly-provision.bash
@@ -82,12 +82,13 @@ echo "::group::Configure and wait for VM"
 PUB_KEY="$(cat vm_key.pub)"
 export PUB_KEY
 
-# dfly_configure_vm.py waits for the boot loader to pass, then types login +
-# serial shell start via sendkey. Once the serial shell responds, all setup
-# commands run through it with prompt detection. The sendkey phase retries
-# internally, so this script needs no retry loop.
+# dfly_configure_vm.py detects when boot finishes (VGA screendump stability),
+# then bootstraps a serial shell via sendkey and runs all setup commands through
+# it with prompt detection. It retries internally, so this script needs no
+# retry loop.
 DFLY_MONITOR_SOCK="$VM_ARTIFACTS/dfly-monitor.sock" \
   DFLY_SERIAL_SOCK="$VM_ARTIFACTS/dfly-serial.sock" \
+  DFLY_ARTIFACTS_DIR="$VM_ARTIFACTS" \
   python3 .ci-scripts/bsd/dfly_configure_vm.py
 
 # Verify ssh is reachable after the serial-driven setup.

--- a/.claude/skills/create-dragonfly-dev-env/SKILL.md
+++ b/.claude/skills/create-dragonfly-dev-env/SKILL.md
@@ -36,9 +36,11 @@ several steps:
   a here-string MUST go through an explicit `/bin/sh`:
   `ssh ... root@localhost /bin/sh <<'EOF' ... EOF`. A bare
   `ssh ... root@localhost 'cmd with $(...)'` fails with `Illegal variable name.`
-- **Boot timing is handled by the script.** `dfly_configure_vm.py` waits past the boot
-  loader and retries login + serial shell start until the serial port responds. If
-  something goes wrong, screendump the console (Step 5 has a helper) to see the VM state.
+- **Boot timing is handled by the script.** `dfly_configure_vm.py` takes periodic VGA
+  screendumps and waits for the screen to stabilize before attempting login, then retries
+  the login + serial shell start until the serial port responds. If something goes wrong,
+  check the diagnostic screendump the script saves, or use the manual screendump helper
+  (Step 5) to see the VM state.
 - **A daemonized QEMU `chdir`s to `/`.** The monitor `screendump` (and any relative path
   the daemon writes) needs an **absolute** path, or it fails `Permission denied`.
 - **No `sudo` needed (and often unavailable).** CI loop-mounts the ISO with `sudo` to get
@@ -168,19 +170,21 @@ it never silently falls back to slow TCG. `-smp`/`-m` are speed knobs; CI uses 4
 
 ### 5. Run the console setup script
 
-The CI console script waits past the boot loader, bootstraps a serial shell via sendkey
-with retries, and runs all setup commands through the serial console with prompt detection.
-It handles boot timing internally, so no screendump wait is needed.
+The CI console script takes periodic VGA screendumps to detect when boot finishes, then
+bootstraps a serial shell via sendkey with retries, and runs all setup commands through
+the serial console with prompt detection. It handles boot timing internally.
 
 The script lives in the repo at `.ci-scripts/bsd/dfly_configure_vm.py`. Copy it into
 `$VMDIR` (it connects to `dfly-monitor.sock` and `dfly-serial.sock` in its working
-directory) and run it there. It logs in, brings up networking, configures sshd, and
-installs your key:
+directory) and run it there. Set `DFLY_ARTIFACTS_DIR` to the VM directory so the script
+can write screendumps for boot detection and diagnostics. It logs in, brings up
+networking, configures sshd, and installs your key:
 
 ```sh
 VMDIR=~/vms/dragonfly-6.4.2; cd "$VMDIR"
 cp "$(git rev-parse --show-toplevel)/.ci-scripts/bsd/dfly_configure_vm.py" "$VMDIR/"
 export PUB_KEY="$(cat vm_key.pub)"
+export DFLY_ARTIFACTS_DIR="$VMDIR"
 python3 dfly_configure_vm.py
 ```
 
@@ -382,8 +386,8 @@ unchanged**. The local setup deliberately differs from CI, and each difference i
   `known_hosts` entry from a prior VM. CI's ephemeral runners never reuse the port, so
   `dragonfly-provision.bash` doesn't bother.
 - `-smp 8` for build speed (CI uses 4).
-- Both use the serial console script for boot timing; locally you can also screendump
-  for debugging.
+- Both use the serial console script with screendump-based boot detection; locally you
+  can also use the manual screendump helper for ad-hoc debugging.
 - No GHCR libs cache (that's token-gated CI plumbing) — you just run `cmake -P lib/build-libs.cmake` once.
 
 The FreeBSD and OpenBSD CI VMs follow the same shape


### PR DESCRIPTION
The DragonFly BSD CI VM intermittently fails at "Provision VM" because `dfly_configure_vm.py` sends blind VGA keystrokes after a fixed 30-second wait. When the VM boots slowly the login keystrokes arrive before the prompt, the serial shell never starts, and all retry attempts hit the same wall.

Replace the fixed wait with QEMU VGA screendump stability detection. The script now takes periodic screendumps via the monitor socket, hashes the pixel data, and waits until consecutive frames are identical for 10 seconds before attempting login. A separate `LOGIN_TIMEOUT` (300s) keeps the login-retry budget independent of the boot-detection budget (`BOOT_TIMEOUT`, 360s). On failure the last screendump is saved for diagnostics.

The screendump file is deleted before each new capture so a stale file from a dropped HMP command can't produce a false-positive stability match.

Failing run: https://github.com/ponylang/ponyc/actions/runs/33600984473/job/100154426581
