### PR TITLE
Add min parameter to PonyCheck set and map generators

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -977,3 +977,35 @@ class A[X, Y: X]
 
 The constraint `Y: X` declares that `Y` is a subtype of `X`, and the compiler now accepts this. Transitive chains also work: `Z: Y` and `Y: X` together imply `Z` is a subtype of `X`.
 
+## Add min parameter to PonyCheck set and map generators
+
+`Generators.set_of`, `Generators.set_is_of`, `Generators.map_of`, and `Generators.map_is_of` now accept `min` and `max` parameters, matching the existing convention in `Generators.seq_of`. The defaults are `min = 0` and `max = 100`.
+
+To generate non-empty collections, pass `min = 1`:
+
+```pony
+let non_empty_set_gen =
+  Generators.set_of[U8](Generators.u8() where min = 1)
+
+let non_empty_map_gen =
+  Generators.map_of[String, I64](
+    Generators.zip2[String, I64](
+      Generators.ascii_printable(1, 10),
+      Generators.i64())
+    where min = 1)
+```
+
+The `min` value is the minimum number of insertion attempts, not a guaranteed minimum collection size. Duplicate keys or values can reduce the final size below `min`.
+
+## Change PonyCheck set and map generator parameter order from (gen, max) to (gen, min, max)
+
+The parameter order for `Generators.set_of`, `Generators.set_is_of`, `Generators.map_of`, and `Generators.map_is_of` changed from `(gen, max)` to `(gen, min, max)` to match `Generators.seq_of`. Callers that passed `max` positionally need to switch to a named argument:
+
+```pony
+// Before
+Generators.set_of[U8](Generators.u8(), 50)
+
+// After
+Generators.set_of[U8](Generators.u8() where max = 50)
+```
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Added
 
+- Add min parameter to PonyCheck set and map generators ([PR #5973](https://github.com/ponylang/ponyc/pull/5973))
 - Add --pass-timings/--pass-timings-json for profiling compiler pass times ([PR #5792](https://github.com/ponylang/ponyc/pull/5792))
 - Add multi-iterator for loop sugar ([PR #5896](https://github.com/ponylang/ponyc/pull/5896))
 - Add `\c_api\` annotation for C-ABI interop ([PR #5898](https://github.com/ponylang/ponyc/pull/5898))
@@ -65,6 +66,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
+- Change PonyCheck set and map generator parameter order from `(gen, max)` to `(gen, min, max)` ([PR #5973](https://github.com/ponylang/ponyc/pull/5973))
 - Type parameter constraints now respect the default cap of the named type ([PR #5886](https://github.com/ponylang/ponyc/pull/5886))
 - Applying a capability to a tuple type alias is a compile error ([PR #5900](https://github.com/ponylang/ponyc/pull/5900))
 - Don't box machine words smaller than 64 bits ([PR #5952](https://github.com/ponylang/ponyc/pull/5952))

--- a/packages/pony_check/_random_case.pony
+++ b/packages/pony_check/_random_case.pony
@@ -31,9 +31,13 @@ actor \nodoc\ Main is TestList
     test(_MapIsOfEmptyTest)
     test(_MapIsOfIdentityTest)
     test(_MapIsOfMaxTest)
+    test(_MapIsOfMinShrinkTest)
+    test(_MapIsOfMinTest)
     test(_MapOfEmptyTest)
     test(_MapOfIdentityTest)
     test(_MapOfMaxTest)
+    test(_MapOfMinShrinkTest)
+    test(_MapOfMinTest)
     test(_MinASCIIStringShrinkTest)
     test(_MinUnicodeStringShrinkTest)
     test(_MultipleForAllTest)
@@ -75,8 +79,13 @@ actor \nodoc\ Main is TestList
     test(_RunnerSometimesErroringGeneratorTest)
     test(_SeqOfTest)
     test(_SetIsOfIdentityTest)
+    test(_SetIsOfMinShrinkTest)
+    test(_SetIsOfMinTest)
     test(_SetOfEmptyTest)
     test(_SetOfMaxTest)
+    test(_SetOfMinMaxEqualTest)
+    test(_SetOfMinShrinkTest)
+    test(_SetOfMinTest)
     test(_SetOfTest)
     test(_SignedShrinkTest)
     test(_StringifyTest)
@@ -660,8 +669,8 @@ class \nodoc\ iso _SetOfTest is UnitTest
     """
     let set_gen =
       Generators.set_of[U8](
-        Generators.u8(),
-        1024)
+        Generators.u8()
+        where max = 1024)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
       let sample: Set[U8] = set_gen.generate_value(rnd)?
@@ -678,8 +687,8 @@ class \nodoc\ iso _SetOfMaxTest is UnitTest
     for size in Range[USize](1, U8.max_value().usize()) do
       let set_gen =
         Generators.set_of[U8](
-          Generators.u8(),
-          size)
+          Generators.u8()
+          where max = size)
       let sample: Set[U8] = set_gen.generate_value(rnd)?
       h.assert_true(sample.size() <= size, "generated set is too big.")
     end
@@ -692,8 +701,8 @@ class \nodoc\ iso _SetOfEmptyTest is UnitTest
     """
     let set_gen =
       Generators.set_of[U8](
-        Generators.u8(),
-        0)
+        Generators.u8()
+        where max = 0)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
       let sample: Set[U8] = set_gen.generate_value(rnd)?
@@ -708,8 +717,8 @@ class \nodoc\ iso _SetIsOfIdentityTest is UnitTest
     """
     let set_is_gen_same =
       Generators.set_is_of[String](
-        Generators.unit[String]("the highlander"),
-        100)
+        Generators.unit[String]("the highlander")
+        where max = 100)
     let rnd = Randomness(Time.millis())
     let sample: SetIs[String] = set_is_gen_same.generate_value(rnd)?
     h.assert_true(
@@ -730,8 +739,8 @@ class \nodoc\ iso _MapOfEmptyTest is UnitTest
               let s = u.string()
               consume s
             }),
-          Generators.i64(-10, 10)),
-        0)
+          Generators.i64(-10, 10))
+        where max = 0)
     let rnd = Randomness(Time.millis())
     let sample = map_gen.generate_value(rnd)?
     h.assert_eq[USize](sample.size(), 0, "non-empty map created")
@@ -749,9 +758,8 @@ class \nodoc\ iso _MapOfMaxTest is UnitTest
             Generators.u16().map[String^]({(u: U16): String^ =>
               u.string()
             }),
-            Generators.i64(-10, 10)
-            ),
-        size)
+            Generators.i64(-10, 10))
+          where max = size)
       let sample = map_gen.generate_value(rnd)?
       h.assert_true(sample.size() <= size, "generated map is too big.")
     end
@@ -770,8 +778,8 @@ class \nodoc\ iso _MapOfIdentityTest is UnitTest
               s.add("the highlander")
               consume s
             }),
-          Generators.i64(-10, 10)),
-      100)
+          Generators.i64(-10, 10))
+        where max = 100)
     let sample = map_gen.generate_value(rnd)?
     h.assert_true(sample.size() <= 1)
 
@@ -789,8 +797,8 @@ class \nodoc\ iso _MapIsOfEmptyTest is UnitTest
               let s = u.string()
               consume s
             }),
-          Generators.i64(-10, 10)),
-        0)
+          Generators.i64(-10, 10))
+        where max = 0)
     let rnd = Randomness(Time.millis())
     let sample = map_is_gen.generate_value(rnd)?
     h.assert_eq[USize](sample.size(), 0, "non-empty map created")
@@ -810,8 +818,8 @@ class \nodoc\ iso _MapIsOfMaxTest is UnitTest
                 let s = u.string()
                 consume s
               }),
-            Generators.i64(-10, 10)),
-        size)
+            Generators.i64(-10, 10))
+          where max = size)
       let sample = map_is_gen.generate_value(rnd)?
       h.assert_true(sample.size() <= size, "generated map is too big.")
     end
@@ -825,11 +833,204 @@ class \nodoc\ iso _MapIsOfIdentityTest is UnitTest
       Generators.map_is_of[String, I64](
         Generators.zip2[String, I64](
           Generators.unit[String]("the highlander"),
-          Generators.i64(-10, 10)
-          ),
-      100)
+          Generators.i64(-10, 10))
+        where max = 100)
     let sample = map_gen.generate_value(rnd)?
     h.assert_true(sample.size() <= 1)
+
+class \nodoc\ iso _SetOfMinTest is UnitTest
+  fun name(): String => "Gen/set_of_min"
+
+  fun apply(h: TestHelper) ? =>
+    let set_gen =
+      Generators.set_of[U8](
+        Generators.u8()
+        where min = 1)
+    let rnd = Randomness(Time.millis())
+    for i in Range(0, 100) do
+      let sample: Set[U8] = set_gen.generate_value(rnd)?
+      h.assert_true(
+        sample.size() >= 1,
+        "empty set created with min = 1")
+    end
+
+class \nodoc\ iso _SetOfMinShrinkTest is UnitTest
+  fun name(): String => "Gen/set_of_min_shrink"
+
+  fun apply(h: TestHelper) ? =>
+    let set_gen =
+      Generators.set_of[U8](
+        Generators.u8()
+        where min = 5)
+    let rnd = Randomness(Time.millis())
+    match set_gen.generate(rnd)?
+    | (let sample: Set[U8], let shrinks: Iterator[Set[U8]^]) =>
+      h.assert_true(
+        sample.size() >= 5,
+        "generated set has fewer than 5 elements")
+      for shrunk in shrinks do
+        h.assert_true(
+          shrunk.size() >= 5,
+          "shrunk set has fewer than 5 elements")
+      end
+    else
+      h.fail("set_of did not produce shrinks")
+    end
+
+class \nodoc\ iso _SetIsOfMinTest is UnitTest
+  fun name(): String => "Gen/set_is_of_min"
+
+  fun apply(h: TestHelper) ? =>
+    let set_is_gen =
+      Generators.set_is_of[String](
+        Generators.ascii(where min = 1, max = 10)
+        where min = 1)
+    let rnd = Randomness(Time.millis())
+    for i in Range(0, 100) do
+      let sample: SetIs[String] = set_is_gen.generate_value(rnd)?
+      h.assert_true(
+        sample.size() >= 1,
+        "empty SetIs created with min = 1")
+    end
+
+class \nodoc\ iso _MapOfMinTest is UnitTest
+  fun name(): String => "Gen/map_of_min"
+
+  fun apply(h: TestHelper) ? =>
+    let map_gen =
+      Generators.map_of[String, I64](
+        Generators.zip2[String, I64](
+          Generators.u16().map[String^]({(u: U16): String^ =>
+            u.string()
+          }),
+          Generators.i64(-10, 10))
+        where min = 1)
+    let rnd = Randomness(Time.millis())
+    for i in Range(0, 100) do
+      let sample = map_gen.generate_value(rnd)?
+      h.assert_true(
+        sample.size() >= 1,
+        "empty map created with min = 1")
+    end
+
+class \nodoc\ iso _MapIsOfMinTest is UnitTest
+  fun name(): String => "Gen/map_is_of_min"
+
+  fun apply(h: TestHelper) ? =>
+    let map_is_gen =
+      Generators.map_is_of[String, I64](
+        Generators.zip2[String, I64](
+          Generators.u16().map[String^]({(u: U16): String^ =>
+            u.string()
+          }),
+          Generators.i64(-10, 10))
+        where min = 1)
+    let rnd = Randomness(Time.millis())
+    for i in Range(0, 100) do
+      let sample = map_is_gen.generate_value(rnd)?
+      h.assert_true(
+        sample.size() >= 1,
+        "empty MapIs created with min = 1")
+    end
+
+class \nodoc\ iso _SetIsOfMinShrinkTest is UnitTest
+  fun name(): String => "Gen/set_is_of_min_shrink"
+
+  fun apply(h: TestHelper) ? =>
+    let set_is_gen =
+      Generators.set_is_of[String](
+        Generators.ascii(where min = 1, max = 10)
+        where min = 5)
+    let rnd = Randomness(Time.millis())
+    match set_is_gen.generate(rnd)?
+    | (let sample: SetIs[String], let shrinks: Iterator[SetIs[String]^]) =>
+      h.assert_true(
+        sample.size() >= 5,
+        "generated SetIs has fewer than 5 elements")
+      for shrunk in shrinks do
+        h.assert_true(
+          shrunk.size() >= 5,
+          "shrunk SetIs has fewer than 5 elements")
+      end
+    else
+      h.fail("set_is_of did not produce shrinks")
+    end
+
+class \nodoc\ iso _MapOfMinShrinkTest is UnitTest
+  fun name(): String => "Gen/map_of_min_shrink"
+
+  fun apply(h: TestHelper) ? =>
+    let map_gen =
+      Generators.map_of[String, I64](
+        Generators.zip2[String, I64](
+          Generators.u16().map[String^]({(u: U16): String^ =>
+            u.string()
+          }),
+          Generators.i64(-10, 10))
+        where min = 5)
+    let rnd = Randomness(Time.millis())
+    match map_gen.generate(rnd)?
+    | (let sample: Map[String, I64],
+      let shrinks: Iterator[Map[String, I64]^])
+    =>
+      h.assert_true(
+        sample.size() >= 5,
+        "generated Map has fewer than 5 elements")
+      for shrunk in shrinks do
+        h.assert_true(
+          shrunk.size() >= 5,
+          "shrunk Map has fewer than 5 elements")
+      end
+    else
+      h.fail("map_of did not produce shrinks")
+    end
+
+class \nodoc\ iso _MapIsOfMinShrinkTest is UnitTest
+  fun name(): String => "Gen/map_is_of_min_shrink"
+
+  fun apply(h: TestHelper) ? =>
+    let map_is_gen =
+      Generators.map_is_of[String, I64](
+        Generators.zip2[String, I64](
+          Generators.u16().map[String^]({(u: U16): String^ =>
+            u.string()
+          }),
+          Generators.i64(-10, 10))
+        where min = 5)
+    let rnd = Randomness(Time.millis())
+    match map_is_gen.generate(rnd)?
+    | (let sample: MapIs[String, I64],
+      let shrinks: Iterator[MapIs[String, I64]^])
+    =>
+      h.assert_true(
+        sample.size() >= 5,
+        "generated MapIs has fewer than 5 elements")
+      for shrunk in shrinks do
+        h.assert_true(
+          shrunk.size() >= 5,
+          "shrunk MapIs has fewer than 5 elements")
+      end
+    else
+      h.fail("map_is_of did not produce shrinks")
+    end
+
+class \nodoc\ iso _SetOfMinMaxEqualTest is UnitTest
+  fun name(): String => "Gen/set_of_min_max_equal"
+
+  fun apply(h: TestHelper) ? =>
+    let set_gen =
+      Generators.set_of[U8](
+        Generators.u8()
+        where min = 5, max = 5)
+    let rnd = Randomness(Time.millis())
+    match set_gen.generate(rnd)?
+    | (let sample: Set[U8], let shrinks: Iterator[Set[U8]^]) =>
+      h.assert_false(
+        shrinks.has_next(),
+        "shrink iterator should be empty when min == max")
+    else
+      h.fail("set_of did not produce shrinks")
+    end
 
 class \nodoc\ iso _ASCIIRangeTest is UnitTest
   fun name(): String => "Gen/ascii_range"

--- a/packages/pony_check/gen_obj.pony
+++ b/packages/pony_check/gen_obj.pony
@@ -508,36 +508,34 @@ primitive Generators
 
   fun set_of[T: (Hashable #read & Equatable[T] #read)](
     gen: Generator[T],
+    min: USize = 0,
     max: USize = 100)
     : Generator[Set[T]]
   =>
     """
     Create a generator for `Set` filled with values
-    of the given generator `gen`.
-    The returned sets will have a size up to `max`,
-    but tend to have fewer than `max`
-    depending on the source generator `gen`.
+    of the given generator `gen`
+    with a minimum of `min` and a maximum of `max` insertion attempts.
 
+    Defaults are 0 and 100, respectively.
+
+    The returned sets can have fewer elements than `min`
+    when the source generator `gen` produces duplicates.
     E.g. if the given generator is for `U8` values and `max` is set to 1024,
-    the set will only ever be of size 256 max.
-
-    Also for efficiency purposes and to not loop forever,
-    this generator will only try to add at most `max` values to the set.
-    If there are duplicates, the set won't grow.
+    the set will only ever be of size 256.
     """
     Generator[Set[T]](
       object is GenObj[Set[T]]
         let _gen: GenObj[T] = gen
         fun generate(rnd: Randomness): GenerateResult[Set[T]] =>
-          let size = rnd.usize(0, max)
+          let size = rnd.usize(min, max)
           let result: Set[T] =
             Set[T].create(size) .> union(
               Iter[T^](_gen.value_iter(rnd))
               .take(size)
             )
           let shrink_iter: Iterator[Set[T]^] =
-            Iter[USize](CountdownIter(size, 0)) // Range(size, 0, -1))
-              // .skip(1)
+            Iter[USize](CountdownIter(size, min))
               .map_stateful[Set[T]^]({
                 (s: USize): Set[T]^ =>
                   Set[T].create(s) .> union(
@@ -549,28 +547,26 @@ primitive Generators
 
   fun set_is_of[T](
     gen: Generator[T],
+    min: USize = 0,
     max: USize = 100)
     : Generator[SetIs[T]]
   =>
     """
     Create a generator for `SetIs` filled with values
-    of the given generator `gen`.
-    The returned `SetIs` will have a size up to `max`,
-    but tend to have fewer entries
-    depending on the source generator `gen`.
+    of the given generator `gen`
+    with a minimum of `min` and a maximum of `max` insertion attempts.
 
-    E.g. if the given generator is for `U8` values and `max` is set to 1024
-    the set will only ever be of size 256 max.
+    Defaults are 0 and 100, respectively.
 
-    Also for efficiency purposes and to not loop forever,
-    this generator will only try to add at most `max` values to the set.
-    If there are duplicates, the set won't grow.
+    The returned sets can have fewer elements than `min`
+    when the source generator `gen` produces duplicates.
+    E.g. if the given generator is for `U8` values and `max` is set to 1024,
+    the set will only ever be of size 256.
     """
-    // TODO: how to remove code duplications
     Generator[SetIs[T]](
       object is GenObj[SetIs[T]]
         fun generate(rnd: Randomness): GenerateResult[SetIs[T]] =>
-          let size = rnd.usize(0, max)
+          let size = rnd.usize(min, max)
 
           let result: SetIs[T] =
             SetIs[T].create(size) .> union(
@@ -578,8 +574,7 @@ primitive Generators
                 .take(size)
             )
           let shrink_iter: Iterator[SetIs[T]^] =
-            Iter[USize](CountdownIter(size, 0)) // Range(size, 0, -1))
-              // .skip(1)
+            Iter[USize](CountdownIter(size, min))
               .map_stateful[SetIs[T]^]({
                 (s: USize): SetIs[T]^ =>
                   SetIs[T].create(s) .> union(
@@ -591,22 +586,24 @@ primitive Generators
 
   fun map_of[K: (Hashable #read & Equatable[K] #read), V](
     gen: Generator[(K, V)],
+    min: USize = 0,
     max: USize = 100)
     : Generator[Map[K, V]]
   =>
     """
-    Create a generator for `Map` from a generator of key-value tuples.
-    The generated maps will have a size up to `max`,
-    but tend to have fewer entries depending on the source generator `gen`.
+    Create a generator for `Map` from a generator of key-value tuples
+    with a minimum of `min` and a maximum of `max` insertion attempts.
 
-    If the generator generates key-value pairs with
-    duplicate keys (based on structural equality),
-    the pair that is generated later will overwrite earlier entries in the map.
+    Defaults are 0 and 100, respectively.
+
+    The generated maps can have fewer entries than `min`
+    when the source generator `gen` produces duplicate keys.
+    Duplicate keys (based on structural equality) overwrite earlier entries.
     """
     Generator[Map[K, V]](
       object is GenObj[Map[K, V]]
         fun generate(rnd: Randomness): GenerateResult[Map[K, V]] =>
-          let size = rnd.usize(0, max)
+          let size = rnd.usize(min, max)
 
           let result: Map[K, V] =
             Map[K, V].create(size) .> concat(
@@ -614,8 +611,7 @@ primitive Generators
                 .take(size)
             )
           let shrink_iter: Iterator[Map[K, V]^] =
-            Iter[USize](CountdownIter(size, 0)) // Range(size, 0, -1))
-              // .skip(1)
+            Iter[USize](CountdownIter(size, min))
               .map_stateful[Map[K, V]^]({
                 (s: USize): Map[K, V]^ =>
                   Map[K, V].create(s) .> concat(
@@ -627,22 +623,24 @@ primitive Generators
 
   fun map_is_of[K, V](
     gen: Generator[(K, V)],
+    min: USize = 0,
     max: USize = 100)
     : Generator[MapIs[K, V]]
   =>
     """
-    Create a generator for `MapIs` from a generator of key-value tuples.
-    The generated maps will have a size up to `max`,
-    but tend to have fewer entries depending on the source generator `gen`.
+    Create a generator for `MapIs` from a generator of key-value tuples
+    with a minimum of `min` and a maximum of `max` insertion attempts.
 
-    If the generator generates key-value pairs with
-    duplicate keys (based on identity),
-    the pair that is generated later will overwrite earlier entries in the map.
+    Defaults are 0 and 100, respectively.
+
+    The generated maps can have fewer entries than `min`
+    when the source generator `gen` produces duplicate keys.
+    Duplicate keys (based on identity) overwrite earlier entries.
     """
     Generator[MapIs[K, V]](
       object is GenObj[MapIs[K, V]]
         fun generate(rnd: Randomness): GenerateResult[MapIs[K, V]] =>
-          let size = rnd.usize(0, max)
+          let size = rnd.usize(min, max)
 
           let result: MapIs[K, V] =
             MapIs[K, V].create(size) .> concat(
@@ -650,8 +648,7 @@ primitive Generators
                 .take(size)
             )
           let shrink_iter: Iterator[MapIs[K, V]^] =
-            Iter[USize](CountdownIter(size, 0)) // Range(size, 0, -1))
-              // .skip(1)
+            Iter[USize](CountdownIter(size, min))
               .map_stateful[MapIs[K, V]^]({
                 (s: USize): MapIs[K, V]^ =>
                   MapIs[K, V].create(s) .> concat(


### PR DESCRIPTION
`Generators.set_of`, `Generators.set_is_of`, `Generators.map_of`, and `Generators.map_is_of` now accept a `min` parameter matching the existing convention in `Generators.seq_of`. The parameter order is `(gen, min, max)` with defaults `min = 0` and `max = 100`.

This is a breaking change: `max` moved from position 2 to position 3. Callers that passed `max` positionally need to switch to a named argument (`where max = N`).

Closes #4046
