### PR TITLE
Fix type parameter defaults

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -873,3 +873,40 @@ Comparing a freshly constructed object with `is` or `isnt` is an error because t
 
 A primitive's constructor returns the one instance, so comparing its result with `is` is allowed. That comparison crashed when the constructor had type parameters or was called on a value, and was wrongly rejected when the primitive was named through a type alias. All three now compile.
 
+## Fix type parameter defaults that refer to an earlier type parameter
+
+A type parameter default that named an earlier type parameter in the same list was not substituted at the use site. The raw reference survived into later passes, producing a spurious "type argument is outside its constraint" error or, when the type was used to construct an object, a compiler crash at code generation.
+
+```pony
+class Iter[A, I: Iterator[A] ref = Iterator[A] ref] is Iterator[A]
+```
+
+`Iter[U8]([0].values())` now compiles. The default `Iterator[A] ref` is reified to `Iterator[U8] ref` when `A` is `U8`. Default type arguments are now reified in all positions: type annotations, aliases, provides lists, partially explicit type argument lists, and calls.
+
+## Fix compiler crash on a lambda type used as a type parameter default
+
+A lambda type serving as a type parameter default captured that parameter, producing an unbound type parameter reference that reached code generation and crashed the compiler.
+
+```pony
+primitive Bar
+  fun foo[A: Any val = {(U8): U8} val](a: A) => None
+```
+
+`Bar.foo(f)` now compiles. The generated interface for the lambda type no longer includes the defaulted parameter or its later siblings as type parameters, unless the lambda type's body names them.
+
+## Fix compiler crash on a type parameter default naming itself or a later one
+
+A type parameter default that named itself or a later type parameter in the same list made the compiler abort at code generation, or produced a misleading error about an internal name the user could not see from the use site.
+
+```pony
+class Foo[A: Any val = B, B: Any val = U8]
+
+actor Main
+  new create(env: Env) =>
+    let x: Foo = Foo
+```
+
+The compiler now reports "not enough type arguments" with a continuation naming the type parameter the default refers to. A definition with such a default that is only ever used with written type arguments keeps compiling.
+
+A type annotation that uses the default at a site that is never reached also becomes an error. `class Foo[A: Any val = A]` used only as `fun unused(x: Foo)` compiled before because the default was filled at the annotation and code generation never processed the unreached one. That program denotes a type with no meaning and is now rejected.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ All notable changes to the Pony compiler and standard library will be documented
 - Fix PropertyRunner double completion on assert-and-error ([PR #5932](https://github.com/ponylang/ponyc/pull/5932))
 - Fix stack overflow in itertools Iter methods ([PR #5936](https://github.com/ponylang/ponyc/pull/5936))
 - Fix compiler crash on `is` with a constructor call ([PR #5964](https://github.com/ponylang/ponyc/pull/5964))
+- Fix type parameter defaults that refer to an earlier type parameter ([PR #5967](https://github.com/ponylang/ponyc/pull/5967))
+- Fix compiler crash on a lambda type used as a type parameter default ([PR #5967](https://github.com/ponylang/ponyc/pull/5967))
+- Fix compiler crash on a type parameter default naming itself or a later one ([PR #5967](https://github.com/ponylang/ponyc/pull/5967))
 
 ### Added
 
@@ -61,6 +64,7 @@ All notable changes to the Pony compiler and standard library will be documented
 - Type parameter constraints now respect the default cap of the named type ([PR #5886](https://github.com/ponylang/ponyc/pull/5886))
 - Applying a capability to a tuple type alias is a compile error ([PR #5900](https://github.com/ponylang/ponyc/pull/5900))
 - Don't box machine words smaller than 64 bits ([PR #5952](https://github.com/ponylang/ponyc/pull/5952))
+- Reject unreachable type annotations with self-referencing defaults ([PR #5967](https://github.com/ponylang/ponyc/pull/5967))
 
 ## [0.69.1] - 2026-08-21
 

--- a/src/libponyc/pass/sugar.c
+++ b/src/libponyc/pass/sugar.c
@@ -1145,6 +1145,80 @@ static void replace_thistype(ast_t* ast, pass_opt_t* opt)
 }
 
 
+// Walk up from a lambda type to see whether it sits inside a type
+// parameter's default.  Returns the TK_TYPEPARAM whose default contains
+// the lambda type, or NULL when the lambda type is not inside a default.
+static ast_t* find_enclosing_default(ast_t* ast)
+{
+  ast_t* child = ast;
+  ast_t* parent = ast_parent(ast);
+
+  while(parent != NULL)
+  {
+    if(ast_id(parent) == TK_TYPEPARAM)
+    {
+      if(child == ast_childidx(parent, 2))
+        return parent;
+
+      return NULL;
+    }
+
+    child = parent;
+    parent = ast_parent(parent);
+  }
+
+  return NULL;
+}
+
+// Check whether any TK_NOMINAL in the subtree has the given name and a
+// TK_NONE package (an unresolved reference to a type parameter at this
+// pass stage).
+static bool subtree_names_param(ast_t* ast, const char* name)
+{
+  if(ast == NULL)
+    return false;
+
+  if(ast_id(ast) == TK_NOMINAL)
+  {
+    ast_t* pkg = ast_child(ast);
+    ast_t* id = ast_sibling(pkg);
+
+    if((ast_id(pkg) == TK_NONE) && (ast_name(id) == name))
+      return true;
+  }
+
+  for(ast_t* child = ast_child(ast); child != NULL; child = ast_sibling(child))
+  {
+    if(subtree_names_param(child, name))
+      return true;
+  }
+
+  return false;
+}
+
+// Remove from `list` every child whose position is in `drop`, a
+// boolean array of `count` entries.  When the list ends up empty, reset
+// its id to TK_NONE to satisfy the tree checker.
+static void filter_list(ast_t* list, bool* drop, size_t count)
+{
+  size_t pos = 0;
+  ast_t* child = ast_child(list);
+
+  while(child != NULL)
+  {
+    ast_t* next = ast_sibling(child);
+
+    if((pos < count) && drop[pos])
+      ast_remove(child);
+
+    child = next;
+    pos++;
+  }
+
+  if(ast_childcount(list) == 0)
+    ast_setid(list, TK_NONE);
+}
+
 static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
 {
   pony_assert(astp != NULL);
@@ -1160,6 +1234,121 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
   {
     ast_setid(apply_cap, TK_AT);
     ast_setid(interface_cap, TK_VAL);
+  }
+
+  // When the lambda type sits inside a type parameter's default,
+  // collect_type_params captures the parameter being defaulted (and its
+  // later siblings) as type parameters of the generated interface.  Those
+  // captures produce an unbound TK_TYPEPARAMREF that reaches code
+  // generation and aborts.  Build a positional drop mask so we can filter
+  // each collected list before the $This append.
+  ast_t* defaulted_tp = find_enclosing_default(ast);
+  bool drop_mask[64];
+  size_t drop_count = 0;
+  memset(drop_mask, 0, sizeof(drop_mask));
+
+  if(defaulted_tp != NULL)
+  {
+    ast_t* tp_list = ast_parent(defaulted_tp);
+    size_t defaulted_index = ast_index(defaulted_tp);
+
+    // Walk entity params then method params (same order as
+    // collect_type_params) and mark the defaulted param and its later
+    // siblings as drop candidates.
+    ast_t* d_entity = ast;
+
+    while(d_entity != NULL && ast_id(d_entity) != TK_INTERFACE &&
+      ast_id(d_entity) != TK_TRAIT && ast_id(d_entity) != TK_PRIMITIVE &&
+      ast_id(d_entity) != TK_STRUCT && ast_id(d_entity) != TK_CLASS &&
+      ast_id(d_entity) != TK_ACTOR && ast_id(d_entity) != TK_TYPE)
+    {
+      d_entity = ast_parent(d_entity);
+    }
+
+    ast_t* d_method = ast;
+
+    while(d_method != NULL && ast_id(d_method) != TK_FUN &&
+      ast_id(d_method) != TK_NEW && ast_id(d_method) != TK_BE)
+    {
+      d_method = ast_parent(d_method);
+    }
+
+    ast_t* all_params[64];
+
+    if(d_entity != NULL)
+    {
+      ast_t* entity_tps = ast_childidx(d_entity, 1);
+
+      for(ast_t* p = ast_child(entity_tps); p != NULL; p = ast_sibling(p))
+      {
+        pony_assert(drop_count < 64);
+        all_params[drop_count] = p;
+        drop_mask[drop_count] =
+          (ast_parent(p) == tp_list) && (ast_index(p) >= defaulted_index);
+        drop_count++;
+      }
+    }
+
+    if(d_method != NULL)
+    {
+      ast_t* method_tps = ast_childidx(d_method, 2);
+
+      for(ast_t* p = ast_child(method_tps); p != NULL; p = ast_sibling(p))
+      {
+        pony_assert(drop_count < 64);
+        all_params[drop_count] = p;
+        drop_mask[drop_count] =
+          (ast_parent(p) == tp_list) && (ast_index(p) >= defaulted_index);
+        drop_count++;
+      }
+    }
+
+    // Retain candidates named in the lambda type's body.
+    for(size_t i = 0; i < drop_count; i++)
+    {
+      if(drop_mask[i])
+      {
+        const char* name = ast_name(ast_child(all_params[i]));
+
+        if(subtree_names_param(apply_t_params, name) ||
+          subtree_names_param(params, name) ||
+          subtree_names_param(ret_type, name))
+        {
+          drop_mask[i] = false;
+        }
+      }
+    }
+
+    // Retain candidates named by a retained param's constraint.
+    bool changed = true;
+
+    while(changed)
+    {
+      changed = false;
+
+      for(size_t i = 0; i < drop_count; i++)
+      {
+        if(!drop_mask[i])
+          continue;
+
+        const char* name = ast_name(ast_child(all_params[i]));
+
+        for(size_t j = 0; j < drop_count; j++)
+        {
+          if(drop_mask[j])
+            continue;
+
+          ast_t* constraint = ast_childidx(all_params[j], 1);
+
+          if(subtree_names_param(constraint, name))
+          {
+            drop_mask[i] = false;
+            changed = true;
+            break;
+          }
+        }
+      }
+    }
   }
 
   // Check if params or ret_type contain this-> viewpoints.
@@ -1198,6 +1387,9 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
   ast_t* interface_t_params;
   ast_t* t_args;
   collect_type_params(ast, NULL, &t_args, opt);
+
+  if(drop_count > 0)
+    filter_list(t_args, drop_mask, drop_count);
 
   if(has_thistype)
   {
@@ -1251,6 +1443,9 @@ static ast_result_t sugar_lambdatype(pass_opt_t* opt, ast_t** astp)
   // Fetch the interface type parameters after we replace the ast, so that if
   // we are an interface type parameter, we get ourselves as the constraint.
   collect_type_params(ast, &interface_t_params, NULL, opt);
+
+  if(drop_count > 0)
+    filter_list(interface_t_params, drop_mask, drop_count);
 
   if(has_thistype)
   {

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -152,6 +152,55 @@ static void reify_reference(pass_opt_t* opt, ast_t** astp, ast_t* typeparams, as
 }
 
 
+static const char* find_dangling_default_ref(ast_t* ast, ast_t* typeparams,
+  size_t pos)
+{
+  if(ast == NULL)
+    return NULL;
+
+  if(ast_id(ast) == TK_TYPEPARAMREF)
+  {
+    ast_t* ref_def = typeparam_root((ast_t*)ast_data(ast));
+    ast_t* tp = ast_child(typeparams);
+    size_t j = 0;
+
+    while(tp != NULL)
+    {
+      if(j >= pos)
+      {
+        ast_t* tp_root = typeparam_root(tp);
+        if(ref_def == tp_root)
+          return ast_name(ast_child(tp));
+      }
+      tp = ast_sibling(tp);
+      j++;
+    }
+  }
+
+  for(ast_t* child = ast_child(ast); child != NULL; child = ast_sibling(child))
+  {
+    const char* name = find_dangling_default_ref(child, typeparams, pos);
+    if(name != NULL)
+      return name;
+  }
+
+  return NULL;
+}
+
+// Reify a type parameter's default against the type arguments decided so far.
+// Sibling references in the default must already be TK_TYPEPARAMREF nodes
+// (via resolve_default_typeargs) so that reify() can substitute them.
+static ast_t* reify_default(ast_t* typeparam, ast_t* typeparams,
+  ast_t* typeargs_so_far, pass_opt_t* opt)
+{
+  ast_t* defarg = ast_childidx(typeparam, 2);
+
+  if(ast_id(defarg) == TK_NONE)
+    return NULL;
+
+  return reify(defarg, typeparams, typeargs_so_far, opt, true);
+}
+
 bool reify_defaults(ast_t* typeparams, ast_t* typeargs, bool errors,
   pass_opt_t* opt)
 {
@@ -189,11 +238,29 @@ bool reify_defaults(ast_t* typeparams, ast_t* typeargs, bool errors,
   {
     ast_t* defarg = ast_childidx(typeparam, 2);
 
-    if(ast_id(defarg) == TK_NONE)
+    const char* dangling = find_dangling_default_ref(defarg, typeparams,
+      arg_count);
+
+    if(dangling != NULL)
+    {
+      if(errors)
+      {
+        ast_error(opt->check.errors, typeargs, "not enough type arguments");
+        ast_error_continue(opt->check.errors, defarg,
+          "default refers to type parameter %s", dangling);
+      }
+
+      return false;
+    }
+
+    ast_t* reified = reify_default(typeparam, typeparams, typeargs, opt);
+
+    if(reified == NULL)
       break;
 
-    ast_append(typeargs, defarg);
+    ast_append(typeargs, reified);
     typeparam = ast_sibling(typeparam);
+    arg_count++;
   }
 
   if(typeparam != NULL)

--- a/test/libponyc/type_params.cc
+++ b/test/libponyc/type_params.cc
@@ -6,12 +6,19 @@
 #include "util.h"
 
 #define TEST_COMPILE(src) DO(test_compile(src, "expr"))
+#define TEST_COMPILE_IR(src) DO(test_compile(src, "ir"))
 #define TEST_ERROR(src) DO(test_error(src, "expr"))
 #define TEST_EQUIV(src, expect) DO(test_equiv(src, "expr", expect, "expr"))
 
 #define TEST_ERRORS_1(src, err1) \
   { const char* errs[] = {err1, NULL}; \
     DO(test_expected_errors(src, "ir", errs)); }
+
+#define TEST_ERROR_WITH_NOTE(src, primary, note) \
+  { const char* errs[] = {primary, NULL}; \
+    const char* frame_strs[] = {note, NULL}; \
+    const char** frames[] = {frame_strs, NULL}; \
+    DO(test_expected_error_frames(src, "ir", errs, frames)); }
 
 class TypeParamsTest : public PassTest
 {};
@@ -60,4 +67,604 @@ TEST_F(TypeParamsTest, ReifySimultaneously)
     " fun val bind[O2](next: State[S, O, O2]): State[S, I, O2]\n";
 
   TEST_COMPILE(src);
+}
+
+TEST_F(TypeParamsTest, DefaultRefersToEarlierParam_FunEquiv)
+{
+  // From issue #3540. A default naming an earlier parameter is reified.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A, B = A](a: A, b: B): None => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[String](\"a\", \"b\")\n";
+
+  const char* expect =
+    "primitive Bar\n"
+    "  fun foo[A, B = A](a: A, b: B): None => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[String, String](\"a\", \"b\")\n";
+
+  TEST_EQUIV(src, expect);
+}
+
+TEST_F(TypeParamsTest, DefaultRefersToEarlierParam_ClassAnnotation)
+{
+  const char* src =
+    "class Foo[A: Any val, B: Any val = A]\n"
+    "  let x: A\n"
+    "  let y: B\n"
+    "  new create(x': A, y': B) =>\n"
+    "    x = x'\n"
+    "    y = y'\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f: Foo[String] = Foo[String](\"hello\", \"world\")\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, DefaultRefersToEarlierParam_Alias)
+{
+  const char* src =
+    "class Foo[A: Any val, B: Any val = A]\n"
+    "  let x: A\n"
+    "  let y: B\n"
+    "  new create(x': A, y': B) =>\n"
+    "    x = x'\n"
+    "    y = y'\n"
+
+    "type Bar[A: Any val, B: Any val = A] is Foo[A, B]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let b: Bar[U8] = Foo[U8](U8(1), U8(2))\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, DefaultRefersToEarlierParam_Recursive)
+{
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val, B: Any val = A](a: A, again: Bool): None =>\n"
+    "    if again then\n"
+    "      foo[A](a, false)\n"
+    "    end\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[String](\"hello\", true)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, DefaultRefersToEarlierParam_ArrowRegression)
+{
+  const char* src =
+    "class Foo[A: Any val]\n"
+    "  fun f[B: Any #read = this->A](x: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo[U8].f(U8(1))\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, DefaultRefersToEarlierParam_IterIssue3540)
+{
+  // The original program from issue #3540.
+  const char* src =
+    "class Iter[A, I: Iterator[A] ref = Iterator[A] ref] is Iterator[A]\n"
+    "  let _inner: I\n"
+    "  new create(inner: I) =>\n"
+    "    _inner = inner\n"
+    "  fun ref has_next(): Bool =>\n"
+    "    _inner.has_next()\n"
+    "  fun ref next(): A ? =>\n"
+    "    _inner.next()?\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let iter = Iter[U8]([as U8: 0].values())\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, DefaultRefersToEarlierParam_ThreeLevelChain)
+{
+  // Three-level default chain: C defaults to B, B defaults to A.
+  const char* src =
+    "class Foo[A: Any val, B: Any val = A, C: Any val = B]\n"
+    "  let _a: A\n"
+    "  let _b: B\n"
+    "  let _c: C\n"
+    "  new create(a: A, b: B, c: C) =>\n"
+    "    _a = a\n"
+    "    _b = b\n"
+    "    _c = c\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo[U8](U8(1), U8(2), U8(3))\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+
+// Issue #5962: lambda type as a type parameter default.
+
+TEST_F(TypeParamsTest, LambdaDefault_MethodForm)
+{
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val = {(U8): U8} val](a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {(x: U8): U8 => x} val\n"
+    "    Bar.foo(f)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, LambdaDefault_ClassForm)
+{
+  const char* src =
+    "class Foo[A: Any val = {(U8): U8} val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {(x: U8): U8 => x} val\n"
+    "    Foo(f)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, LambdaDefault_ClassAnnotation)
+{
+  const char* src =
+    "class Foo[A: Any val = {(U8): U8} val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {(x: U8): U8 => x} val\n"
+    "    let x: Foo = Foo(f)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, LambdaDefault_PartialExplicit_Class)
+{
+  const char* src =
+    "class Foo[A: Any val, B: Any val = {(U8): U8} val]\n"
+    "  let _a: A\n"
+    "  let _b: B\n"
+    "  new create(a: A, b: B) =>\n"
+    "    _a = a\n"
+    "    _b = b\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {(x: U8): U8 => x} val\n"
+    "    Foo[U8](U8(1), f)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, LambdaDefault_PartialExplicit_Method)
+{
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val, B: Any val = {(U8): U8} val](a: A, b: B)"
+    "  => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {(x: U8): U8 => x} val\n"
+    "    Bar.foo[U8](U8(1), f)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, LambdaDefault_OwnTypeParams_Single)
+{
+  // {[X: Any val](X): X} val as a default on the only type param.
+  // The interface ends up with no type params (only the defaulted one,
+  // which is dropped).
+  const char* src =
+    "class Foo[A: Any val = {[X: Any val](X): X} val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[X: Any val](x: X): X => x} val\n"
+    "    Foo(f)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, LambdaDefault_OwnTypeParams_WithEarlierSibling)
+{
+  // {[X: Any val](X): X} val as a default with an earlier sibling.
+  // The interface keeps A (the earlier sibling).
+  const char* src =
+    "class Foo[A: Any val, B: Any val = {[X: Any val](X): X} val]\n"
+    "  let _a: A\n"
+    "  let _b: B\n"
+    "  new create(a: A, b: B) =>\n"
+    "    _a = a\n"
+    "    _b = b\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {[X: Any val](x: X): X => x} val\n"
+    "    Foo[U8](U8(1), f)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, LambdaDefault_AliasWrittenStillWorks)
+{
+  const char* src =
+    "type Fn is {(U8): U8} val\n"
+
+    "primitive Bar\n"
+    "  fun foo[A: Any val = Fn](a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {(x: U8): U8 => x} val\n"
+    "    Bar.foo(f)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, LambdaDefault_SelfRefWithWrittenArg)
+{
+  // [A = {(A): A} val] used as Foo[U8] — the type argument is written,
+  // so the default is not used and the self-reference is harmless.
+  const char* src =
+    "class Foo[A: Any val = {(A): A} val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo[U8](U8(1))\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, LambdaDefault_ConstraintKept_WrittenArgs)
+{
+  // B is kept because A's constraint names B.
+  const char* src =
+    "class Foo[A: (B | None), B: Any val = {(U8): U8} val]\n"
+    "  let _a: A\n"
+    "  let _b: B\n"
+    "  new create(a: A, b: B) =>\n"
+    "    _a = a\n"
+    "    _b = b\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f = {(x: U8): U8 => x} val\n"
+    "    Foo[None, {(U8): U8} val](None, f)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+
+// Issue #5957: default naming itself or a later sibling.
+
+TEST_F(TypeParamsTest, DanglingDefault_ClassAnnotation)
+{
+  const char* src =
+    "class Foo[A: Any val = B, B: Any val = U8]\n"
+    "  new create() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Foo = Foo\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter B");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_MethodCall)
+{
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val = B, B: Any val = U8](x: U8) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1))\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter B");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_PartialExplicit_Class)
+{
+  const char* src =
+    "class Foo[A: Any val, B: Any val = C, C: Any val = U8]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo[U8](U8(1))\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter C");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_PartialExplicit_Method)
+{
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val, B: Any val = C, C: Any val = U8]"
+    "(x: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1))\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter C");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_SelfRef_Class)
+{
+  const char* src =
+    "class Foo[A: Any val = A]\n"
+    "  new create() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Foo = Foo\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter A");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_SelfRef_Method)
+{
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val = A](x: U8) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1))\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter A");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_Nested)
+{
+  const char* src =
+    "class Foo[A: Any val = Array[B] val, B: Any val = U8]\n"
+    "  new create() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Foo = Foo\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter B");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_Alias)
+{
+  const char* src =
+    "class Foo[A: Any val = B, B: Any val = U8]\n"
+    "  new create() => None\n"
+
+    "type Bar is Foo\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Bar = Foo\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter B");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_LambdaSelfRef_Unused)
+{
+  // A self-referencing lambda default at an unreached annotation site.
+  // The default has no meaning (it refers to itself) and is rejected.
+  const char* src =
+    "class Foo[A: Any val = {(A): A} val]\n"
+    "  new create() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Foo = Foo\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter A");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_LambdaConstraintKeepsB)
+{
+  // A defaults to B, B defaults to a lambda. The dangling check fires
+  // on A's default because it names B (a later sibling).
+  const char* src =
+    "class Foo[A: Any val = B, B: Any val = {(U8): U8} val]\n"
+    "  new create() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Foo = Foo\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter B");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_LambdaOwnParam_NamesLaterSibling)
+{
+  // {[X: B](X): X} val as a default on A, where B is a later sibling.
+  const char* src =
+    "class Foo[A: Any val = {[X: B](X): X} val, B: Any val = U8]\n"
+    "  new create() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Foo = Foo\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter B");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_LambdaConstraintNamesB)
+{
+  // B's default {(U8): U8} val doesn't name B, but A's constraint
+  // (B | None) does. The constraint dependency keeps B in the
+  // sugared interface, making the nominal $0[A, B] reference B.
+  const char* src =
+    "class Foo[A: (B | None), B: Any val = {(U8): U8} val]\n"
+    "  new create() => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Foo[None] = Foo[None]\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter B");
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_LambdaOwnParamDefaultedByLater)
+{
+  // {[X: Any val = B](X): X} val where B is a later sibling. The
+  // lambda's own type parameter X has a default naming B.
+  const char* src =
+    "class Foo[A: Any val = {[X: Any val = B](X): X} val,"
+    " B: Any val = U8]\n"
+    "  new create() => None\n"
+
+    "primitive Bar\n"
+    "  fun foo[A: Any val = {[X: Any val = B](X): X} val,"
+    " B: Any val = U8](x: U8) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1))\n";
+
+  TEST_ERROR_WITH_NOTE(src, "not enough type arguments",
+    "default refers to type parameter B");
+}
+
+// Green pins for #5957: these must keep compiling.
+
+TEST_F(TypeParamsTest, DanglingDefault_ConstraintOnly_Green)
+{
+  // A constraint naming a later sibling is legal.
+  const char* src =
+    "class Foo[A: (B | None), B: Any val = U8]\n"
+    "  let _a: A\n"
+    "  let _b: B\n"
+    "  new create(a: A, b: B) =>\n"
+    "    _a = a\n"
+    "    _b = b\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo[U8](U8(1), U8(2))\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_WrittenArgs_Green)
+{
+  // Dangling default, but all type arguments are written, so the default
+  // is never used.
+  const char* src =
+    "class Foo[A: Any val = B, B: Any val = U8]\n"
+    "  let _a: A\n"
+    "  let _b: B\n"
+    "  new create(a: A, b: B) =>\n"
+    "    _a = a\n"
+    "    _b = b\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo[U8, U8](U8(1), U8(2))\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_DefinitionOnly_Green)
+{
+  // A definition with a dangling default that is only ever used with
+  // written type arguments keeps compiling.
+  const char* src =
+    "class Foo[A: Any val = B, B: Any val = U8]\n"
+    "  let _a: A\n"
+    "  let _b: B\n"
+    "  new create(a: A, b: B) =>\n"
+    "    _a = a\n"
+    "    _b = b\n"
+
+    "primitive Bar\n"
+    "  fun foo(x: Foo[U8, U8]) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(Foo[U8, U8](U8(1), U8(2)))\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_RecursiveMethod_Green)
+{
+  // A method that calls itself with [B] — B is the method's own type
+  // parameter whose default is A (an earlier sibling). The call supplies
+  // B from the caller's scope, so no dangling reference. The recursive
+  // call passes b (type B) as both arguments; in the recursive frame
+  // A=B and B=A (from the default), so both parameters accept B.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val, B: Any val = A](a: A, b: B,"
+    " again: Bool): None =>\n"
+    "    if again then\n"
+    "      foo[B](b, b, false)\n"
+    "    end\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[String](\"hello\", \"world\", true)\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeParamsTest, DanglingDefault_ReturnUsesLaterParam_Green)
+{
+  // fun g(): (Foo[B] | None) with both arguments written at the call.
+  const char* src =
+    "class Foo[A: Any val, B: Any val = A]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+    "  fun g(): (Foo[B] val | None) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let f: Foo[U8, U8] val = Foo[U8](U8(1))\n"
+    "    f.g()\n";
+
+  TEST_COMPILE_IR(src);
 }


### PR DESCRIPTION
Three interacting bugs prevented type parameter defaults from working when they referenced other type parameters.

**Earlier-sibling defaults** (#3540): `[A, B = A]` — the default was not reified against type arguments already decided, so the raw reference survived into later passes and crashed or produced a spurious constraint error.

**Lambda-type defaults** (#5962): `[A = {(U8): U8} val]` — the generated interface captured the parameter being defaulted, producing an unbound reference that crashed at codegen. This was a prerequisite for #5957.

**Self/later-sibling defaults** (#5957): `[A = B, B = U8]` — the unsubstituted reference reached codegen undetected. The compiler now reports "not enough type arguments" with a continuation naming the offending parameter. Programs that supply all type arguments explicitly keep compiling.

Unreachable annotation sites that relied on a meaningless self-referencing default (e.g. `class Foo[A = A]` used only in `fun unused(x: Foo)`) are now rejected — the default has no meaning and was accepted only because codegen never processed the unreached site.
