### PR TITLE
Fix type parameters constrained by other type parameters

### DIFF
--- a/.release-notes/fix-constrained-typeparam-subtyping.md
+++ b/.release-notes/fix-constrained-typeparam-subtyping.md
@@ -1,0 +1,11 @@
+## Fix type parameters constrained by other type parameters
+
+When one type parameter was constrained by another, the compiler rejected code that treated the constrained parameter as a subtype of its constraint:
+
+```pony
+class A[X, Y: X]
+  fun foo(y: Y) =>
+    let x: X = consume y
+```
+
+The constraint `Y: X` declares that `Y` is a subtype of `X`, and the compiler now accepts this. Transitive chains also work: `Z: Y` and `Y: X` together imply `Z` is a subtype of `X`.

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -1536,6 +1536,38 @@ static bool is_typeparam_sub_typeparam(ast_t* sub, ast_t* super,
   if(sub_def == super_def)
     return is_sub_cap_and_eph(sub, super, check_cap, errorf, opt);
 
+  // Walk sub's constraint chain to see if super appears in it. When a type
+  // parameter Y is constrained by another type parameter X (class A[X, Y: X]),
+  // Y <: X holds by the constraint declaration. Unconstrained parameters are
+  // represented internally as self-constrained (X: X), so the walk terminates
+  // on a cycle without false positives.
+  ast_t* walk = sub_def;
+  astlist_t* visited = astlist_push(NULL, walk);
+
+  while(true)
+  {
+    ast_t* constraint = ast_childidx(walk, 1);
+
+    if(ast_id(constraint) != TK_TYPEPARAMREF)
+      break;
+
+    ast_t* constraint_def = typeparam_root((ast_t*)ast_data(constraint));
+
+    if(constraint_def == super_def)
+    {
+      astlist_free(visited);
+      return is_sub_cap_and_eph(sub, super, check_cap, errorf, opt);
+    }
+
+    if(astlist_find(visited, constraint_def))
+      break;
+
+    visited = astlist_push(visited, constraint_def);
+    walk = constraint_def;
+  }
+
+  astlist_free(visited);
+
   if(errorf != NULL)
   {
     ast_error_frame(errorf, sub,

--- a/test/libponyc/type_params.cc
+++ b/test/libponyc/type_params.cc
@@ -668,3 +668,74 @@ TEST_F(TypeParamsTest, DanglingDefault_ReturnUsesLaterParam_Green)
 
   TEST_COMPILE_IR(src);
 }
+
+TEST_F(TypeParamsTest, ConstrainedByTypeParam_DirectAssignment)
+{
+  // From issue #1697: Y constrained by X implies Y <: X.
+  const char* src =
+    "class A[X, Y: X]\n"
+    "  fun foo(y: Y) =>\n"
+    "    let x: X = consume y\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(TypeParamsTest, ConstrainedByTypeParam_CrossClassTypeArg)
+{
+  // From issue #1697: Y constrained by X can be passed as a type argument
+  // to another class with the same constraint.
+  const char* src =
+    "class B[X, Y: X]\n"
+    "class A[X, Y: X]\n"
+    "  var f: B[X, Y] = B[X, Y]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(TypeParamsTest, ConstrainedByTypeParam_Transitive)
+{
+  // Transitive constraint: Z: Y and Y: X implies Z <: X directly, not just
+  // Z <: Y and Y <: X as separate single steps.
+  const char* src =
+    "class A[X, Y: X, Z: Y]\n"
+    "  fun foo(z: Z) =>\n"
+    "    let x: X = consume z\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(TypeParamsTest, ConstrainedByTypeParam_ReverseNotSubtype)
+{
+  // X is NOT constrained by Y, so X <: Y must fail.
+  const char* src =
+    "class A[X, Y: X]\n"
+    "  fun foo(x: X) =>\n"
+    "    let y: Y = consume x\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n";
+
+  TEST_ERROR(src);
+}
+
+TEST_F(TypeParamsTest, ConstrainedByTypeParam_SelfReferentialStillWorks)
+{
+  // A type using itself with its own params should still compile.
+  const char* src =
+    "class A[X, Y: X]\n"
+    "  var f: A[X, Y] = A[X, Y]\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None\n";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
When one type parameter is constrained by another (`class A[X, Y: X]`), Y <: X should hold — the constraint declares it. The subtype checker only compared type parameter identity; it never walked the constraint chain, so Y and X looked like unrelated parameters. The fallback through the upper-bound machinery couldn't help either because unconstrained parameters are internally self-constrained (X: X), which the constraint resolver treated as a cycle and returned NULL.

Walk the constraint chain in `is_typeparam_sub_typeparam`: after the identity check fails, follow sub's constraint links looking for super's definition, using a visited set for cycle termination. When the chain reaches super, delegate to the existing capability check.

Closes #1697
