### PR TITLE
Improve error for match capture without let

### DIFF
--- a/src/libponyc/ast/parser.c
+++ b/src/libponyc/ast/parser.c
@@ -810,6 +810,18 @@ DEF(caseexpr);
   SKIP(NULL, TK_PIPE);
   ANNOTATE(annotations);
   OPT RULE("case pattern", casepattern);
+  REWRITE(
+    if(parser_current_token_id(parser) == TK_COLON)
+    {
+      ast_t* pattern = ast_child(ast);
+      ast_error(parser_errors(parser), pattern != NULL ? pattern : ast,
+        "match capture requires 'let', e.g. 'let <name>: <type>'");
+      parser_set_failed(parser);
+      ast_free(ast);
+      ast = NULL;
+      return PARSE_ERROR;
+    }
+  );
   IF(TK_IF, RULE("guard expression", rawseq));
   IF(TK_DBLARROW, RULE("case body", rawseq));
   DONE();

--- a/src/libponyc/ast/parserapi.c
+++ b/src/libponyc/ast/parserapi.c
@@ -550,6 +550,27 @@ void parse_set_next_flags(parser_t* parser, uint32_t flags)
 }
 
 
+token_id parser_current_token_id(parser_t* parser)
+{
+  pony_assert(parser != NULL);
+  return current_token_id(parser);
+}
+
+
+errors_t* parser_errors(parser_t* parser)
+{
+  pony_assert(parser != NULL);
+  return parser->errors;
+}
+
+
+void parser_set_failed(parser_t* parser)
+{
+  pony_assert(parser != NULL);
+  parser->failed = true;
+}
+
+
 /* Tidy up a successfully parsed rule.
  * Args:
  *    rule_set is a NULL terminated list.

--- a/src/libponyc/ast/parserapi.h
+++ b/src/libponyc/ast/parserapi.h
@@ -129,6 +129,11 @@ void parse_set_next_flags(parser_t* parser, uint32_t flags);
 
 ast_t* parse_rule_complete(parser_t* parser, rule_state_t* state);
 
+token_id parser_current_token_id(parser_t* parser);
+
+errors_t* parser_errors(parser_t* parser);
+
+void parser_set_failed(parser_t* parser);
 
 // External API
 

--- a/test/libponyc/parse_expr.cc
+++ b/test/libponyc/parse_expr.cc
@@ -327,6 +327,20 @@ TEST_F(ParseExprTest, ParenthesisedSequenceDoesNotLeakMissingSemicolon)
   TEST_COMPILE(src);
 }
 
+TEST_F(ParseExprTest, MatchCaptureWithoutLetGivesSpecificError)
+{
+  const char* src =
+    "class Foo\n"
+    "  fun m() =>\n"
+    "    let a: (I64 | None) = 7\n"
+    "    match a\n"
+    "    | n: I64 => None\n"
+    "    end";
+
+  TEST_ERRORS_1(src, "match capture requires 'let'");
+}
+
+
 // Regression test for #3660: a long statement sequence must not overflow the
 // parser stack. The old right-recursive grammar recursed once per statement; a
 // regression to it fails this test by overflowing the stack (a crash that


### PR DESCRIPTION
When a user writes `| n: I64 =>` instead of `| let n: I64 =>`, the parser now reports "match capture requires 'let'" pointing at the pattern, instead of the confusing "unterminated match expression" pointing at the match keyword.

The fix uses a REWRITE block in the caseexpr parser rule to detect a colon following the case pattern — a token that is never valid in that position — and emit a targeted error. Three small accessor functions (`parser_current_token_id`, `parser_errors`, `parser_set_failed`) are added to the parser API so that grammar rules can peek at the current token and report errors through the opaque `parser_t`.

The REWRITE approach was chosen because `parser.c` is compiled twice — once as the real parser and once `#include`d by `bnfprint.c` for grammar printing. REWRITE is a no-op in bnfprint, so the error-handling code compiles cleanly in both contexts. IF-based approaches failed because bnfprint expands the IF body in a context that lacks parser state variables.

Closes #1479
