### PR TITLE
Add generic type argument inference for method and constructor calls

### DIFF
--- a/.release-notes/generic-type-inference.md
+++ b/.release-notes/generic-type-inference.md
@@ -1,0 +1,74 @@
+## Add generic type argument inference for method and constructor calls
+
+The compiler can now infer type arguments from the arguments of a generic call. When the arguments determine a unique type for each type parameter, you can omit the type arguments:
+
+```pony
+primitive Sorter
+  fun sort[A: Comparable[A] val](a: A, b: A): (A, A) =>
+    if a < b then (a, b) else (b, a) end
+
+actor Main
+  new create(env: Env) =>
+    // Before: Sorter.sort[U8](U8(3), U8(1))
+    // After:
+    let result = Sorter.sort(U8(3), U8(1))
+```
+
+Constructor calls infer the class's type parameters the same way:
+
+```pony
+class Pair[A: Any val, B: Any val]
+  let _a: A
+  let _b: B
+  new create(a: A, b: B) => _a = a; _b = b
+
+actor Main
+  new create(env: Env) =>
+    // Before: Pair[String, U8]("hello", U8(42))
+    // After:
+    let p = Pair("hello", U8(42))
+```
+
+When a type parameter has a default, the default is kept when every argument fits it. Otherwise the inferred type replaces the default:
+
+```pony
+class Wrapper[A: Any val = String]
+  let _a: A
+  new create(a: A) => _a = a
+
+actor Main
+  new create(env: Env) =>
+    let w1 = Wrapper("hello")   // A is String (the default fits)
+    let w2 = Wrapper(U8(42))    // A is U8 (the argument overrides the default)
+```
+
+When a type parameter has a default that refers to another type parameter in the same list — `[A: Any val = B, B: Any val = U8]` — and the referred-to parameter cannot be determined from the arguments, the compiler reports which parameter's default it cannot resolve. Programs that write out their type arguments are not affected; programs where such a default caused a crash at code generation now get a compile-time error instead.
+
+When a parameter type mentions a type parameter, arguments at that position whose own type depends on the inferred type — such as lambdas and array literals — are skipped during inference and typed afterward. This works as long as at least one other argument determines the type parameter:
+
+```pony
+primitive Bar
+  fun foo[A: Any val](a: A, f: {(A): A} val): A =>
+    f(a)
+
+actor Main
+  new create(env: Env) =>
+    // A is inferred as U8 from the first argument;
+    // the lambda is then typed against {(U8): U8} val
+    let x: U8 = Bar.foo(U8(42), {(x: U8): U8 => x + 1})
+```
+
+Each inferred type argument is the type a `let` binding would receive from that argument position, except that an `iso` or `trn` alias is kept as `iso` or `trn` so the compiler can report a missing `consume` rather than silently widening.
+
+For programs that already fail to compile, the first error reported — and sometimes the number of errors — can change.
+
+### Known gaps
+
+The following do not participate in type argument inference. Write the type arguments explicitly when you use them:
+
+- Array literals and lambda arguments at positions where the parameter type mentions a type parameter through structural nesting. `Foo(["a"; "b"])` still needs `Foo[String](["a"; "b"])`.
+- Type parameters that appear only in a lambda's result type.
+- Type aliases wrapping a generic type.
+- Union-typed parameters. A parameter like `(Array[A] val | Array[U8] val | None)` does not determine `A`; write the type argument explicitly.
+- The `where` syntax for named-only arguments.
+- A generic method called on a generic type written without its type arguments (`Foo.some_method(x)` where `Foo` has defaulted type parameters): the method's arguments are typed before inference runs, so array literals and lambdas at those positions see the unresolved parameter type. Adding explicit type arguments to either `Foo` or the method avoids this.

--- a/src/libponyc/CMakeLists.txt
+++ b/src/libponyc/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(libponyc STATIC
     expr/call.c
     expr/control.c
     expr/ffi.c
+    expr/infer.c
     expr/lambda.c
     expr/literal.c
     expr/match.c

--- a/src/libponyc/ast/treecheckdef.h
+++ b/src/libponyc/ast/treecheckdef.h
@@ -92,7 +92,10 @@ RULE(type_param,
   CHILD(type, none),  // Default
   TK_TYPEPARAM);
 
-RULE(type_args, ONE_OR_MORE(type), TK_TYPEARGS);
+RULE(type_args,
+  HAS_DATA  // Non-NULL when inferred (points to definition TK_TYPEPARAMS)
+  ONE_OR_MORE(type),
+  TK_TYPEARGS);
 
 RULE(params,
   ZERO_OR_MORE(param)

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -1,5 +1,6 @@
 #include "call.h"
 #include "ffi.h"
+#include "infer.h"
 #include "postfix.h"
 #include "control.h"
 #include "literal.h"
@@ -94,6 +95,93 @@ bool method_check_type_params(pass_opt_t* opt, ast_t** astp)
   return true;
 }
 
+bool apply_typeargs(pass_opt_t* opt, ast_t** astp, ast_t* typeargs,
+  ast_t* inferred_from)
+{
+  ast_t* lhs = *astp;
+  ast_t* type = ast_type(lhs);
+
+  if(is_typecheck_error(type))
+  {
+    ast_free_unattached(typeargs);
+    return false;
+  }
+
+  ast_t* typeparams = ast_childidx(type, 1);
+  pony_assert(ast_id(type) == TK_FUNTYPE);
+
+  if(inferred_from != NULL)
+    ast_setdata(typeargs, inferred_from);
+
+  if(!check_constraints(lhs, typeparams, typeargs, true, opt))
+  {
+    if(inferred_from != NULL)
+    {
+      ast_t* tp = ast_child(inferred_from);
+      ast_t* ta = ast_child(typeargs);
+
+      while(tp != NULL && ta != NULL)
+      {
+        if(ast_line(ta) != ast_line(lhs) || ast_pos(ta) != ast_pos(lhs))
+        {
+          ast_error_continue(opt->check.errors, ta,
+            "'%s' was inferred as %s from this argument",
+            ast_name(ast_child(tp)),
+            ast_print_type(ta, opt->strtab));
+        }
+
+        tp = ast_sibling(tp);
+        ta = ast_sibling(ta);
+      }
+    }
+
+    ast_free_unattached(typeargs);
+    return false;
+  }
+
+  type = reify(type, typeparams, typeargs, opt, true);
+  typeparams = ast_childidx(type, 1);
+  ast_replace(&typeparams, ast_from(typeparams, TK_NONE));
+
+  REPLACE(astp, NODE(ast_id(lhs), TREE(lhs) TREE(typeargs)));
+  ast_settype(*astp, type);
+
+  return true;
+}
+
+static bool method_infer_type_params(pass_opt_t* opt, ast_t** astp,
+  ast_t* positional, ast_t* namedargs)
+{
+  ast_t* lhs = *astp;
+  ast_t* type = ast_type(lhs);
+
+  if(is_typecheck_error(type))
+    return false;
+
+  pony_assert(ast_id(type) == TK_FUNTYPE);
+  ast_t* typeparams = ast_childidx(type, 1);
+
+  if(ast_id(typeparams) == TK_NONE)
+    return true;
+
+  AST_GET_CHILDREN(type, cap, tp_node, params, result);
+
+  if(!normalise_args(opt, params, positional, namedargs))
+    return false;
+
+  ast_t* method_name = ast_childidx(lhs, 1);
+  const char* callee_name = (method_name != NULL && ast_id(method_name) == TK_ID)
+    ? ast_name(method_name) : "apply";
+
+  ast_t* typeargs = infer_typeargs(opt, typeparams, NULL, params, positional,
+    ast_parent(lhs), callee_name);
+
+  if(typeargs == NULL)
+    return false;
+
+  return apply_typeargs(opt, astp, typeargs, typeparams);
+}
+
 static bool extend_positional_args(pass_opt_t* opt, ast_t* params,
   ast_t* positional)
 {
@@ -175,6 +263,15 @@ static bool apply_named_args(pass_opt_t* opt, ast_t* params, ast_t* positional,
 
   ast_setid(namedargs, TK_NONE);
   return true;
+}
+
+bool normalise_args(pass_opt_t* opt, ast_t* params, ast_t* positional,
+  ast_t* namedargs)
+{
+  if(!extend_positional_args(opt, params, positional))
+    return false;
+
+  return apply_named_args(opt, params, positional, namedargs);
 }
 
 static bool apply_default_arg(pass_opt_t* opt, ast_t* param, ast_t** argp)
@@ -653,10 +750,47 @@ static bool method_application(pass_opt_t* opt, ast_t* ast, bool partial)
 {
   AST_GET_CHILDREN(ast, lhs, positional, namedargs, question);
 
-  if(!method_check_type_params(opt, &lhs))
+  ast_t* type = ast_type(lhs);
+
+  if(is_typecheck_error(type))
     return false;
 
-  ast_t* type = ast_type(lhs);
+  ast_t* typeparams_check = ast_childidx(type, 1);
+  bool needs_inference = (ast_id(typeparams_check) == TK_TYPEPARAMS);
+
+  if(needs_inference)
+  {
+    ast_t* params_check = ast_childidx(type, 2);
+    bool has_bindable = false;
+    ast_t* p = ast_child(params_check);
+
+    while(p != NULL)
+    {
+      if(infer_bindable_position(ast_childidx(p, 1), typeparams_check))
+      {
+        has_bindable = true;
+        break;
+      }
+
+      p = ast_sibling(p);
+    }
+
+    if(!has_bindable)
+      needs_inference = false;
+  }
+
+  if(needs_inference)
+  {
+    if(!method_infer_type_params(opt, &lhs, positional, namedargs))
+      return false;
+  }
+  else
+  {
+    if(!method_check_type_params(opt, &lhs))
+      return false;
+  }
+
+  type = ast_type(lhs);
 
   if(is_typecheck_error(type))
     return false;
@@ -664,11 +798,14 @@ static bool method_application(pass_opt_t* opt, ast_t* ast, bool partial)
   AST_GET_CHILDREN(type, cap, typeparams, params, result);
   bool bare = (ast_id(cap) == TK_AT);
 
-  if(!extend_positional_args(opt, params, positional))
-    return false;
+  if(!needs_inference)
+  {
+    if(!extend_positional_args(opt, params, positional))
+      return false;
 
-  if(!apply_named_args(opt, params, positional, namedargs))
-    return false;
+    if(!apply_named_args(opt, params, positional, namedargs))
+      return false;
+  }
 
   if(!check_arg_types(opt, params, positional, partial, bare))
     return false;
@@ -1208,6 +1345,318 @@ static bool method_chain(pass_opt_t* opt, ast_t* ast)
   }
 
   return true;
+}
+
+static ast_t* constructor_path_typeref(ast_t* lhs, const char** member_name)
+{
+  token_id lid = ast_id(lhs);
+
+  if(lid == TK_TYPEREF)
+  {
+    *member_name = "create";
+    return lhs;
+  }
+
+  if(lid == TK_DOT || lid == TK_TILDE)
+  {
+    ast_t* receiver = ast_child(lhs);
+
+    if(ast_id(receiver) == TK_TYPEREF)
+    {
+      ast_t* name_node = ast_sibling(receiver);
+
+      if(name_node != NULL && ast_id(name_node) == TK_ID)
+        *member_name = ast_name(name_node);
+      else
+        *member_name = "create";
+
+      return receiver;
+    }
+  }
+
+  if(lid == TK_QUALIFY)
+  {
+    ast_t* inner = ast_child(lhs);
+    token_id iid = ast_id(inner);
+
+    if(iid == TK_DOT || iid == TK_TILDE)
+    {
+      ast_t* receiver = ast_child(inner);
+
+      if(ast_id(receiver) == TK_TYPEREF)
+      {
+        ast_t* name_node = ast_sibling(receiver);
+
+        if(name_node != NULL && ast_id(name_node) == TK_ID)
+          *member_name = ast_name(name_node);
+        else
+          *member_name = "create";
+
+        return receiver;
+      }
+    }
+  }
+
+  return NULL;
+}
+
+static ast_result_t constructor_path_infer(pass_opt_t* opt, ast_t* ast,
+  ast_t* typeref, const char* member_name)
+{
+  ast_t* typeargs = ast_childidx(typeref, 2);
+
+  if(ast_id(typeargs) != TK_NONE)
+    return AST_OK;
+
+  ast_t* def = (ast_t*)ast_data(typeref);
+
+  if(def == NULL)
+    return AST_OK;
+
+  switch(ast_id(def))
+  {
+    case TK_PRIMITIVE:
+    case TK_STRUCT:
+    case TK_CLASS:
+    case TK_ACTOR:
+      break;
+
+    default:
+      return AST_OK;
+  }
+
+  ast_t* class_typeparams = ast_childidx(def, 1);
+
+  if(ast_id(class_typeparams) != TK_TYPEPARAMS)
+    return AST_OK;
+
+  ast_t* member = ast_get(def, stringtab(opt->strtab, member_name), NULL);
+
+  if(member == NULL || ast_id(member) != TK_NEW)
+    return AST_OK;
+
+  ast_t* method_typeparams = ast_childidx(member, 2);
+  ast_t* params = ast_childidx(member, 3);
+
+  if(ast_id(params) == TK_NONE || ast_childcount(params) == 0)
+    return AST_OK;
+
+  bool has_bindable = false;
+  ast_t* p = ast_child(params);
+
+  while(p != NULL)
+  {
+    if(infer_bindable_position(ast_childidx(p, 1), class_typeparams))
+    {
+      has_bindable = true;
+      break;
+    }
+
+    p = ast_sibling(p);
+  }
+
+  if(!has_bindable)
+    return AST_OK;
+
+  ast_t* positional = ast_childidx(ast, 1);
+  ast_t* namedargs = ast_childidx(ast, 2);
+
+  if(!normalise_args(opt, params, positional, namedargs))
+    return AST_ERROR;
+
+  ast_t* param = ast_child(params);
+  ast_t* arg = ast_child(positional);
+
+  while(param != NULL && arg != NULL)
+  {
+    if(ast_id(arg) != TK_NONE)
+    {
+      token_id aid = ast_id(arg);
+      bool skip = false;
+
+      if(aid == TK_ARRAY || aid == TK_LAMBDA || aid == TK_BARELAMBDA)
+      {
+        ast_t* p_type = ast_childidx(param, 1);
+
+        if(type_mentions_typeparams(p_type, class_typeparams))
+          skip = true;
+      }
+
+      if(!skip)
+      {
+        ast_result_t ar = ast_visit(&arg, pass_pre_expr, pass_expr,
+          opt, PASS_EXPR);
+
+        if(ar == AST_FATAL)
+          return AST_FATAL;
+      }
+    }
+
+    param = ast_sibling(param);
+    arg = ast_sibling(arg);
+  }
+
+  positional = ast_childidx(ast, 1);
+
+  ast_t* other_tp = (ast_id(method_typeparams) == TK_TYPEPARAMS)
+    ? method_typeparams : NULL;
+
+  ast_t* inferred = infer_typeargs(opt, class_typeparams, other_tp, params,
+    positional, typeref, member_name);
+
+  if(inferred == NULL)
+  {
+    ast_settype(ast, ast_from(ast, TK_ERRORTYPE));
+    return AST_ERROR;
+  }
+
+  if(!check_constraints(typeref, class_typeparams, inferred, true, opt))
+  {
+    ast_free_unattached(inferred);
+    ast_settype(ast, ast_from(ast, TK_ERRORTYPE));
+    return AST_ERROR;
+  }
+
+  ast_replace(&typeargs, inferred);
+  ast_setdata(inferred, (void*)class_typeparams);
+
+  ast_t* ta_child = ast_child(inferred);
+  while(ta_child != NULL)
+  {
+    ast_pass_record(ta_child, PASS_EXPR);
+    ta_child = ast_sibling(ta_child);
+  }
+  ast_pass_record(inferred, PASS_EXPR);
+
+  return AST_OK;
+}
+
+ast_result_t expr_pre_call(pass_opt_t* opt, ast_t** astp)
+{
+  ast_t* ast = *astp;
+  ast_t* lhs = ast_child(ast);
+
+  // Constructor-path shapes: the LHS is rooted at an unqualified TYPEREF.
+  const char* member_name = NULL;
+  ast_t* typeref = constructor_path_typeref(lhs, &member_name);
+
+  if(typeref != NULL)
+  {
+    ast_result_t cr = constructor_path_infer(opt, ast, typeref, member_name);
+
+    if(cr != AST_OK)
+      return cr;
+  }
+
+  // Type the LHS.
+  ast_result_t r = ast_visit(&lhs, pass_pre_expr, pass_expr, opt, PASS_EXPR);
+
+  // Re-read in case expr_dot/expr_tilde replaced the child.
+  lhs = ast_child(ast);
+
+  if(r == AST_FATAL)
+    return AST_FATAL;
+
+  if(r == AST_ERROR || is_typecheck_error(ast_type(lhs)))
+    return AST_ERROR;
+
+  ast_t* type = ast_type(lhs);
+
+  if(type == NULL || ast_id(type) != TK_FUNTYPE)
+    return AST_OK;
+
+  ast_t* typeparams = ast_childidx(type, 1);
+
+  if(ast_id(typeparams) != TK_TYPEPARAMS)
+    return AST_OK;
+
+  // Check that at least one parameter mentions a type parameter.
+  ast_t* params = ast_childidx(type, 2);
+  bool has_bindable = false;
+  ast_t* p = ast_child(params);
+
+  while(p != NULL)
+  {
+    if(infer_bindable_position(ast_childidx(p, 1), typeparams))
+    {
+      has_bindable = true;
+      break;
+    }
+
+    p = ast_sibling(p);
+  }
+
+  if(!has_bindable)
+    return AST_OK;
+
+  // Normalise arguments.
+  ast_t* positional = ast_childidx(ast, 1);
+  ast_t* namedargs = ast_childidx(ast, 2);
+
+  if(!normalise_args(opt, params, positional, namedargs))
+    return AST_ERROR;
+
+  // Visit arguments early. Skip array literals, lambdas, and bare lambdas
+  // at bindable positions — they are antecedent-dependent and will be typed
+  // by the normal post-order visit against the reified parameter type.
+  ast_t* param = ast_child(params);
+  ast_t* arg = ast_child(positional);
+
+  while(param != NULL && arg != NULL)
+  {
+    if(ast_id(arg) != TK_NONE)
+    {
+      token_id aid = ast_id(arg);
+      bool skip = false;
+
+      if(aid == TK_ARRAY || aid == TK_LAMBDA || aid == TK_BARELAMBDA)
+      {
+        ast_t* p_type = ast_childidx(param, 1);
+
+        if(type_mentions_typeparams(p_type, typeparams))
+          skip = true;
+      }
+
+      if(!skip)
+      {
+        ast_result_t ar = ast_visit(&arg, pass_pre_expr, pass_expr,
+          opt, PASS_EXPR);
+
+        if(ar == AST_FATAL)
+          return AST_FATAL;
+      }
+    }
+
+    param = ast_sibling(param);
+    arg = ast_sibling(arg);
+  }
+
+  // Re-read after visits may have replaced children.
+  positional = ast_childidx(ast, 1);
+  lhs = ast_child(ast);
+
+  ast_t* method_name = ast_childidx(lhs, 1);
+  const char* callee_name =
+    (method_name != NULL && ast_id(method_name) == TK_ID)
+    ? ast_name(method_name) : "apply";
+
+  ast_t* typeargs = infer_typeargs(opt, typeparams, NULL, params, positional,
+    ast_parent(lhs), callee_name);
+
+  if(typeargs == NULL)
+  {
+    ast_settype(ast, ast_from(ast, TK_ERRORTYPE));
+    return AST_ERROR;
+  }
+
+  // &lhs has a parent, so REPLACE updates the tree.
+  if(!apply_typeargs(opt, &lhs, typeargs, typeparams))
+  {
+    ast_settype(ast, ast_from(ast, TK_ERRORTYPE));
+    return AST_ERROR;
+  }
+
+  return AST_OK;
 }
 
 bool expr_call(pass_opt_t* opt, ast_t** astp)

--- a/src/libponyc/expr/call.h
+++ b/src/libponyc/expr/call.h
@@ -11,6 +11,16 @@ bool method_check_type_params(pass_opt_t* opt, ast_t** astp);
 bool check_auto_recover_newref(ast_t* dest_type, ast_t* ast,
   pass_opt_t* opt);
 
+// Extend positional arguments and apply named arguments for a call.
+bool normalise_args(pass_opt_t* opt, ast_t* params, ast_t* positional,
+  ast_t* namedargs);
+
+// Apply inferred type arguments to a call's LHS (reify and replace).
+bool apply_typeargs(pass_opt_t* opt, ast_t** astp, ast_t* typeargs,
+  ast_t* inferred_from);
+
+// Pre-order hook for TK_CALL: infer type arguments before child visiting.
+ast_result_t expr_pre_call(pass_opt_t* opt, ast_t** astp);
 bool expr_call(pass_opt_t* opt, ast_t** astp);
 
 PONY_EXTERN_C_END

--- a/src/libponyc/expr/infer.c
+++ b/src/libponyc/expr/infer.c
@@ -1,0 +1,1300 @@
+#include "infer.h"
+#include "call.h"
+#include "../ast/astbuild.h"
+#include "../pass/expr.h"
+#include "../type/alias.h"
+#include "../type/assemble.h"
+#include "../type/reify.h"
+#include "../type/subtype.h"
+#include "../type/typealias.h"
+#include "../type/typeparam.h"
+#include "../../libponyrt/mem/pool.h"
+#include "ponyassert.h"
+#include <string.h>
+
+typedef enum
+{
+  REASON_NO_POSITION,
+  REASON_NO_ARGUMENT,
+  REASON_LITERAL_ONLY,
+  REASON_UNTYPED_ARG,
+  REASON_DEPENDENT,
+  REASON_DEFAULT_UNDECIDED
+} unbound_reason_t;
+
+typedef enum
+{
+  REC_UNBOUND,
+  REC_BOUND,
+  REC_PINNED,
+  REC_CONFLICT
+} record_state_t;
+
+typedef struct
+{
+  record_state_t state;
+  ast_t* typeparam;
+
+  union
+  {
+    struct
+    {
+      unbound_reason_t reason;
+      ast_t* anchor;
+      const char* detail;
+    } unbound;
+
+    struct
+    {
+      ast_t* type;
+      ast_t* arg;
+    } bound;
+
+    struct
+    {
+      ast_t* type;
+      ast_t* arg;
+    } pinned;
+
+    struct
+    {
+      ast_t* arg_i;
+      ast_t* arg_j;
+      bool nested;
+    } conflict;
+  };
+} infer_record_t;
+
+// True when def is one of the type parameters in the given list, by root
+// pointer (scope resolution stores the original definition in ast_data).
+static bool is_typeparam_of(ast_t* def, ast_t* typeparams)
+{
+  ast_t* root = typeparam_root(def);
+
+  ast_t* tp = ast_child(typeparams);
+  while(tp != NULL)
+  {
+    if(typeparam_root(tp) == root)
+      return true;
+    tp = ast_sibling(tp);
+  }
+
+  return false;
+}
+
+static bool type_mentions_one_typeparam(ast_t* type, ast_t* tp_node)
+{
+  if(type == NULL)
+    return false;
+
+  if(ast_id(type) == TK_TYPEPARAMREF)
+  {
+    ast_t* def = (ast_t*)ast_data(type);
+    return typeparam_root(def) == typeparam_root(tp_node);
+  }
+
+  for(ast_t* child = ast_child(type); child != NULL;
+    child = ast_sibling(child))
+  {
+    if(type_mentions_one_typeparam(child, tp_node))
+      return true;
+  }
+
+  return false;
+}
+
+bool type_mentions_typeparams(ast_t* type, ast_t* typeparams)
+{
+  if(type == NULL)
+    return false;
+
+  if(ast_id(type) == TK_TYPEPARAMREF)
+  {
+    ast_t* def = (ast_t*)ast_data(type);
+    return is_typeparam_of(def, typeparams);
+  }
+
+  for(ast_t* child = ast_child(type); child != NULL;
+    child = ast_sibling(child))
+  {
+    if(type_mentions_typeparams(child, typeparams))
+      return true;
+  }
+
+  return false;
+}
+
+static bool bindable_position_one(ast_t* type, ast_t* tp_node)
+{
+  if(type == NULL)
+    return false;
+
+  switch(ast_id(type))
+  {
+    case TK_TYPEPARAMREF:
+    {
+      ast_t* def = (ast_t*)ast_data(type);
+      return typeparam_root(def) == typeparam_root(tp_node);
+    }
+
+    case TK_NOMINAL:
+    {
+      ast_t* typeargs = ast_childidx(type, 2);
+      ast_t* ta = ast_child(typeargs);
+      while(ta != NULL)
+      {
+        if(type_mentions_one_typeparam(ta, tp_node))
+          return true;
+        ta = ast_sibling(ta);
+      }
+      return false;
+    }
+
+    case TK_TUPLETYPE:
+    {
+      ast_t* elem = ast_child(type);
+      while(elem != NULL)
+      {
+        if(bindable_position_one(elem, tp_node))
+          return true;
+        elem = ast_sibling(elem);
+      }
+      return false;
+    }
+
+    default:
+      return false;
+  }
+}
+
+bool infer_bindable_position(ast_t* type, ast_t* typeparams)
+{
+  if(type == NULL)
+    return false;
+
+  switch(ast_id(type))
+  {
+    case TK_TYPEPARAMREF:
+    {
+      ast_t* def = (ast_t*)ast_data(type);
+      return is_typeparam_of(def, typeparams);
+    }
+
+    case TK_NOMINAL:
+    {
+      ast_t* typeargs = ast_childidx(type, 2);
+      ast_t* ta = ast_child(typeargs);
+      while(ta != NULL)
+      {
+        if(type_mentions_typeparams(ta, typeparams))
+          return true;
+        ta = ast_sibling(ta);
+      }
+      return false;
+    }
+
+    case TK_TUPLETYPE:
+    {
+      ast_t* elem = ast_child(type);
+      while(elem != NULL)
+      {
+        if(infer_bindable_position(elem, typeparams))
+          return true;
+        elem = ast_sibling(elem);
+      }
+      return false;
+    }
+
+    default:
+      return false;
+  }
+}
+
+ast_t* antecedent_prune(ast_t* type, ast_t* typeparams)
+{
+  if(type == NULL || ast_id(typeparams) == TK_NONE)
+    return type;
+
+  switch(ast_id(type))
+  {
+    case TK_TYPEPARAMREF:
+      return type;
+
+    case TK_NOMINAL:
+    {
+      if(type_mentions_typeparams(type, typeparams))
+        return NULL;
+      return type;
+    }
+
+    case TK_TUPLETYPE:
+    case TK_ARROW:
+    case TK_FUNTYPE:
+    {
+      if(type_mentions_typeparams(type, typeparams))
+        return NULL;
+      return type;
+    }
+
+    case TK_UNIONTYPE:
+    case TK_ISECTTYPE:
+    {
+      ast_t* survivor = NULL;
+      size_t survivors = 0;
+      bool any_dropped = false;
+
+      ast_t* member = ast_child(type);
+      while(member != NULL)
+      {
+        if(ast_id(member) == TK_TYPEPARAMREF)
+        {
+          survivor = member;
+          survivors++;
+        }
+        else if(!type_mentions_typeparams(member, typeparams))
+        {
+          survivor = member;
+          survivors++;
+        }
+        else
+        {
+          any_dropped = true;
+        }
+        member = ast_sibling(member);
+      }
+
+      if(!any_dropped)
+        return type;
+
+      if(survivors == 1)
+        return survivor;
+
+      return NULL;
+    }
+
+    case TK_TYPEALIASREF:
+    {
+      if(type_mentions_typeparams(type, typeparams))
+        return NULL;
+      return type;
+    }
+
+    default:
+      return type;
+  }
+}
+
+// Walk up from a node through propagation contexts, returning the parent
+// context or NULL when propagation stops. The method_body and loop_body
+// parameters are the targets of TK_RETURN and TK_BREAK respectively.
+static ast_t* antecedent_parent(ast_t* ast, ast_t* method_body,
+  ast_t* loop_body, bool* is_recovered)
+{
+  ast_t* parent = ast_parent(ast);
+
+  switch(ast_id(parent))
+  {
+    case TK_SEQ:
+    {
+      if(ast_childlast(parent) == ast)
+        return parent;
+
+      if(ast_id(ast_parent(parent)) == TK_ARRAY)
+        return parent;
+
+      return NULL;
+    }
+
+    case TK_TUPLE:
+      return parent;
+
+    case TK_RECOVER:
+    {
+      if(is_recovered != NULL)
+        *is_recovered = true;
+      return parent;
+    }
+
+    case TK_RETURN:
+      return method_body;
+
+    case TK_BREAK:
+      return loop_body;
+
+    case TK_IF:
+    case TK_IFDEF:
+    case TK_IFTYPE:
+    case TK_IFTYPE_SET:
+    case TK_THEN:
+    case TK_ELSE:
+    case TK_WHILE:
+    case TK_REPEAT:
+    case TK_MATCH:
+    case TK_CASES:
+    case TK_CASE:
+    case TK_TRY:
+    case TK_TRY_NO_CHECK:
+    case TK_DISPOSING_BLOCK:
+    case TK_CALL:
+      return parent;
+
+    default:
+      return NULL;
+  }
+}
+
+// Find the structural loop body (nearest TK_WHILE or TK_REPEAT's body)
+// between a TK_BREAK node and a given ancestor. Returns NULL when no
+// loop intervenes.
+static ast_t* structural_break_target(ast_t* brk, ast_t* ancestor)
+{
+  ast_t* node = ast_parent(brk);
+
+  while(node != NULL && node != ancestor)
+  {
+    if(ast_id(node) == TK_WHILE || ast_id(node) == TK_REPEAT)
+      return ast_child(node);
+
+    node = ast_parent(node);
+  }
+
+  return NULL;
+}
+
+// True when a node in the argument's subtree is antecedent-dependent:
+// an array literal, lambda, object literal, or `as` cast reachable through
+// propagation contexts from the argument root.
+static bool subtree_has_dependent(ast_t* node, ast_t* argument)
+{
+  switch(ast_id(node))
+  {
+    case TK_ARRAY:
+    case TK_LAMBDA:
+    case TK_BARELAMBDA:
+    case TK_OBJECT:
+    case TK_AS:
+    {
+      ast_t* start = node;
+
+      // For an array literal that is the receiver of a DOT (`.values()`),
+      // start from the DOT.
+      if(ast_id(node) == TK_ARRAY)
+      {
+        ast_t* p = ast_parent(node);
+        if(p != NULL && ast_id(p) == TK_DOT && ast_child(p) == node)
+          start = p;
+      }
+
+      ast_t* walk = start;
+      while(walk != NULL && walk != argument)
+      {
+        ast_t* break_target = NULL;
+
+        if(ast_id(walk) == TK_BREAK)
+          break_target = structural_break_target(walk, argument);
+
+        walk = antecedent_parent(walk, NULL, break_target, NULL);
+      }
+
+      return (walk == argument);
+    }
+
+    default:
+      break;
+  }
+
+  // Don't enter lambda/object bodies.
+  if(ast_id(node) == TK_FUN || ast_id(node) == TK_BE ||
+    ast_id(node) == TK_NEW)
+    return false;
+
+  for(ast_t* child = ast_child(node); child != NULL;
+    child = ast_sibling(child))
+  {
+    if(subtree_has_dependent(child, argument))
+      return true;
+  }
+
+  return false;
+}
+
+static bool is_antecedent_dependent(ast_t* arg)
+{
+  return subtree_has_dependent(arg, arg);
+}
+
+// Find the index of a type parameter in the list by root pointer.
+static size_t typeparam_index(ast_t* def, ast_t* typeparams)
+{
+  ast_t* root = typeparam_root(def);
+  size_t i = 0;
+
+  ast_t* tp = ast_child(typeparams);
+  while(tp != NULL)
+  {
+    if(typeparam_root(tp) == root)
+      return i;
+    tp = ast_sibling(tp);
+    i++;
+  }
+
+  return (size_t)-1;
+}
+
+// Record evidence at a direct position: the argument's aliased type is a
+// candidate for the type parameter. The record takes ownership of a dup.
+static void record_direct(infer_record_t* records, ast_t* typeparams,
+  ast_t* def, ast_t* candidate, ast_t* arg, pass_opt_t* opt)
+{
+  size_t idx = typeparam_index(def, typeparams);
+  if(idx == (size_t)-1)
+    return;
+
+  infer_record_t* rec = &records[idx];
+
+  switch(rec->state)
+  {
+    case REC_UNBOUND:
+      rec->state = REC_BOUND;
+      rec->bound.type = ast_dup(candidate);
+      rec->bound.arg = arg;
+      break;
+
+    case REC_BOUND:
+    {
+      // Merge: find the supertype.
+      if(is_subtype(rec->bound.type, candidate, NULL, opt))
+      {
+        ast_free_unattached(rec->bound.type);
+        rec->bound.type = ast_dup(candidate);
+        rec->bound.arg = arg;
+      }
+      else if(!is_subtype(candidate, rec->bound.type, NULL, opt))
+      {
+        ast_t* first_arg = rec->bound.arg;
+        ast_free_unattached(rec->bound.type);
+        rec->state = REC_CONFLICT;
+        rec->conflict.arg_i = first_arg;
+        rec->conflict.arg_j = arg;
+        rec->conflict.nested = false;
+      }
+      break;
+    }
+
+    case REC_PINNED:
+      // Pinned wins; direct left to check_arg_types.
+      break;
+
+    case REC_CONFLICT:
+      break;
+  }
+}
+
+// Record evidence at a nested position: exact type from structural matching.
+// The record takes ownership of a dup.
+static void record_nested(infer_record_t* records, ast_t* typeparams,
+  ast_t* def, ast_t* exact_type, ast_t* arg, pass_opt_t* opt)
+{
+  size_t idx = typeparam_index(def, typeparams);
+  if(idx == (size_t)-1)
+    return;
+
+  infer_record_t* rec = &records[idx];
+
+  switch(rec->state)
+  {
+    case REC_UNBOUND:
+      rec->state = REC_PINNED;
+      rec->pinned.type = ast_dup(exact_type);
+      rec->pinned.arg = arg;
+      break;
+
+    case REC_BOUND:
+      // Pinned wins over direct.
+      ast_free_unattached(rec->bound.type);
+      rec->state = REC_PINNED;
+      rec->pinned.type = ast_dup(exact_type);
+      rec->pinned.arg = arg;
+      break;
+
+    case REC_PINNED:
+    {
+      if(!is_eqtype(rec->pinned.type, exact_type, NULL, opt))
+      {
+        ast_free_unattached(rec->pinned.type);
+        rec->state = REC_CONFLICT;
+        rec->conflict.arg_i = rec->pinned.arg;
+        rec->conflict.arg_j = arg;
+        rec->conflict.nested = true;
+      }
+      break;
+    }
+
+    case REC_CONFLICT:
+      break;
+  }
+}
+
+static void extract_nested(infer_record_t* records, ast_t* typeparams,
+  ast_t* other_typeparams, ast_t* param_type, ast_t* arg_type, ast_t* arg,
+  pass_opt_t* opt);
+
+// Walk the provides list of arg_type's def to find param_type's def.
+static void provides_walk(infer_record_t* records, ast_t* typeparams,
+  ast_t* other_typeparams, ast_t* param_type, ast_t* arg_type, ast_t* arg,
+  pass_opt_t* opt)
+{
+  ast_t* param_def = (ast_t*)ast_data(param_type);
+  ast_t* arg_def = (ast_t*)ast_data(arg_type);
+
+  if(param_def == NULL || arg_def == NULL)
+    return;
+
+  ast_t* provides = ast_childidx(arg_def, 3);
+  if(provides == NULL || ast_id(provides) == TK_NONE)
+    return;
+
+  ast_t* arg_tp = ast_childidx(arg_def, 1);
+  ast_t* arg_ta = ast_childidx(arg_type, 2);
+
+  bool multi = (ast_id(provides) == TK_PROVIDES ||
+    ast_id(provides) == TK_UNIONTYPE ||
+    ast_id(provides) == TK_ISECTTYPE);
+
+  ast_t* entry = multi ? ast_child(provides) : provides;
+
+  while(entry != NULL)
+  {
+    ast_t* reified_entry = reify(entry, arg_tp, arg_ta, opt, true);
+
+    if(ast_id(reified_entry) == TK_NOMINAL)
+    {
+      ast_t* entry_def = (ast_t*)ast_data(reified_entry);
+      if(entry_def == param_def)
+      {
+        // Match: recurse pairwise.
+        ast_t* p_ta = ast_childidx(param_type, 2);
+        ast_t* e_ta = ast_childidx(reified_entry, 2);
+
+        ast_t* p_arg = ast_child(p_ta);
+        ast_t* e_arg = ast_child(e_ta);
+
+        while(p_arg != NULL && e_arg != NULL)
+        {
+          extract_nested(records, typeparams, other_typeparams,
+            p_arg, e_arg, arg, opt);
+          p_arg = ast_sibling(p_arg);
+          e_arg = ast_sibling(e_arg);
+        }
+
+        ast_free_unattached(reified_entry);
+        return;
+      }
+    }
+    else if(ast_id(reified_entry) != TK_ARROW)
+    {
+      // Non-arrow, non-nominal: might have nested matches.
+      // (Arrow types from reification treated as opaque.)
+    }
+
+    ast_free_unattached(reified_entry);
+    entry = multi ? ast_sibling(entry) : NULL;
+  }
+}
+
+static void extract_nested(infer_record_t* records, ast_t* typeparams,
+  ast_t* other_typeparams, ast_t* param_type, ast_t* arg_type, ast_t* arg,
+  pass_opt_t* opt)
+{
+  if(param_type == NULL || arg_type == NULL)
+    return;
+
+  ast_t* p_unfolded = NULL;
+  ast_t* a_unfolded = NULL;
+
+  if(ast_id(param_type) == TK_TYPEALIASREF)
+  {
+    p_unfolded = typealias_unfold(param_type);
+    if(p_unfolded != NULL)
+      param_type = p_unfolded;
+  }
+
+  if(ast_id(arg_type) == TK_TYPEALIASREF)
+  {
+    a_unfolded = typealias_unfold(arg_type);
+    if(a_unfolded != NULL)
+      arg_type = a_unfolded;
+  }
+
+  // Direct position: bare TYPEPARAMREF of the inferred list.
+  if(ast_id(param_type) == TK_TYPEPARAMREF)
+  {
+    ast_t* def = (ast_t*)ast_data(param_type);
+
+    if(is_typeparam_of(def, typeparams))
+    {
+      record_nested(records, typeparams, def, arg_type, arg, opt);
+      goto cleanup;
+    }
+
+    goto cleanup;
+  }
+
+  // Nominal: same def -> pairwise; different def -> provides walk.
+  if(ast_id(param_type) == TK_NOMINAL && ast_id(arg_type) == TK_NOMINAL)
+  {
+    ast_t* param_def = (ast_t*)ast_data(param_type);
+    ast_t* arg_def = (ast_t*)ast_data(arg_type);
+
+    if(param_def == arg_def)
+    {
+      ast_t* p_ta = ast_childidx(param_type, 2);
+      ast_t* a_ta = ast_childidx(arg_type, 2);
+
+      ast_t* p_arg = ast_child(p_ta);
+      ast_t* a_arg = ast_child(a_ta);
+
+      while(p_arg != NULL && a_arg != NULL)
+      {
+        extract_nested(records, typeparams, other_typeparams,
+          p_arg, a_arg, arg, opt);
+        p_arg = ast_sibling(p_arg);
+        a_arg = ast_sibling(a_arg);
+      }
+    }
+    else
+    {
+      provides_walk(records, typeparams, other_typeparams,
+        param_type, arg_type, arg, opt);
+    }
+
+    goto cleanup;
+  }
+
+  // Intersection argument: try each member.
+  if(ast_id(arg_type) == TK_ISECTTYPE)
+  {
+    ast_t* member = ast_child(arg_type);
+    while(member != NULL)
+    {
+      extract_nested(records, typeparams, other_typeparams,
+        param_type, member, arg, opt);
+      member = ast_sibling(member);
+    }
+    goto cleanup;
+  }
+
+  // TYPEPARAMREF argument at a nested position: retry against constraint.
+  if(ast_id(arg_type) == TK_TYPEPARAMREF)
+  {
+    ast_t* arg_def = (ast_t*)ast_data(arg_type);
+    if(arg_def == NULL)
+      goto cleanup;
+
+    ast_t* constraint = typeparam_constraint(arg_type);
+    if(constraint != NULL && ast_id(constraint) != TK_NONE)
+    {
+      extract_nested(records, typeparams, other_typeparams,
+        param_type, constraint, arg, opt);
+    }
+    goto cleanup;
+  }
+
+  // Tuples: pairwise.
+  if(ast_id(param_type) == TK_TUPLETYPE && ast_id(arg_type) == TK_TUPLETYPE)
+  {
+    ast_t* p_elem = ast_child(param_type);
+    ast_t* a_elem = ast_child(arg_type);
+
+    while(p_elem != NULL && a_elem != NULL)
+    {
+      extract_nested(records, typeparams, other_typeparams,
+        p_elem, a_elem, arg, opt);
+      p_elem = ast_sibling(p_elem);
+      a_elem = ast_sibling(a_elem);
+    }
+    goto cleanup;
+  }
+
+cleanup:
+  if(p_unfolded != NULL)
+    ast_free_unattached(p_unfolded);
+  if(a_unfolded != NULL)
+    ast_free_unattached(a_unfolded);
+}
+
+static void collect_evidence(infer_record_t* records, ast_t* typeparams,
+  ast_t* other_typeparams, ast_t* param_type, ast_t* arg,
+  pass_opt_t* opt)
+{
+  if(ast_id(param_type) == TK_TYPEPARAMREF)
+  {
+    // Direct position.
+    ast_t* def = (ast_t*)ast_data(param_type);
+    if(!is_typeparam_of(def, typeparams))
+      return;
+
+    ast_t* arg_type = ast_type(arg);
+    ast_t* candidate = alias(arg_type, opt);
+
+    // If alias introduces TK_ALIASED, use the argument's own type
+    // so the missing consume is reported by check_arg_types.
+    if(candidate != NULL && ast_id(candidate) == TK_ALIASED)
+    {
+      ast_free_unattached(candidate);
+      candidate = arg_type;
+    }
+    else if(candidate == NULL)
+    {
+      return;
+    }
+
+    record_direct(records, typeparams, def, candidate, arg, opt);
+
+    if(candidate != arg_type)
+      ast_free_unattached(candidate);
+  }
+  else
+  {
+    // Nested position.
+    ast_t* arg_type = ast_type(arg);
+    ast_t* aliased = alias(arg_type, opt);
+
+    if(aliased == NULL)
+      return;
+
+    if(ast_id(aliased) == TK_ALIASED)
+    {
+      ast_free_unattached(aliased);
+      aliased = arg_type;
+    }
+
+    extract_nested(records, typeparams, other_typeparams,
+      param_type, aliased, arg, opt);
+
+    if(aliased != arg_type)
+      ast_free_unattached(aliased);
+  }
+}
+
+// Report a continuation message for one unbound type parameter.
+static void report_unbound(pass_opt_t* opt, ast_t* error_at,
+  const char* callee_name, infer_record_t* rec)
+{
+  ast_t* tp = rec->typeparam;
+  const char* tp_name = ast_name(ast_child(tp));
+
+  ast_error_continue(opt->check.errors, tp,
+    "type parameter '%s' could not be determined", tp_name);
+
+  switch(rec->unbound.reason)
+  {
+    case REASON_NO_POSITION:
+      ast_error_continue(opt->check.errors, tp,
+        "'%s' is not mentioned by the type of any parameter of '%s'",
+        tp_name, callee_name);
+      ast_error_continue(opt->check.errors, tp,
+        "no argument can determine '%s'", tp_name);
+      break;
+
+    case REASON_NO_ARGUMENT:
+      ast_error_continue(opt->check.errors, error_at,
+        "no argument was given for any parameter whose type mentions '%s'",
+        tp_name);
+      break;
+
+    case REASON_LITERAL_ONLY:
+      ast_error_continue(opt->check.errors, rec->unbound.anchor,
+        "'%s' could only be determined by this argument", tp_name);
+      ast_error_continue(opt->check.errors, rec->unbound.anchor,
+        "a literal has no type of its own until the parameter type is known");
+      ast_error_continue(opt->check.errors, rec->unbound.anchor,
+        "give the literal a type, as in 'U8(1)'");
+      break;
+
+    case REASON_DEPENDENT:
+      ast_error_continue(opt->check.errors, rec->unbound.anchor,
+        "this argument cannot determine '%s'", tp_name);
+      ast_error_continue(opt->check.errors, rec->unbound.anchor,
+        "its type is inferred from the parameter");
+      ast_error_continue(opt->check.errors, rec->unbound.anchor,
+        "with the type argument written, this argument's type comes "
+        "from the parameter");
+      break;
+
+    case REASON_UNTYPED_ARG:
+      break;
+
+    case REASON_DEFAULT_UNDECIDED:
+      ast_error_continue(opt->check.errors, tp,
+        "the default for '%s' refers to '%s', which could not be determined",
+        tp_name, rec->unbound.detail);
+      break;
+  }
+}
+
+// Report the error for conflicting type evidence.
+static void report_conflict(pass_opt_t* opt, ast_t* error_at,
+  const char* callee_name, infer_record_t* rec)
+{
+  const char* tp_name = ast_name(ast_child(rec->typeparam));
+
+  ast_error(opt->check.errors, error_at,
+    "the arguments give conflicting types for type parameter '%s'", tp_name);
+
+  if(rec->conflict.nested)
+  {
+    ast_error_continue(opt->check.errors, rec->conflict.arg_i,
+      "this argument gives %s for '%s', from %s",
+      ast_print_type(ast_type(rec->conflict.arg_i), opt->strtab),
+      tp_name,
+      ast_print_type(ast_type(rec->conflict.arg_i), opt->strtab));
+
+    ast_error_continue(opt->check.errors, rec->conflict.arg_j,
+      "this argument gives %s for '%s', from %s",
+      ast_print_type(ast_type(rec->conflict.arg_j), opt->strtab),
+      tp_name,
+      ast_print_type(ast_type(rec->conflict.arg_j), opt->strtab));
+
+    ast_error_continue(opt->check.errors, error_at,
+      "the types must be exactly the same, because type arguments "
+      "are invariant");
+  }
+  else
+  {
+    ast_error_continue(opt->check.errors, rec->conflict.arg_i,
+      "this argument gives %s for '%s'",
+      ast_print_type(ast_type(rec->conflict.arg_i), opt->strtab),
+      tp_name);
+
+    ast_error_continue(opt->check.errors, rec->conflict.arg_j,
+      "this argument gives %s for '%s'",
+      ast_print_type(ast_type(rec->conflict.arg_j), opt->strtab),
+      tp_name);
+
+    ast_error_continue(opt->check.errors, error_at,
+      "the types must be the same, or one a subtype of the other");
+    ast_error_continue(opt->check.errors, error_at,
+      "when one is a subtype of the other, the supertype is used");
+  }
+
+  ast_error_continue(opt->check.errors, error_at,
+    "write the type argument to choose between them, as in '%s[T](...)'",
+    callee_name);
+}
+
+static void free_records(infer_record_t* records, size_t count,
+  size_t alloc_size)
+{
+  for(size_t i = 0; i < count; i++)
+  {
+    if(records[i].state == REC_BOUND)
+      ast_free_unattached(records[i].bound.type);
+    else if(records[i].state == REC_PINNED)
+      ast_free_unattached(records[i].pinned.type);
+  }
+
+  ponyint_pool_free_size(alloc_size, records);
+}
+
+ast_t* infer_typeargs(pass_opt_t* opt, ast_t* typeparams,
+  ast_t* other_typeparams, ast_t* params, ast_t* positional,
+  ast_t* error_at, const char* callee_name)
+{
+  pony_assert(ast_id(typeparams) == TK_TYPEPARAMS);
+
+  size_t tp_count = ast_childcount(typeparams);
+  pony_assert(tp_count > 0);
+
+  size_t alloc_size = tp_count * sizeof(infer_record_t);
+  infer_record_t* records =
+    (infer_record_t*)ponyint_pool_alloc_size(alloc_size);
+  memset(records, 0, alloc_size);
+
+  ast_t* tp = ast_child(typeparams);
+  for(size_t i = 0; i < tp_count; i++)
+  {
+    records[i].state = REC_UNBOUND;
+    records[i].typeparam = tp;
+    records[i].unbound.reason = REASON_NO_POSITION;
+    records[i].unbound.anchor = tp;
+    records[i].unbound.detail = NULL;
+    tp = ast_sibling(tp);
+  }
+
+  ast_t* param = ast_child(params);
+  ast_t* arg = ast_child(positional);
+  bool has_untyped = false;
+
+  while(param != NULL && arg != NULL)
+  {
+    ast_t* p_type = ast_childidx(param, 1);
+
+    ast_t* tp_node = ast_child(typeparams);
+    for(size_t i = 0; i < tp_count; i++)
+    {
+      if(records[i].state != REC_UNBOUND)
+      {
+        tp_node = ast_sibling(tp_node);
+        continue;
+      }
+
+      if(bindable_position_one(p_type, tp_node))
+      {
+        if(records[i].unbound.reason == REASON_NO_POSITION)
+        {
+          // Upgrade to at least NO_ARGUMENT.
+          if(type_mentions_one_typeparam(p_type, tp_node))
+            records[i].unbound.reason = REASON_NO_ARGUMENT;
+        }
+      }
+
+      tp_node = ast_sibling(tp_node);
+    }
+
+    if(ast_id(arg) == TK_NONE)
+    {
+      param = ast_sibling(param);
+      arg = ast_sibling(arg);
+      continue;
+    }
+
+    if(!infer_bindable_position(p_type, typeparams))
+    {
+      param = ast_sibling(param);
+      arg = ast_sibling(arg);
+      continue;
+    }
+
+    // Classification ORDER: (1) TK_NONE (above); (2) dependent;
+    // (3) type error; (4) literal; (5) evidence.
+    if(is_antecedent_dependent(arg))
+    {
+      tp_node = ast_child(typeparams);
+      for(size_t i = 0; i < tp_count; i++)
+      {
+        if(records[i].state == REC_UNBOUND &&
+          records[i].unbound.reason != REASON_DEPENDENT)
+        {
+          if(type_mentions_one_typeparam(p_type, tp_node))
+          {
+            records[i].unbound.reason = REASON_DEPENDENT;
+            records[i].unbound.anchor = arg;
+          }
+        }
+        tp_node = ast_sibling(tp_node);
+      }
+
+      param = ast_sibling(param);
+      arg = ast_sibling(arg);
+      continue;
+    }
+
+    ast_t* arg_type = ast_type(arg);
+    if(is_typecheck_error(arg_type))
+    {
+      has_untyped = true;
+      tp_node = ast_child(typeparams);
+      for(size_t i = 0; i < tp_count; i++)
+      {
+        if(records[i].state == REC_UNBOUND &&
+          type_mentions_one_typeparam(p_type, tp_node))
+        {
+          records[i].unbound.reason = REASON_UNTYPED_ARG;
+          records[i].unbound.anchor = arg;
+        }
+        tp_node = ast_sibling(tp_node);
+      }
+
+      param = ast_sibling(param);
+      arg = ast_sibling(arg);
+      continue;
+    }
+
+    if(ast_id(arg_type) == TK_LITERAL || ast_id(arg_type) == TK_OPERATORLITERAL)
+    {
+      tp_node = ast_child(typeparams);
+      for(size_t i = 0; i < tp_count; i++)
+      {
+        if(records[i].state == REC_UNBOUND &&
+          records[i].unbound.reason != REASON_LITERAL_ONLY &&
+          records[i].unbound.reason != REASON_DEPENDENT)
+        {
+          if(type_mentions_one_typeparam(p_type, tp_node))
+          {
+            records[i].unbound.reason = REASON_LITERAL_ONLY;
+            records[i].unbound.anchor = arg;
+          }
+        }
+        tp_node = ast_sibling(tp_node);
+      }
+
+      param = ast_sibling(param);
+      arg = ast_sibling(arg);
+      continue;
+    }
+
+    collect_evidence(records, typeparams, other_typeparams, p_type, arg, opt);
+
+    param = ast_sibling(param);
+    arg = ast_sibling(arg);
+  }
+
+  // Cache is_antecedent_dependent per argument for the default-first loop.
+  size_t arg_count = ast_childcount(positional);
+  bool* dep_cache = NULL;
+  if(arg_count > 0)
+  {
+    size_t dep_size = arg_count * sizeof(bool);
+    dep_cache = (bool*)ponyint_pool_alloc_size(dep_size);
+    ast_t* a = ast_child(positional);
+    for(size_t k = 0; k < arg_count; k++)
+    {
+      dep_cache[k] = is_antecedent_dependent(a);
+      a = ast_sibling(a);
+    }
+  }
+
+  // Resolution: default-first, in declaration order.
+  BUILD(typeargs, error_at, NODE(TK_TYPEARGS));
+
+  bool ok = true;
+
+  for(size_t i = 0; i < tp_count; i++)
+  {
+    infer_record_t* rec = &records[i];
+    ast_t* resolved = NULL;
+    bool resolved_is_owned = false;
+
+    if(rec->state == REC_CONFLICT)
+    {
+      report_conflict(opt, error_at, callee_name, rec);
+      ok = false;
+      break;
+    }
+
+    ast_t* tp_node = rec->typeparam;
+    ast_t* defarg = ast_childidx(tp_node, 2);
+
+    if(ast_id(defarg) != TK_NONE)
+    {
+      // Reify the default against the decided prefix.
+      ast_t* reified_default = reify_default(tp_node, typeparams,
+        typeargs, opt);
+
+      if(reified_default != NULL)
+      {
+        // Postcondition: the reified default must not mention any type
+        // parameter from position i onward.
+        const char* dangling_name = find_dangling_default_ref(
+          reified_default, typeparams, i);
+        if(dangling_name != NULL)
+        {
+          if(rec->state == REC_BOUND || rec->state == REC_PINNED)
+          {
+            ast_free_unattached(reified_default);
+            resolved = (rec->state == REC_BOUND) ?
+              rec->bound.type : rec->pinned.type;
+          }
+          else
+          {
+                rec->state = REC_UNBOUND;
+            rec->unbound.reason = REASON_DEFAULT_UNDECIDED;
+            rec->unbound.anchor = tp_node;
+            rec->unbound.detail = dangling_name;
+
+            ast_free_unattached(reified_default);
+            // Fall through to unbound reporting below.
+            goto report_unbound_label;
+          }
+        }
+        else
+        {
+          // Default is usable. Check if all arguments fit it.
+          bool default_ok = true;
+
+          if(rec->state == REC_BOUND || rec->state == REC_PINNED)
+          {
+            // Check argument assignability under the default.
+            ast_t* p2 = ast_child(params);
+            ast_t* a2 = ast_child(positional);
+            size_t a2_idx = 0;
+
+            while(p2 != NULL && a2 != NULL)
+            {
+              if(ast_id(a2) != TK_NONE)
+              {
+                ast_t* a2_type = ast_type(a2);
+
+                if(!is_typecheck_error(a2_type) &&
+                  ast_id(a2_type) != TK_LITERAL &&
+                  ast_id(a2_type) != TK_OPERATORLITERAL &&
+                  (dep_cache == NULL || !dep_cache[a2_idx]))
+                {
+                  ast_t* pt2 = ast_childidx(p2, 1);
+
+                  if(type_mentions_typeparams(pt2, typeparams))
+                  {
+                    // Skip if this param also mentions undecided later params.
+                    bool skip = false;
+                    for(size_t j = i + 1; j < tp_count; j++)
+                    {
+                      if(records[j].state == REC_UNBOUND &&
+                        type_mentions_one_typeparam(pt2,
+                          records[j].typeparam))
+                      {
+                        skip = true;
+                        break;
+                      }
+                    }
+
+                    if(!skip && (other_typeparams == NULL ||
+                      !type_mentions_typeparams(pt2, other_typeparams)))
+                    {
+                      // Reify the parameter type with the trial binding.
+                      ast_t* trial_args = ast_dup(typeargs);
+                      ast_append(trial_args, ast_dup(reified_default));
+                      ast_t* trial_type = reify(pt2, typeparams,
+                        trial_args, opt, true);
+
+                      ast_t* wp = consume_type(trial_type, TK_NONE,
+                        false, opt);
+
+                      if(wp != NULL)
+                      {
+                        ast_t* aliased_arg = alias(a2_type, opt);
+                        if(aliased_arg == NULL ||
+                          ast_id(aliased_arg) == TK_ALIASED)
+                        {
+                          if(aliased_arg != NULL)
+                            ast_free_unattached(aliased_arg);
+                          aliased_arg = a2_type;
+                        }
+
+                        errorframe_t info = NULL;
+                        if(!is_subtype(aliased_arg, wp, &info, opt))
+                          default_ok = false;
+
+                        errorframe_discard(&info);
+
+                        if(aliased_arg != a2_type)
+                          ast_free_unattached(aliased_arg);
+
+                        ast_free_unattached(wp);
+                      }
+                      else
+                      {
+                        default_ok = false;
+                      }
+
+                      ast_free_unattached(trial_type);
+                      ast_free_unattached(trial_args);
+                    }
+                  }
+                }
+              }
+
+              p2 = ast_sibling(p2);
+              a2 = ast_sibling(a2);
+              a2_idx++;
+            }
+          }
+
+          if(default_ok)
+          {
+            resolved = reified_default;
+            resolved_is_owned = true;
+          }
+          else
+          {
+            ast_free_unattached(reified_default);
+            reified_default = NULL;
+
+            if(rec->state == REC_BOUND)
+              resolved = rec->bound.type;
+            else if(rec->state == REC_PINNED)
+              resolved = rec->pinned.type;
+          }
+
+        }
+      }
+      else if(rec->state == REC_BOUND || rec->state == REC_PINNED)
+      {
+        resolved = (rec->state == REC_BOUND) ?
+          rec->bound.type : rec->pinned.type;
+      }
+    }
+    else
+    {
+      if(rec->state == REC_BOUND)
+        resolved = rec->bound.type;
+      else if(rec->state == REC_PINNED)
+        resolved = rec->pinned.type;
+    }
+
+report_unbound_label:
+    if(resolved == NULL && rec->state == REC_UNBOUND)
+    {
+      // An argument with no type already reported its own error; exit
+      // silently so the inference message doesn't pile on.
+      if(has_untyped)
+      {
+        ast_free_unattached(typeargs);
+        free_records(records, tp_count, alloc_size);
+        if(dep_cache != NULL)
+          ponyint_pool_free_size(arg_count * sizeof(bool), dep_cache);
+        return NULL;
+      }
+
+      ast_error(opt->check.errors, error_at,
+        "could not infer the type arguments of '%s' from this call's "
+        "arguments", callee_name);
+
+      report_unbound(opt, error_at, callee_name, rec);
+
+      ast_error_continue(opt->check.errors, error_at,
+        "write the type arguments explicitly, as in '%s[T](...)'",
+        callee_name);
+
+      ok = false;
+      break;
+    }
+
+    if(resolved == NULL)
+    {
+      // Should not get here — means conflict was already reported.
+      ok = false;
+      break;
+    }
+
+    ast_t* ta = ast_dup(resolved);
+
+    if(resolved_is_owned)
+      ast_free_unattached(resolved);
+
+    if(rec->state == REC_BOUND && rec->bound.arg != NULL)
+    {
+      ast_setpos(ta, ast_source(rec->bound.arg),
+        ast_line(rec->bound.arg), ast_pos(rec->bound.arg));
+    }
+    else if(rec->state == REC_PINNED && rec->pinned.arg != NULL)
+    {
+      ast_setpos(ta, ast_source(rec->pinned.arg),
+        ast_line(rec->pinned.arg), ast_pos(rec->pinned.arg));
+    }
+
+    ast_append(typeargs, ta);
+  }
+
+  free_records(records, tp_count, alloc_size);
+  if(dep_cache != NULL)
+    ponyint_pool_free_size(arg_count * sizeof(bool), dep_cache);
+
+  if(!ok)
+  {
+    ast_free_unattached(typeargs);
+    return NULL;
+  }
+
+  return typeargs;
+}

--- a/src/libponyc/expr/infer.h
+++ b/src/libponyc/expr/infer.h
@@ -1,0 +1,37 @@
+#ifndef EXPR_INFER_H
+#define EXPR_INFER_H
+
+#include <platform.h>
+#include "../ast/ast.h"
+#include "../pass/pass.h"
+
+PONY_EXTERN_C_BEGIN
+
+// Infer type arguments for a generic call from its positional arguments.
+// typeparams: the type parameters being inferred (TK_TYPEPARAMS).
+// other_typeparams: the callee's OTHER still-open type parameters, or NULL.
+// params: the callee's parameter list (TK_PARAMS).
+// positional: the positional arguments after normalisation (TK_POSITIONALARGS).
+// error_at: the node that anchors error messages (the call or TYPEREF).
+// callee_name: the callee as written (for messages).
+// Returns a TK_TYPEARGS node on success, NULL on failure (one error reported,
+// or silent when an argument has no type).
+ast_t* infer_typeargs(pass_opt_t* opt, ast_t* typeparams,
+  ast_t* other_typeparams, ast_t* params, ast_t* positional,
+  ast_t* error_at, const char* callee_name);
+
+// True when a parameter at this position is bindable: the type mentions at
+// least one type parameter from the given list in a direct or nested position.
+bool infer_bindable_position(ast_t* type, ast_t* typeparams);
+
+// True when type mentions any type parameter from the given list.
+bool type_mentions_typeparams(ast_t* type, ast_t* typeparams);
+
+// Return the parameter type pruned of parts that mention an open type
+// parameter inside structure. Returns a borrowed pointer (the parameter type,
+// one of its members, or NULL).
+ast_t* antecedent_prune(ast_t* type, ast_t* typeparams);
+
+PONY_EXTERN_C_END
+
+#endif

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -331,6 +331,51 @@ bool expr_typeref(pass_opt_t* opt, ast_t** astp)
   ast_t* type = ast_type(ast);
   if(type == NULL || (ast_id(type) == TK_INFERTYPE))
   {
+    if(ast_id(typeargs) == TK_NONE)
+    {
+      ast_t* def = (ast_t*)ast_data(ast);
+
+      if(def != NULL)
+      {
+        switch(ast_id(def))
+        {
+          case TK_PRIMITIVE:
+          case TK_STRUCT:
+          case TK_CLASS:
+          case TK_ACTOR:
+          {
+            ast_t* def_typeparams = ast_childidx(def, 1);
+
+            if(ast_id(def_typeparams) == TK_TYPEPARAMS)
+            {
+              BUILD(probe_args, ast, NODE(TK_NONE));
+              bool has_defaults =
+                reify_defaults(def_typeparams, probe_args, false, opt);
+              ast_free_unattached(probe_args);
+
+              if(!has_defaults)
+              {
+                ast_error(opt->check.errors, ast,
+                  "not enough type arguments");
+                ast_error_continue(opt->check.errors, def_typeparams,
+                  "definition is here");
+                ast_error_continue(opt->check.errors, ast,
+                  "type arguments are inferred only from the arguments"
+                  " of a constructor call");
+                ast_settype(ast, ast_from(ast, TK_ERRORTYPE));
+                return false;
+              }
+            }
+
+            break;
+          }
+
+          default:
+            break;
+        }
+      }
+    }
+
     // Assemble the type node from the package name and type name strings.
     const char* name = ast_name(id);
     const char* package_name =

--- a/src/libponyc/pass/expr.c
+++ b/src/libponyc/pass/expr.c
@@ -4,6 +4,7 @@
 #include "../expr/operator.h"
 #include "../expr/postfix.h"
 #include "../expr/call.h"
+#include "../expr/infer.h"
 #include "../expr/control.h"
 #include "../expr/match.h"
 #include "../expr/array.h"
@@ -388,7 +389,14 @@ ast_t* find_antecedent_type(pass_opt_t* opt, ast_t* ast, bool* is_recovered,
       while((arg != NULL) && (param != NULL))
       {
         if(arg == ast)
-          return ast_childidx(param, 1);
+        {
+          ast_t* ptype = ast_childidx(param, 1);
+
+          if(ast_id(t_params) != TK_NONE)
+            ptype = antecedent_prune(ptype, t_params);
+
+          return ptype;
+        }
 
         arg = ast_sibling(arg);
         param = ast_sibling(param);
@@ -420,7 +428,14 @@ ast_t* find_antecedent_type(pass_opt_t* opt, ast_t* ast, bool* is_recovered,
       while(param != NULL)
       {
         if(ast_name(ast_child(param)) == name)
-          return ast_childidx(param, 1);
+        {
+          ast_t* ptype = ast_childidx(param, 1);
+
+          if(ast_id(t_params) != TK_NONE)
+            ptype = antecedent_prune(ptype, t_params);
+
+          return ptype;
+        }
 
         param = ast_sibling(param);
       }
@@ -628,6 +643,7 @@ ast_result_t pass_pre_expr(ast_t** astp, pass_opt_t* options)
   switch(ast_id(ast))
   {
     case TK_ARRAY: return expr_pre_array(options, astp);
+    case TK_CALL: return expr_pre_call(options, astp);
     case TK_IFDEFNOT:
     case TK_IFDEFAND:
     case TK_IFDEFOR:

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -152,7 +152,7 @@ static void reify_reference(pass_opt_t* opt, ast_t** astp, ast_t* typeparams, as
 }
 
 
-static const char* find_dangling_default_ref(ast_t* ast, ast_t* typeparams,
+const char* find_dangling_default_ref(ast_t* ast, ast_t* typeparams,
   size_t pos)
 {
   if(ast == NULL)
@@ -190,7 +190,7 @@ static const char* find_dangling_default_ref(ast_t* ast, ast_t* typeparams,
 // Reify a type parameter's default against the type arguments decided so far.
 // Sibling references in the default must already be TK_TYPEPARAMREF nodes
 // (via resolve_default_typeargs) so that reify() can substitute them.
-static ast_t* reify_default(ast_t* typeparam, ast_t* typeparams,
+ast_t* reify_default(ast_t* typeparam, ast_t* typeparams,
   ast_t* typeargs_so_far, pass_opt_t* opt)
 {
   ast_t* defarg = ast_childidx(typeparam, 2);

--- a/src/libponyc/type/reify.h
+++ b/src/libponyc/type/reify.h
@@ -17,6 +17,12 @@ typedef struct deferred_reification_t
   ast_t* thistype;
 } deferred_reification_t;
 
+ast_t* reify_default(ast_t* typeparam, ast_t* typeparams,
+  ast_t* typeargs_so_far, pass_opt_t* opt);
+
+const char* find_dangling_default_ref(ast_t* ast, ast_t* typeparams,
+  size_t pos);
+
 bool reify_defaults(ast_t* typeparams, ast_t* typeargs, bool errors,
   pass_opt_t* opt);
 

--- a/test/full-program-tests/generic-type-inference-constructor/main.pony
+++ b/test/full-program-tests/generic-type-inference-constructor/main.pony
@@ -1,0 +1,12 @@
+class Wrapper[A: Any val]
+  let _a: A
+  new create(a: A) => _a = a
+  fun get(): A => _a
+
+actor Main
+  new create(env: Env) =>
+    let w = Wrapper("hello")
+    let s: String val = w.get()
+
+    let w2 = Wrapper.create(U8(42))
+    let n: U8 = w2.get()

--- a/test/full-program-tests/generic-type-inference-default-kept/main.pony
+++ b/test/full-program-tests/generic-type-inference-default-kept/main.pony
@@ -1,0 +1,6 @@
+primitive Bar
+  fun foo[A: Any val = U8](a: A): A => a
+
+actor Main
+  new create(env: Env) =>
+    let x: U8 = Bar.foo(U8(42))

--- a/test/full-program-tests/generic-type-inference-lambda/main.pony
+++ b/test/full-program-tests/generic-type-inference-lambda/main.pony
@@ -1,0 +1,7 @@
+primitive Bar
+  fun foo[A: Any val](a: A, f: {(A): A} val): A =>
+    f(a)
+
+actor Main
+  new create(env: Env) =>
+    let x: U8 = Bar.foo(U8(42), {(x: U8): U8 => x + 1})

--- a/test/full-program-tests/generic-type-inference-method/main.pony
+++ b/test/full-program-tests/generic-type-inference-method/main.pony
@@ -1,0 +1,9 @@
+primitive Bar
+  fun foo[A: Any val](a: A): A => a
+
+  fun two[A: Any val, B: Any val](a: A, b: B): A => a
+
+actor Main
+  new create(env: Env) =>
+    let x: U8 = Bar.foo(U8(42))
+    let y: U8 = Bar.two(U8(1), "hello")

--- a/test/libponyc/CMakeLists.txt
+++ b/test/libponyc/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(libponyc.tests
     traits.cc
     type_check_bind.cc
     type_check_subtype.cc
+    typearg_inference.cc
     type_params.cc
     use.cc
     userflags.cc

--- a/test/libponyc/typearg_inference.cc
+++ b/test/libponyc/typearg_inference.cc
@@ -1,0 +1,671 @@
+#include <gtest/gtest.h>
+#include <platform.h>
+
+#include "util.h"
+
+#define TEST_COMPILE(src) DO(test_compile(src, "expr"))
+#define TEST_COMPILE_IR(src) DO(test_compile(src, "ir"))
+#define TEST_ERROR(src) DO(test_error(src, "expr"))
+#define TEST_EQUIV(src, expect) DO(test_equiv(src, "expr", expect, "expr"))
+
+#define TEST_ERRORS_1(src, err1) \
+  { const char* errs[] = {err1, NULL}; \
+    DO(test_expected_errors(src, "expr", errs)); }
+
+#define TEST_ERRORS_2(src, err1, err2) \
+  { const char* errs[] = {err1, err2, NULL}; \
+    DO(test_expected_errors(src, "expr", errs)); }
+
+
+class TypeArgInferenceTest : public PassTest
+{};
+
+
+// --- Simple inference from a single argument ---
+
+TEST_F(TypeArgInferenceTest, SingleParam_DirectPosition)
+{
+  // foo(U8(1)) should infer A = U8
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1))\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1))\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, TwoParams_DirectPosition)
+{
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val, B: Any val](a: A, b: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1), \"hello\")\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val, B: Any val](a: A, b: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8, String val](U8(1), \"hello\")\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+// --- Default-first rule ---
+
+TEST_F(TypeArgInferenceTest, DefaultKept_WhenArgFits)
+{
+  // A has default U8; argument is U8 — default is kept.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val = U8](a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1))\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val = U8](a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1))\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, DefaultOverridden_WhenArgDoesNotFit)
+{
+  // A has default U8; argument is String — inferred type overrides default.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val = U8](a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(\"hello\")\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val = U8](a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[String val](\"hello\")\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+// --- Multiple arguments for the same type parameter ---
+
+TEST_F(TypeArgInferenceTest, TwoArgs_SameTypeParam_SameType)
+{
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1), U8(2))\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1), U8(2))\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+// --- Nested position inference ---
+
+TEST_F(TypeArgInferenceTest, NestedPosition_ArrayElement)
+{
+  // fun foo[A: Any val](a: Array[A] val) => None
+  // foo(recover val [as String val: "hello"] end) — A inferred from Array
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: Array[A] val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(recover val [as String val: \"hello\"] end)\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: Array[A] val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[String val](recover val [as String val: \"hello\"] end)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+// --- M1 errors (no evidence) ---
+
+TEST_F(TypeArgInferenceTest, M1_NoPosition)
+{
+  // Type parameter not mentioned in any parameter type.
+  // Falls through to defaults-only path since no param mentions A.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](x: U8) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1))\n";
+
+  TEST_ERRORS_1(src, "not enough type arguments");
+}
+
+TEST_F(TypeArgInferenceTest, M1_LiteralOnly)
+{
+  // All arguments at bindable positions are literals — no evidence.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(1)\n";
+
+  TEST_ERRORS_1(src, "could not infer the type arguments");
+}
+
+
+// --- M2 error (conflict) ---
+
+TEST_F(TypeArgInferenceTest, M2_Conflict)
+{
+  // Two arguments for the same type parameter with incompatible types.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1), \"hello\")\n";
+
+  TEST_ERRORS_1(src, "conflicting types for type parameter");
+}
+
+
+// --- Self-call equivalence ---
+
+TEST_F(TypeArgInferenceTest, SelfCall_Equiv)
+{
+  // fun foo[A: Any val](a: A, b: A) calling foo(a, b)
+  // should be equivalent to foo[A](a, b)
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: A): A =>\n"
+    "    foo(a, b)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1), U8(2))\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: A): A =>\n"
+    "    foo[A](a, b)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1), U8(2))\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+// --- Same-name caller equivalence ---
+
+TEST_F(TypeArgInferenceTest, SameNameCaller_Equiv)
+{
+  // fun bar[A: Any val](a: A) => Baz.foo(a)
+  // should be equivalent to Baz.foo[A](a)
+  const char* inferred =
+    "primitive Baz\n"
+    "  fun foo[A: Any val](a: A): A => a\n"
+
+    "primitive Bar\n"
+    "  fun bar[A: Any val](a: A): A =>\n"
+    "    Baz.foo(a)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.bar[U8](U8(1))\n";
+
+  const char* explicit_form =
+    "primitive Baz\n"
+    "  fun foo[A: Any val](a: A): A => a\n"
+
+    "primitive Bar\n"
+    "  fun bar[A: Any val](a: A): A =>\n"
+    "    Baz.foo[A](a)\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.bar[U8](U8(1))\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+// --- Pre-order hook: antecedent-dependent arguments ---
+
+TEST_F(TypeArgInferenceTest, PreOrder_LambdaGetsReifiedType)
+{
+  // The lambda's parameter type depends on the inferred type parameter.
+  // The pre-order hook infers A=U8 from the first argument, reifies
+  // the parameter types, then the normal pass visits the lambda against
+  // the reified type.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, f: {(A): A} val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1), {(x: U8): U8 => x})\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, f: {(A): A} val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1), {(x: U8): U8 => x})\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+// --- Constructor-path inference ---
+
+TEST_F(TypeArgInferenceTest, ConstructorPath_BareTyperef)
+{
+  // Foo(x) -> Foo[String val](x)
+  const char* inferred =
+    "class Foo[A: Any val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo(\"hello\")\n";
+
+  const char* explicit_form =
+    "class Foo[A: Any val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo[String val](\"hello\")\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, ConstructorPath_DotCreate)
+{
+  // Foo.create(x) -> Foo[String val].create(x)
+  const char* inferred =
+    "class Foo[A: Any val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo.create(\"hello\")\n";
+
+  const char* explicit_form =
+    "class Foo[A: Any val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo[String val].create(\"hello\")\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, ConstructorPath_TwoParams)
+{
+  // Two class type params inferred from constructor args.
+  const char* inferred =
+    "class Pair[A: Any val, B: Any val]\n"
+    "  let _a: A\n"
+    "  let _b: B\n"
+    "  new create(a: A, b: B) => _a = a; _b = b\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Pair(U8(1), \"hello\")\n";
+
+  const char* explicit_form =
+    "class Pair[A: Any val, B: Any val]\n"
+    "  let _a: A\n"
+    "  let _b: B\n"
+    "  new create(a: A, b: B) => _a = a; _b = b\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Pair[U8, String val](U8(1), \"hello\")\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+TEST_F(TypeArgInferenceTest, M4_MethodCall_NotConstructor)
+{
+  // Foo.some_fun(x) — type args not inferred on non-constructor calls.
+  const char* src =
+    "class Foo[A: Any val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+    "  fun get(): A => _a\n"
+
+    "primitive Bar\n"
+    "  fun apply() =>\n"
+    "    Foo.get()\n";
+
+  TEST_ERRORS_1(src, "not enough type arguments");
+}
+
+
+// --- Codegen survival: inferred type args must survive through IR ---
+
+TEST_F(TypeArgInferenceTest, Codegen_SimpleInference)
+{
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A): A => a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: U8 = Bar.foo(U8(42))\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+TEST_F(TypeArgInferenceTest, Codegen_TwoParamInference)
+{
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val, B: Any val](a: A, b: B): A => a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: U8 = Bar.foo(U8(42), \"hello\")\n";
+
+  TEST_COMPILE_IR(src);
+}
+
+
+// --- H1: unbound reasons that had no tests ---
+
+TEST_F(TypeArgInferenceTest, M1_NoArgument)
+{
+  // A is mentioned at a bindable position but no argument is given there.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: U8 = 0) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(where b = U8(1))\n";
+
+  TEST_ERRORS_1(src, "could not infer the type arguments");
+}
+
+TEST_F(TypeArgInferenceTest, M1_Dependent)
+{
+  // The only argument mentioning A is a lambda — antecedent-dependent,
+  // so inference has no evidence for A.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](f: {(A): A} val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo({(x: U8): U8 => x})\n";
+
+  TEST_ERRORS_1(src, "could not infer the type arguments");
+}
+
+TEST_F(TypeArgInferenceTest, M1_DefaultUndecided)
+{
+  // A's default is B, but B cannot be determined from the arguments.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val = B, B: Any val](b: B) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1))\n";
+
+  TEST_ERRORS_1(src, "could not infer the type arguments");
+}
+
+
+// --- M3: state transitions ---
+
+TEST_F(TypeArgInferenceTest, SupertypeMerge)
+{
+  // Two arguments with incompatible types for the same type parameter.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1), USize(2))\n";
+
+  TEST_ERRORS_1(src, "conflicting types for type parameter");
+}
+
+TEST_F(TypeArgInferenceTest, BoundToPinned_NestedOverridesDirect)
+{
+  // First argument at direct position → Bound. Second at nested → Pinned.
+  // Pinned wins over direct.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: Array[A] val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1), recover val [as U8: U8(2)] end)\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: Array[A] val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1), recover val [as U8: U8(2)] end)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, PinnedConflict_TwoNestedDisagree)
+{
+  // Two nested positions give different exact types → Pinned then Conflict.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: Array[A] val, b: Array[A] val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(recover val [as U8: U8(1)] end, "
+    "            recover val [as String val: \"hello\"] end)\n";
+
+  TEST_ERRORS_1(src, "conflicting types for type parameter");
+}
+
+
+// --- M5: provides_walk ---
+
+TEST_F(TypeArgInferenceTest, ProvidesWalk_InterfaceArg)
+{
+  // Argument type implements an interface matching the parameter type.
+  // provides_walk finds the match through the implements chain.
+  const char* inferred =
+    "interface Gettable[A: Any val]\n"
+    "  fun get(): A\n"
+
+    "primitive GetU8 is Gettable[U8]\n"
+    "  fun get(): U8 => U8(0)\n"
+
+    "primitive Bar\n"
+    "  fun foo[A: Any val](s: Gettable[A] val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(GetU8)\n";
+
+  const char* explicit_form =
+    "interface Gettable[A: Any val]\n"
+    "  fun get(): A\n"
+
+    "primitive GetU8 is Gettable[U8]\n"
+    "  fun get(): U8 => U8(0)\n"
+
+    "primitive Bar\n"
+    "  fun foo[A: Any val](s: Gettable[A] val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](GetU8)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+// --- M6: two-level inference (class + method type params) ---
+
+TEST_F(TypeArgInferenceTest, TwoLevel_ClassAndMethodTypeParams)
+{
+  // Constructor path infers the class type parameter; then method-level
+  // inference infers B from the second argument.
+  const char* inferred =
+    "class Box2[A: Any val]\n"
+    "  let _a: A\n"
+    "  new create[B: Any val](a: A, b: B) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Box2(U8(1), \"hello\")\n";
+
+  const char* explicit_form =
+    "class Box2[A: Any val]\n"
+    "  let _a: A\n"
+    "  new create[B: Any val](a: A, b: B) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Box2[U8].create[String val](U8(1), \"hello\")\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+
+// --- L12: named constructor, array skip, conflict continuation text ---
+
+TEST_F(TypeArgInferenceTest, ConstructorPath_NamedConstructor)
+{
+  // Foo.from_u8(x) — a named constructor, not `create`.
+  const char* inferred =
+    "class Wrap[A: Any val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+    "  new from_u8(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Wrap.from_u8(U8(42))\n";
+
+  const char* explicit_form =
+    "class Wrap[A: Any val]\n"
+    "  let _a: A\n"
+    "  new create(a: A) => _a = a\n"
+    "  new from_u8(a: A) => _a = a\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Wrap[U8].from_u8(U8(42))\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, PreOrder_ArraySkippedAtBindablePosition)
+{
+  // Array literal at a bindable position is skipped during inference;
+  // the second argument determines A, and the array is typed afterward.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: Array[A] val, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(recover val [as U8: U8(1)] end, U8(2))\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: Array[A] val, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](recover val [as U8: U8(1)] end, U8(2))\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, SubtypeMerge_WidensToSupertype)
+{
+  // Two arguments where one is a subtype of the other: the supertype wins.
+  // U8 <: (U8 | String val), so passing U8 and (U8 | String val) should
+  // resolve to (U8 | String val).
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: (U8 | String val) = U8(1)\n"
+    "    Bar.foo(U8(2), x)\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: (U8 | String val) = U8(1)\n"
+    "    Bar.foo[(U8 | String val)](U8(2), x)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}

--- a/tools/lib/ponylang/pony_compiler/pony_compiler/module.pony
+++ b/tools/lib/ponylang/pony_compiler/pony_compiler/module.pony
@@ -122,6 +122,10 @@ class val PositionIndex
     for child' in ast.children() do
       if filter_none and (child'.id() == TokenIds.tk_none()) then
         None // skip TK_NONE children of certain parent types
+      elseif (child'.id() == TokenIds.tk_typeargs()) and
+        (not child'.data[None]().is_null())
+      then
+        None // skip inferred type arguments (non-null data on TK_TYPEARGS)
       else
         let from_module =
           match child'.source_file()

--- a/tools/pony-lsp/workspace/document_highlight.pony
+++ b/tools/pony-lsp/workspace/document_highlight.pony
@@ -167,6 +167,17 @@ class ref _HighlightCollector is ASTVisitor
         end
       end
 
+      // Inferred type arguments carry a non-null data pointer on their
+      // tk_typeargs parent — skip those too.
+      try
+        let p = ast.parent() as AST
+        if (p.id() == TokenIds.tk_typeargs()) and
+          (not p.data[None]().is_null())
+        then
+          return Continue
+        end
+      end
+
       let kind: I64 =
         if _is_assign_lhs(ast) then
           // LHS of any assignment — covers regular writes,

--- a/tools/pony-lsp/workspace/references.pony
+++ b/tools/pony-lsp/workspace/references.pony
@@ -103,6 +103,17 @@ class ref _ReferenceCollector is ASTVisitor
         end
       end
 
+      // Inferred type arguments carry a non-null data pointer on their
+      // tk_typeargs parent — skip those too.
+      try
+        let p = ast.parent() as AST
+        if (p.id() == TokenIds.tk_typeargs()) and
+          (not p.data[None]().is_null())
+        then
+          return Continue
+        end
+      end
+
       let hl_node = ASTIdentifier.identifier_node(ast)
       (let start_pos, let end_pos) = hl_node.span()
       // AST.visit's _from_same_source filter ensures every node visited


### PR DESCRIPTION
Implements RFC 0010. The compiler infers type arguments from the arguments of a generic method or constructor call, so `Sorter.sort(U8(3), U8(1))` compiles without writing `Sorter.sort[U8](U8(3), U8(1))`. Constructor calls like `Pair("hello", U8(42))` infer the class's type parameters the same way.

When a type parameter has a default, the default is kept when every argument fits it. When an argument doesn't fit, the inferred type replaces the default.

Arguments whose type depends on the inferred type — lambdas, array literals, object literals — are skipped during inference and typed afterward against the reified parameter type. This works as long as at least one other argument determines the type parameter.

The inference engine is in `src/libponyc/expr/infer.c`. It runs from a pre-order hook (`expr_pre_call`) that visits non-dependent arguments early, infers type arguments, then applies them before the normal post-order child visit. Constructor-path inference detects unqualified `TYPEREF` shapes and looks up the constructor to infer the class's type parameters.

Known gaps are documented in the release note. The main ones: array literals and lambdas at structurally nested positions, type aliases wrapping generics, union-typed parameters, and `where` named-only arguments.

Closes #1184
