### PR TITLE
Fix compiler crash on generic calls in runtime_override_defaults

### DIFF
--- a/.release-notes/fix-runtime-override-typeargs.md
+++ b/.release-notes/fix-runtime-override-typeargs.md
@@ -1,0 +1,15 @@
+## Fix compiler crash on generic calls in runtime_override_defaults
+
+Calling a primitive's function with type arguments inside `runtime_override_defaults` crashed the compiler with an assertion failure instead of compiling the program.
+
+```pony
+primitive P
+  fun @get[B: Any val](b: B): U32 => 4
+
+actor Main
+  new create(env: Env) => None
+  fun @runtime_override_defaults(rto: RuntimeOptions) =>
+    rto.ponymaxthreads = P.get[U8](U8(1))
+```
+
+The same crash occurred with constructor calls that supply type arguments, such as `P.create[U8](U8(1)).get()`. Generic calls on primitives in `runtime_override_defaults` now compile as expected.

--- a/src/libponyc/verify/fun.c
+++ b/src/libponyc/verify/fun.c
@@ -14,8 +14,11 @@ static bool verify_calls_runtime_override(pass_opt_t* opt, ast_t* ast)
   if((tk == TK_NEWREF) || (tk == TK_NEWBEREF) ||
      (tk == TK_FUNREF) || (tk == TK_BEREF))
   {
-    ast_t* method = ast_sibling(ast_child(ast));
     ast_t* receiver = ast_child(ast);
+    ast_t* method = ast_sibling(receiver);
+
+    if(ast_id(receiver) == ast_id(ast))
+      AST_GET_CHILDREN_NO_DECL(receiver, receiver, method);
 
     // Look up the original method definition for this method call.
     deferred_reification_t* method_def = lookup(opt, ast, ast_type(receiver),

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -4119,3 +4119,79 @@ TEST_F(BadPonyTest, NamedLiteralArgumentToObjectWithoutApplyReportsOnce)
   TEST_ERRORS_1(src, "couldn't find 'apply' in 'NoApply'");
 }
 
+TEST_F(BadPonyTest, RuntimeOverrideDefaultsGenericCallOnPrimitive)
+{
+  const char* src =
+    "primitive P\n"
+    "  fun @get[B: Any val](b: B): U32 => 4\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun @runtime_override_defaults(rto: RuntimeOptions) =>\n"
+    "    P.get[U8](U8(1))";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, RuntimeOverrideDefaultsGenericConstructorOnPrimitive)
+{
+  const char* src =
+    "primitive P\n"
+    "  new create[B: Any val](b: B) => None\n"
+    "  fun @result(): U32 => 4\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun @runtime_override_defaults(rto: RuntimeOptions) =>\n"
+    "    P.create[U8](U8(1)).result()";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(BadPonyTest, RuntimeOverrideDefaultsGenericCallOnNonPrimitive)
+{
+  const char* src =
+    "class Foo\n"
+    "  var x: U32 = 0\n"
+    "  fun @get[B: Any val](b: B): U32 => 4\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun @runtime_override_defaults(rto: RuntimeOptions) =>\n"
+    "    Foo.get[U8](U8(1))";
+
+  TEST_ERRORS_1(src,
+    "the runtime_override_defaults method of the Main actor can only call "
+    "functions on primitives");
+}
+
+TEST_F(BadPonyTest, RuntimeOverrideDefaultsGenericConstructorOnNonPrimitive)
+{
+  const char* src =
+    "class Foo\n"
+    "  new create[B: Any val](b: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun @runtime_override_defaults(rto: RuntimeOptions) =>\n"
+    "    Foo.create[U8](U8(1))";
+
+  TEST_ERRORS_1(src,
+    "the runtime_override_defaults method of the Main actor can only call "
+    "functions on primitives");
+}
+
+TEST_F(BadPonyTest, RuntimeOverrideDefaultsDefaultedTypeParamsOnPrimitive)
+{
+  const char* src =
+    "primitive P\n"
+    "  fun @get[B: Any val = U8](b: B): U32 => 4\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n"
+    "  fun @runtime_override_defaults(rto: RuntimeOptions) =>\n"
+    "    P.get(U8(1))";
+
+  TEST_COMPILE(src);
+}
+


### PR DESCRIPTION
When a call inside `runtime_override_defaults` supplies type arguments (explicit or defaulted), the compiler wraps the method reference in a qualification node. `verify_calls_runtime_override` read the second child of that wrapper as the method name, hitting the `TK_STRING`/`TK_ID` assertion on the `TK_TYPEARGS` node instead.

Unwrap the qualification wrapper before extracting the receiver and method name — the same check `verify/call.c` and `is_call_to_method` already do.

Closes #5963