### PR TITLE
Fix segfault in programs with finalizers compiled with --runtimebc

### DIFF
--- a/.ci-scripts/linux-runtimebc-smoke.sh
+++ b/.ci-scripts/linux-runtimebc-smoke.sh
@@ -30,8 +30,12 @@ smoke=/tmp/runtimebc-smoke
 rm -rf "$smoke"
 mkdir -p "$smoke"
 cat > "$smoke/main.pony" <<'PONY'
+class _Disposable
+  fun _final() => None
+
 actor Main
   new create(env: Env) =>
+    _Disposable
     env.out.print("runtimebc smoke ok")
 PONY
 

--- a/.release-notes/fix-runtimebc-finalizer-segfault.md
+++ b/.release-notes/fix-runtimebc-finalizer-segfault.md
@@ -1,0 +1,15 @@
+## Fix segfault in programs with finalizers compiled with --runtimebc
+
+Programs compiled with `--runtimebc` that used classes with `_final()` methods crashed with a segfault during garbage collection.
+
+```pony
+class Foo
+  fun _final() =>
+    None
+
+actor Main
+  new create(env: Env) =>
+    Foo
+```
+
+The same program ran correctly without `--runtimebc`. This has been fixed.

--- a/src/libponyrt/actor/actor.c
+++ b/src/libponyrt/actor/actor.c
@@ -1217,7 +1217,7 @@ PONY_API void* pony_alloc_final(pony_ctx_t* ctx, size_t size)
     TRACK_ALL_FINALISERS);
 }
 
-void* pony_alloc_small_final(pony_ctx_t* ctx, uint32_t sizeclass)
+PONY_API void* pony_alloc_small_final(pony_ctx_t* ctx, uint32_t sizeclass)
 {
   pony_assert(ctx->current != NULL);
   DTRACE3(HEAP_ALLOC, (uintptr_t)ctx->scheduler, (uintptr_t)ctx->current, HEAP_MIN << sizeclass);
@@ -1226,7 +1226,7 @@ void* pony_alloc_small_final(pony_ctx_t* ctx, uint32_t sizeclass)
     sizeclass, TRACK_ALL_FINALISERS);
 }
 
-void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size)
+PONY_API void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size)
 {
   pony_assert(ctx->current != NULL);
   DTRACE3(HEAP_ALLOC, (uintptr_t)ctx->scheduler, (uintptr_t)ctx->current, size);

--- a/src/libponyrt/pony.h
+++ b/src/libponyrt/pony.h
@@ -209,15 +209,19 @@ PONY_API ATTRIBUTE_MALLOC void* pony_realloc(pony_ctx_t* ctx, void* p, size_t si
  *
  * Attach a finaliser that will be run on memory when it is collected. Such
  * memory cannot be safely realloc'd.
+ *
+ * _final allocators must not have ATTRIBUTE_MALLOC: the GC reads the type
+ * descriptor through the heap chunk pointer, not the returned pointer, so
+ * noalias lets LLVM eliminate the descriptor store under --runtimebc LTO.
  */
-PONY_API ATTRIBUTE_MALLOC void* pony_alloc_final(pony_ctx_t* ctx, size_t size);
+PONY_API void* pony_alloc_final(pony_ctx_t* ctx, size_t size);
 
 /// Allocate using a HEAP_INDEX instead of a size in bytes.
-PONY_API ATTRIBUTE_MALLOC void* pony_alloc_small_final(pony_ctx_t* ctx,
+PONY_API void* pony_alloc_small_final(pony_ctx_t* ctx,
   uint32_t sizeclass);
 
 /// Allocate when we know it's larger than HEAP_MAX.
-PONY_API ATTRIBUTE_MALLOC void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size);
+PONY_API void* pony_alloc_large_final(pony_ctx_t* ctx, size_t size);
 
 /// Trigger GC next time the current actor is scheduled
 PONY_API void pony_triggergc(pony_ctx_t* ctx);


### PR DESCRIPTION
`ATTRIBUTE_MALLOC` on the `_final` allocation functions (`pony_alloc_final`, `pony_alloc_small_final`, `pony_alloc_large_final`) put `noalias` on the return pointer in the runtime bitcode. The compiler's codegen deliberately omits `noalias` from these functions because the GC reads the type descriptor through the heap chunk pointer, not through the returned pointer. With `--runtimebc`, the runtime bitcode's `noalias` overwrote the compiler's omission during LTO merge, enabling LLVM's dead-store elimination to remove the type descriptor store. At GC finalization the NULL descriptor dereference segfaulted.

Removes `ATTRIBUTE_MALLOC` from the three `_final` declarations in `pony.h`. Also adds missing `PONY_API` to the definitions of `pony_alloc_small_final` and `pony_alloc_large_final` in `actor.c`, and adds a finalizer class to the runtimebc smoke test.
