### PR TITLE
Fix compiler crash on array literals passed by name or to a call on a literal

### DIFF
--- a/.release-notes/fix-array-literal-antecedent-receiver.md
+++ b/.release-notes/fix-array-literal-antecedent-receiver.md
@@ -1,0 +1,5 @@
+## Fix compiler crash on array literals passed by name or to a call on a literal
+
+The compiler crashed when an array literal appeared as an argument in certain positions: as an operand to a numeric literal (`1 + [as U8: 2]`), as a named argument to a callable object (`f(where x = [as U8: 1])`), or through update sugar when `update` is a field holding a callable object. These now compile or produce a normal error message.
+
+Passing an array literal to an object with no `apply` method, or to a tuple, reported the error twice. Each now reports one error.

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -289,6 +289,35 @@ static ast_t* find_tuple_type(pass_opt_t* opt, ast_t* ast, size_t child_count)
   return NULL;
 }
 
+// Return the function type for a call's receiver. A function reference already
+// carries one; any other receiver gets it from its apply method. Returns NULL
+// when the type has no apply or cannot have members.
+static ast_t* call_funtype(pass_opt_t* opt, ast_t* receiver, ast_t* recv_type)
+{
+  if(ast_id(recv_type) == TK_FUNTYPE)
+    return recv_type;
+
+  // lookup_try: a missing apply is reported by the call's own lookup,
+  // not duplicated here.
+  deferred_reification_t* fun = lookup_try(opt, receiver, recv_type,
+    stringtab(opt->strtab, "apply"), false);
+
+  if(fun == NULL)
+    return NULL;
+
+  if((ast_id(fun->ast) != TK_BE) && (ast_id(fun->ast) != TK_FUN))
+  {
+    deferred_reify_free(fun);
+    return NULL;
+  }
+
+  ast_t* r_fun = deferred_reify_method_def(fun, fun->ast, opt);
+  ast_t* funtype = type_for_fun(r_fun);
+  ast_free_unattached(r_fun);
+  deferred_reify_free(fun);
+  return funtype;
+}
+
 ast_t* find_antecedent_type(pass_opt_t* opt, ast_t* ast, bool* is_recovered)
 {
   ast_t* parent = ast_parent(ast);
@@ -336,27 +365,9 @@ ast_t* find_antecedent_type(pass_opt_t* opt, ast_t* ast, bool* is_recovered)
       if(is_typecheck_error(funtype))
         return funtype;
 
-      // If this is a call to a callable object instead of a function reference,
-      // we need to use the funtype of the apply method of the object.
-      if(ast_id(funtype) != TK_FUNTYPE)
-      {
-        deferred_reification_t* fun = lookup(opt, receiver, funtype,
-          stringtab(opt->strtab, "apply"));
-
-        if(fun == NULL)
-          return NULL;
-
-        if((ast_id(fun->ast) != TK_BE) && (ast_id(fun->ast) != TK_FUN))
-        {
-          deferred_reify_free(fun);
-          return NULL;
-        }
-
-        ast_t* r_fun = deferred_reify_method_def(fun, fun->ast, opt);
-        funtype = type_for_fun(r_fun);
-        ast_free_unattached(r_fun);
-        deferred_reify_free(fun);
-      }
+      funtype = call_funtype(opt, receiver, funtype);
+      if(funtype == NULL)
+        return NULL;
 
       AST_GET_CHILDREN(funtype, cap, t_params, params, ret_type);
 
@@ -385,7 +396,11 @@ ast_t* find_antecedent_type(pass_opt_t* opt, ast_t* ast, bool* is_recovered)
       ast_t* funtype = ast_type(receiver);
       if(is_typecheck_error(funtype))
         return funtype;
-      pony_assert(ast_id(funtype) == TK_FUNTYPE);
+
+      funtype = call_funtype(opt, receiver, funtype);
+      if(funtype == NULL)
+        return NULL;
+
       AST_GET_CHILDREN(funtype, cap, t_params, params, ret_type);
 
       // Find the parameter type corresponding to this named argument.

--- a/src/libponyc/type/lookup.c
+++ b/src/libponyc/type/lookup.c
@@ -627,7 +627,8 @@ static deferred_reification_t* lookup_base(pass_opt_t* opt, ast_t* from,
     default: {}
   }
 
-  pony_assert(0);
+  // No other kind of type has members.
+  pony_assert(!errors);
   return NULL;
 }
 

--- a/src/libponyc/type/lookup.h
+++ b/src/libponyc/type/lookup.h
@@ -8,9 +8,13 @@
 
 PONY_EXTERN_C_BEGIN
 
+// Find a member of a type by name. Reports an error when not found.
+// Asserts if the type is a kind that cannot have members.
 deferred_reification_t* lookup(pass_opt_t* opt, ast_t* from, ast_t* type,
   const char* name);
 
+// Find a member of a type by name, returning NULL when the type has no
+// such member or cannot have members. Reports no errors.
 deferred_reification_t* lookup_try(pass_opt_t* opt, ast_t* from, ast_t* type,
   const char* name, bool allow_private);
 

--- a/test/libponyc/array.cc
+++ b/test/libponyc/array.cc
@@ -289,3 +289,76 @@ TEST_F(ArrayTest, NonEmptyArrayLiteralCompilesThroughReach)
 
   DO(test_compile(src, "ir"));
 }
+
+
+TEST_F(ArrayTest, NamedLiteralArgumentToCallableObject)
+{
+  // The parameter is val on purpose: without the antecedent the literal would
+  // be Array[U8] ref, which is not a subtype of the val parameter.
+  const char* src =
+    "class Callable\n"
+    "  fun apply(x: Array[U8] val) => None\n"
+
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let f = Callable\n"
+    "    f(where x = [as U8: 1])";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(ArrayTest, NamedLiteralArgumentToUnionOfCallableObjects)
+{
+  const char* src =
+    "class C1\n"
+    "  fun apply(x: Array[U8] val) => None\n"
+
+    "class C2\n"
+    "  fun apply(x: Array[U8] val) => None\n"
+
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let f: (C1 | C2) = C1\n"
+    "    f(where x = [as U8: 1])";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(ArrayTest, NamedLiteralArgumentInfersElementType)
+{
+  // The literal has no element type of its own; the antecedent from the named
+  // parameter supplies it.
+  const char* src =
+    "class Callable\n"
+    "  fun apply(x: Array[U8] val) => None\n"
+
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let f = Callable\n"
+    "    f(where x = [1])";
+
+  TEST_COMPILE(src);
+}
+
+
+TEST_F(ArrayTest, LiteralArgumentToUpdateSugarOnCallableField)
+{
+  // `o(0) = v` is sugar for a call to `o.update`, which here is a field
+  // holding a callable object rather than a method, so the call's receiver is
+  // that object.
+  const char* src =
+    "class Inner\n"
+    "  fun apply(key: USize, value: Array[U8] val) => None\n"
+
+    "class Outer\n"
+    "  let update: Inner = Inner\n"
+
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let o = Outer\n"
+    "    o(0) = [as U8: 1]";
+
+  TEST_COMPILE(src);
+}

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -3867,3 +3867,91 @@ TEST_F(BadPonyTest, AliasedConstraintOnTypeParamRefTrn)
   TEST_ERRORS_1(src, "function body isn't the result type");
 }
 
+
+TEST_F(BadPonyTest, LiteralArgumentToOperatorOnIntegerLiteralIsAnError)
+{
+  // An integer literal has a literal type, which cannot have members.
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let x = 1 + [as U8: 2]";
+
+  TEST_ERRORS_1(src, "could not infer literal type, no valid types found");
+}
+
+TEST_F(BadPonyTest, LiteralArgumentToCallOnIntegerLiteralIsAnError)
+{
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let x = 1([as U8: 2])";
+
+  TEST_ERRORS_1(src, "Cannot call a literal");
+}
+
+TEST_F(BadPonyTest, CallOnTupleWithLiteralArgumentReportsOnce)
+{
+  // One error, from the call itself. The antecedent lookup returns NULL for
+  // the tuple rather than producing a duplicate.
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let t = (U8(1), U8(2))\n"
+    "    t([as U8: 1])";
+
+  TEST_ERRORS_1(src, "lookup on a tuple must take the form _X");
+}
+
+TEST_F(BadPonyTest, CallOnObjectWithoutApplyReportsOnce)
+{
+  // One error, from the call itself. The antecedent lookup returns NULL for
+  // the missing apply rather than producing a duplicate.
+  const char* src =
+    "class NoApply\n"
+
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let f = NoApply\n"
+    "    f([as U8: 1])";
+
+  TEST_ERRORS_1(src, "couldn't find 'apply' in 'NoApply'");
+}
+
+TEST_F(BadPonyTest, NamedLiteralArgumentToCallOnIntegerLiteralIsAnError)
+{
+  // Named path: a literal receiver produces the call's own error, not an
+  // abort.
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let x = 1(where x = [as U8: 2])";
+
+  TEST_ERRORS_1(src, "Cannot call a literal");
+}
+
+TEST_F(BadPonyTest, NamedLiteralArgumentToCallOnTupleReportsOnce)
+{
+  // As for the positional argument: one error, from the call itself.
+  const char* src =
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let t = (U8(1), U8(2))\n"
+    "    t(where x = [as U8: 1])";
+
+  TEST_ERRORS_1(src, "lookup on a tuple must take the form _X");
+}
+
+TEST_F(BadPonyTest, NamedLiteralArgumentToObjectWithoutApplyReportsOnce)
+{
+  // As for the positional argument: one error, from the call itself.
+  const char* src =
+    "class NoApply\n"
+
+    "primitive Foo\n"
+    "  fun apply() =>\n"
+    "    let f = NoApply\n"
+    "    f(where x = [as U8: 1])";
+
+  TEST_ERRORS_1(src, "couldn't find 'apply' in 'NoApply'");
+}
+


### PR DESCRIPTION
The positional branch in `find_antecedent_type` called `lookup` on every non-function receiver, and `lookup` asserts for types without members. The named branch asserted the receiver was always a function type. A literal type or a callable-object receiver hit one of those asserts.

Both branches now share a helper that uses `lookup_try`. `lookup_try` returns NULL for type kinds with no members instead of asserting; `lookup` keeps its assert. The alternative was an allowlist in `expr.c`, which would restate `lookup_base`'s dispatch table with nothing tying the two together.

The function type built from a looked-up `apply` is not freed; the named branch now shares that leak. The owner out-parameter proposed in #5958 covers both branches, so fixing it here would duplicate that work.

A missing `apply` on a positional argument, or a call on a tuple, now produces one error instead of two.

First of the prerequisite PRs for RFC 0010.
