### PR TITLE
Fix compiler crash on `is` with a constructor call

### DIFF
--- a/.release-notes/fix-is-comparison-constructor-type-args.md
+++ b/.release-notes/fix-is-comparison-constructor-type-args.md
@@ -1,0 +1,5 @@
+## Fix compiler crash on `is` with a constructor call
+
+Comparing a freshly constructed object with `is` or `isnt` is an error because the comparison is always false. Two shapes of constructor call crashed the compiler instead of reporting that error: a constructor with its own type parameters, as in `Foo[String].create[U8]("x", U8(1)) is y`, and a constructor called on a value, as in `x.create() is y`. Both now report the error.
+
+A primitive's constructor returns the one instance, so comparing its result with `is` is allowed. That comparison crashed when the constructor had type parameters or was called on a value, and was wrongly rejected when the primitive was named through a type alias. All three now compile.

--- a/src/libponyc/pass/verify.c
+++ b/src/libponyc/pass/verify.c
@@ -519,56 +519,36 @@ static bool verify_assign(pass_opt_t* opt, ast_t* ast)
   return true;
 }
 
-// This function checks if the passed AST node represent
-// a constructor call assuming the passed AST node is
-// of TK_CALL type.
-//
-// This is going to be positive when creating a new object
-// or a new actor. If the constructor is invoked on a
-// primitive this will return false as we aren't really
-// creating a new object.
-static bool is_creating_object(ast_t *ast) {
-  ast_t* type;
-  ast_t* receiver;
+static ast_t* concrete_nominal_def(ast_t* type, ast_t** to_free);
 
+// Whether the call constructs a new object or actor. A primitive's
+// constructor returns the one instance, so it is not creating anything.
+// The entity comes from the call's type through concrete_nominal_def,
+// not from the callee's receiver, which may be a value, a wrapper
+// carrying type arguments, or a type reference to an alias or a type
+// parameter.
+static bool is_creating_object(ast_t* ast)
+{
   pony_assert(ast_id(ast) == TK_CALL);
 
-  // The following diagram represent the AST structure
-  // of the following example, where C is supposed to
-  // be a class:
-  //
-  //     C.create()
-  //
-  // type: TK_CALL (`C.create`)
-  // children:
-  // - type: TK_NEWREF
-  //
-  // In the previous example, if `C` is an actor, we'll
-  // the following structure:
-  //
-  // type: TK_CALL (`C.create`)
-  // children:
-  // - type: TK_NEWBEREF
-
+  // Only constructor calls are relevant. Any other call's type is the
+  // method's return type, which could also be a class.
   ast_t* callee = ast_child(ast);
-  switch(ast_id(callee))
-  {
-    case TK_NEWREF:
-    case TK_NEWBEREF:
-      receiver = ast_child(callee);
-      pony_assert(ast_id(receiver) == TK_TYPEREF);
+  if((ast_id(callee) != TK_NEWREF) && (ast_id(callee) != TK_NEWBEREF))
+    return false;
 
-      type = (ast_t*) ast_data(receiver);
-      if(ast_id(type) == TK_PRIMITIVE)
-      {
-        return false;
-      }
+  ast_t* to_free;
+  ast_t* def = concrete_nominal_def(ast_type(ast), &to_free);
 
-      return true;
+  // When the type does not resolve to a single entity (e.g. a type
+  // parameter), treat it as creating an object: the constraint does not
+  // determine whether the argument is a primitive.
+  bool creating = (def == NULL) || (ast_id(def) != TK_PRIMITIVE);
 
-    default:
-      return false;
-  }
+  if(to_free != NULL)
+    ast_free_unattached(to_free);
+
+  return creating;
 }
 
 static bool verify_is_comparand(pass_opt_t* opt, ast_t* ast)

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -1704,6 +1704,170 @@ TEST_F(BadPonyTest, IsComparingCreate)
   }
 }
 
+TEST_F(BadPonyTest, IsComparingConstructorWithMethodTypeArguments)
+{
+  // Exercises both operand positions, isnt, and inside a tuple.
+  const char* src =
+    "class Foo[A]\n"
+    "  new create[B](a: A, b: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let y = Foo[String].create[U8](\"x\", U8(1))\n"
+    "    Foo[String].create[U8](\"x\", U8(1)) is y\n"
+    "    y isnt Foo[String].create[U8](\"x\", U8(1))\n"
+    "    y is (y, Foo[String].create[U8](\"x\", U8(1)))";
+
+  const char* err = "identity comparison with a new object will always be false";
+  const char* errs[] = {err, err, err, NULL};
+  DO(test_expected_errors(src, "verify", errs));
+}
+
+TEST_F(BadPonyTest, IsComparingConstructorCalledOnValue)
+{
+  const char* src =
+    "class Foo\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x = Foo\n"
+    "    let y = x.create()\n"
+    "    x.create() is y";
+
+  const char* errs[] =
+    {"identity comparison with a new object will always be false", NULL};
+  DO(test_expected_errors(src, "verify", errs));
+}
+
+TEST_F(BadPonyTest, IsComparingPrimitiveConstructorCalledOnValue)
+{
+  const char* src =
+    "primitive P\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x = P\n"
+    "    let y = x.create()\n"
+    "    x.create() is y";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, IsComparingConstructorOnTypeParameter)
+{
+  // The constraint does not determine whether the argument is a primitive.
+  const char* src =
+    "class Foo\n"
+
+    "class Maker[A: Foo ref]\n"
+    "  fun make(y: A) =>\n"
+    "    A.create() is y";
+
+  const char* errs[] =
+    {"identity comparison with a new object will always be false", NULL};
+  DO(test_expected_errors(src, "verify", errs));
+}
+
+TEST_F(BadPonyTest, IsComparingConstructorThroughAliasToClass)
+{
+  const char* src =
+    "class Foo\n"
+    "type FA is Foo\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let y = FA.create()\n"
+    "    FA.create() is y";
+
+  const char* errs[] =
+    {"identity comparison with a new object will always be false", NULL};
+  DO(test_expected_errors(src, "verify", errs));
+}
+
+TEST_F(BadPonyTest, IsComparingConstructorWithDefaultedMethodTypeArguments)
+{
+  const char* src =
+    "class Foo[A]\n"
+    "  new create[B: Any val = U8](a: A, b: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let y = Foo[String].create(\"x\", U8(1))\n"
+    "    Foo[String].create(\"x\", U8(1)) is y";
+
+  const char* errs[] =
+    {"identity comparison with a new object will always be false", NULL};
+  DO(test_expected_errors(src, "verify", errs));
+}
+
+TEST_F(BadPonyTest, IsComparingActorConstructorWithMethodTypeArguments)
+{
+  const char* src =
+    "actor Act[A: Any val]\n"
+    "  new create[B: Any val](a: A, b: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let y = Act[String].create[U8](\"x\", U8(1))\n"
+    "    Act[String].create[U8](\"x\", U8(1)) is y";
+
+  const char* errs[] =
+    {"identity comparison with a new object will always be false", NULL};
+  DO(test_expected_errors(src, "verify", errs));
+}
+
+TEST_F(BadPonyTest, IsComparingActorConstructorWithDefaultedMethodTypeArguments)
+{
+  const char* src =
+    "actor Act[A: Any val]\n"
+    "  new create[B: Any val = U8](a: A, b: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let y = Act[String].create(\"x\", U8(1))\n"
+    "    Act[String].create(\"x\", U8(1)) is y";
+
+  const char* errs[] =
+    {"identity comparison with a new object will always be false", NULL};
+  DO(test_expected_errors(src, "verify", errs));
+}
+
+TEST_F(BadPonyTest, IsComparingPrimitiveConstructorWithMethodTypeArguments)
+{
+  const char* src =
+    "primitive P\n"
+    "  new create[B: Any val](b: B) => None\n"
+
+    "primitive Q\n"
+    "  new create[B: Any val = U8](b: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let y = P.create[U8](U8(1))\n"
+    "    P.create[U8](U8(1)) is y\n"
+    "    let z = Q.create(U8(1))\n"
+    "    Q.create(U8(1)) is z";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, IsComparingPrimitiveConstructorThroughAlias)
+{
+  const char* src =
+    "primitive P\n"
+    "type PA is P\n"
+    "type PV is P val\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let y = PA.create()\n"
+    "    PA.create() is y\n"
+    "    let z = PV.create()\n"
+    "    PV.create() is z";
+
+  TEST_COMPILE(src);
+}
+
 TEST_F(BadPonyTest, IsComparingNamedConstructor)
 {
   // From issue #4162, this is about testing named


### PR DESCRIPTION
`is_creating_object` assumed the callee's receiver was a plain type reference. A constructor with its own type parameters (`Foo[String].create[U8]("x", U8(1)) is y`) and a constructor called on a value (`x.create() is y`) both crashed the compiler, and a primitive behind a type alias was wrongly reported as creating an object. The function now resolves the entity from the call's own type through `concrete_nominal_def`.

Design call: when the type does not resolve to a single entity (a type parameter, for instance), the function still treats it as creating an object. A type parameter constrained to a primitive gets a false positive, but with type arguments on the constructor that shape crashed before this change, so the wrong error is strictly better than no compiler at all.

Found on the way: `verify_calls_runtime_override` in `verify/fun.c` crashes on a qualified call inside a `runtime_override_defaults` body for the same wrapper reason (#5963), and `verify_is_comparand` does not descend into `recover` blocks or `.>` chains.

Second of the prerequisite PRs for RFC 0010 (generic type inference).
