### PR TITLE
Fix PonyCheck collection generators when min > max

### DIFF
--- a/.release-notes/fix-ponycheck-min-max.md
+++ b/.release-notes/fix-ponycheck-min-max.md
@@ -1,0 +1,3 @@
+## Fix PonyCheck collection generators when min > max
+
+PonyCheck's collection and string generators silently produced wrong-sized output when `min` was greater than `max`. Passing `min = 10, max = 5` generated collections from an arbitrarily large range instead of producing collections with 5 to 10 elements. Inverted arguments now produce the same result as the correctly ordered equivalent.

--- a/packages/pony_check/_random_case.pony
+++ b/packages/pony_check/_random_case.pony
@@ -13,6 +13,7 @@ actor \nodoc\ Main is TestList
   fun tag tests(test: PonyTest) =>
     test(_ASCIIRangeTest)
     test(_ASCIIStringShrinkTest)
+    test(_ByteStringInvertedMinMaxTest)
     test(_ErroringPropertyTest)
     test(_FailingPropertyTest)
     test(_FilterMapShrinkTest)
@@ -27,14 +28,17 @@ actor \nodoc\ Main is TestList
     test(_GenOneOfTest)
     test(_GenRndTest)
     test(_GenUnionTest)
+    test(_IsoSeqOfInvertedMinMaxTest)
     test(_IsoSeqOfTest)
     test(_MapIsOfEmptyTest)
     test(_MapIsOfIdentityTest)
+    test(_MapIsOfInvertedMinMaxTest)
     test(_MapIsOfMaxTest)
     test(_MapIsOfMinShrinkTest)
     test(_MapIsOfMinTest)
     test(_MapOfEmptyTest)
     test(_MapOfIdentityTest)
+    test(_MapOfInvertedMinMaxTest)
     test(_MapOfMaxTest)
     test(_MapOfMinShrinkTest)
     test(_MapOfMinTest)
@@ -77,11 +81,14 @@ actor \nodoc\ Main is TestList
     test(_RunnerInfiniteShrinkTest)
     test(_RunnerReportFailedSampleTest)
     test(_RunnerSometimesErroringGeneratorTest)
+    test(_SeqOfInvertedMinMaxTest)
     test(_SeqOfTest)
     test(_SetIsOfIdentityTest)
+    test(_SetIsOfInvertedMinMaxTest)
     test(_SetIsOfMinShrinkTest)
     test(_SetIsOfMinTest)
     test(_SetOfEmptyTest)
+    test(_SetOfInvertedMinMaxTest)
     test(_SetOfMaxTest)
     test(_SetOfMinMaxEqualTest)
     test(_SetOfMinShrinkTest)
@@ -103,6 +110,7 @@ actor \nodoc\ Main is TestList
     test(_SuccessfulProperty4Test)
     test(_UnicodeStringShrinkTest)
     test(_UnsignedShrinkTest)
+    test(_Utf32CodePointStringInvertedMinMaxTest)
     test(_UTF32CodePointStringTest)
 
 class \nodoc\ iso _StringifyTest is UnitTest
@@ -1031,6 +1039,165 @@ class \nodoc\ iso _SetOfMinMaxEqualTest is UnitTest
     else
       h.fail("set_of did not produce shrinks")
     end
+
+class \nodoc\ iso _SeqOfInvertedMinMaxTest is UnitTest
+  fun name(): String => "Gen/seq_of_inverted_min_max"
+
+  fun apply(h: TestHelper) ? =>
+    let seq_gen =
+      Generators.seq_of[U8, Array[U8]](
+        Generators.u8()
+        where min = 10, max = 5)
+    let rnd = Randomness(Time.millis())
+    h.assert_true(
+      Iter[Array[U8]^](seq_gen.value_iter(rnd))
+        .take(100)
+        .all(
+          {(a: Array[U8]): Bool =>
+            (a.size() >= 5) and (a.size() <= 10)
+          }),
+      "seq_of with inverted min/max produced out-of-bounds sizes")
+
+    match seq_gen.generate(rnd)?
+    | (let sample: Array[U8], let shrinks: Iterator[Array[U8]^]) =>
+      h.assert_true(
+        Iter[Array[U8]^](shrinks)
+          .all({(a: Array[U8]): Bool => a.size() >= 5 }),
+        "shrinking of seq_of with inverted min/max went below lower bound")
+    else
+      h.fail("seq_of with inverted min/max did not produce shrinks")
+    end
+
+class \nodoc\ iso _IsoSeqOfInvertedMinMaxTest is UnitTest
+  fun name(): String => "Gen/iso_seq_of_inverted_min_max"
+
+  fun apply(h: TestHelper) =>
+    let seq_gen =
+      Generators.iso_seq_of[String, Array[String] iso](
+        Generators.ascii()
+        where min = 10, max = 5)
+    let rnd = Randomness(Time.millis())
+    h.assert_true(
+      Iter[Array[String] iso^](seq_gen.value_iter(rnd))
+        .take(100)
+        .all(
+          {(a: Array[String] iso): Bool =>
+            (a.size() >= 5) and (a.size() <= 10)
+          }),
+      "iso_seq_of with inverted min/max produced out-of-bounds sizes")
+
+class \nodoc\ iso _SetOfInvertedMinMaxTest is UnitTest
+  fun name(): String => "Gen/set_of_inverted_min_max"
+
+  fun apply(h: TestHelper) ? =>
+    let set_gen =
+      Generators.set_of[U8](
+        Generators.u8()
+        where min = 10, max = 5)
+    let rnd = Randomness(Time.millis())
+    for i in Range(0, 100) do
+      let sample: Set[U8] = set_gen.generate_value(rnd)?
+      h.assert_true(
+        sample.size() <= 10,
+        "set_of with inverted min/max produced too large a set")
+    end
+
+class \nodoc\ iso _MapOfInvertedMinMaxTest is UnitTest
+  fun name(): String => "Gen/map_of_inverted_min_max"
+
+  fun apply(h: TestHelper) ? =>
+    let map_gen =
+      Generators.map_of[String, I64](
+        Generators.zip2[String, I64](
+          Generators.u8().map[String](
+            {(u: U8): String^ =>
+              let s = u.string()
+              consume s
+            }),
+          Generators.i64())
+        where min = 10, max = 5)
+    let rnd = Randomness(Time.millis())
+    for i in Range(0, 100) do
+      let sample: Map[String, I64] = map_gen.generate_value(rnd)?
+      h.assert_true(
+        sample.size() <= 10,
+        "map_of with inverted min/max produced too large a map")
+    end
+
+class \nodoc\ iso _SetIsOfInvertedMinMaxTest is UnitTest
+  fun name(): String => "Gen/set_is_of_inverted_min_max"
+
+  fun apply(h: TestHelper) ? =>
+    let set_gen =
+      Generators.set_is_of[String](
+        Generators.ascii()
+        where min = 10, max = 5)
+    let rnd = Randomness(Time.millis())
+    for i in Range(0, 100) do
+      let sample: SetIs[String] = set_gen.generate_value(rnd)?
+      h.assert_true(
+        sample.size() <= 10,
+        "set_is_of with inverted min/max produced too large a set")
+    end
+
+class \nodoc\ iso _MapIsOfInvertedMinMaxTest is UnitTest
+  fun name(): String => "Gen/map_is_of_inverted_min_max"
+
+  fun apply(h: TestHelper) ? =>
+    let map_gen =
+      Generators.map_is_of[String, I64](
+        Generators.zip2[String, I64](
+          Generators.u8().map[String](
+            {(u: U8): String^ =>
+              let s = u.string()
+              consume s
+            }),
+          Generators.i64())
+        where min = 10, max = 5)
+    let rnd = Randomness(Time.millis())
+    for i in Range(0, 100) do
+      let sample: MapIs[String, I64] = map_gen.generate_value(rnd)?
+      h.assert_true(
+        sample.size() <= 10,
+        "map_is_of with inverted min/max produced too large a map")
+    end
+
+class \nodoc\ iso _Utf32CodePointStringInvertedMinMaxTest is UnitTest
+  fun name(): String => "Gen/utf32_codepoint_string_inverted_min_max"
+
+  fun apply(h: TestHelper) =>
+    let str_gen =
+      Generators.utf32_codepoint_string(
+        Generators.u32()
+        where min = 10, max = 5)
+    let rnd = Randomness(Time.millis())
+    h.assert_true(
+      Iter[String^](str_gen.value_iter(rnd))
+        .take(100)
+        .all(
+          {(s: String): Bool =>
+            (s.codepoints() >= 5) and (s.codepoints() <= 10)
+          }),
+      "utf32_codepoint_string with inverted min/max produced out-of-bounds"
+      + " lengths")
+
+class \nodoc\ iso _ByteStringInvertedMinMaxTest is UnitTest
+  fun name(): String => "Gen/byte_string_inverted_min_max"
+
+  fun apply(h: TestHelper) =>
+    let str_gen =
+      Generators.byte_string(
+        Generators.u8()
+        where min = 10, max = 5)
+    let rnd = Randomness(Time.millis())
+    h.assert_true(
+      Iter[String^](str_gen.value_iter(rnd))
+        .take(100)
+        .all(
+          {(s: String): Bool =>
+            (s.size() >= 5) and (s.size() <= 10)
+          }),
+      "byte_string with inverted min/max produced out-of-bounds lengths")
 
 class \nodoc\ iso _ASCIIRangeTest is UnitTest
   fun name(): String => "Gen/ascii_range"

--- a/packages/pony_check/gen_obj.pony
+++ b/packages/pony_check/gen_obj.pony
@@ -379,24 +379,25 @@ primitive Generators
     minimum and maximum size.
 
     Defaults are 0 and 100, respectively.
+
+    If `min > max`, the values are swapped.
     """
+    let lo = min.min(max)
+    let hi = min.max(max)
 
     Generator[S](
       object is GenObj[S]
         let _gen: GenObj[T] = gen
         fun generate(rnd: Randomness): GenerateResult[S] =>
-          let size = rnd.usize(min, max)
+          let size = rnd.usize(lo, hi)
 
           let result: S =
             Iter[T^](_gen.value_iter(rnd))
               .take(size)
               .collect[S](S.create(size))
 
-          // create shrink_iter with smaller seqs and elements
-          // generated from _gen.value_iter
           let shrink_iter =
-            Iter[USize](CountdownIter(size, min)) // Range(size, min, -1))
-              // .skip(1)
+            Iter[USize](CountdownIter(size, lo))
               .map_stateful[S^]({
                 (s: USize): S^ =>
                   Iter[T^](_gen.value_iter(rnd))
@@ -420,12 +421,17 @@ primitive Generators
     there is no other way to populate the iso seq if the elements might be
     non-sendable (i.e. ref), as then the seq would leak references via
     its elements.
+
+    If `min > max`, the values are swapped.
     """
+    let lo = min.min(max)
+    let hi = min.max(max)
+
     Generator[S](
       object is GenObj[S]
         let _gen: GenObj[T] = gen
         fun generate(rnd: Randomness): GenerateResult[S] =>
-          let size = rnd.usize(min, max)
+          let size = rnd.usize(lo, hi)
 
           let result: S = recover iso S.create(size) end
           let iter = _gen.value_iter(rnd)
@@ -437,11 +443,8 @@ primitive Generators
             result.push(consume elem)
             i = i + 1
           end
-          // create shrink_iter with smaller seqs and elements
-          // generated from _gen.value_iter
           let shrink_iter =
-            Iter[USize](CountdownIter(size, min)) // Range(size, min, -1))
-              // .skip(1)
+            Iter[USize](CountdownIter(size, lo))
               .map_stateful[S^]({
                 (s: USize): S^ =>
                   let res = recover iso S.create(s) end
@@ -523,19 +526,24 @@ primitive Generators
     when the source generator `gen` produces duplicates.
     E.g. if the given generator is for `U8` values and `max` is set to 1024,
     the set will only ever be of size 256.
+
+    If `min > max`, the values are swapped.
     """
+    let lo = min.min(max)
+    let hi = min.max(max)
+
     Generator[Set[T]](
       object is GenObj[Set[T]]
         let _gen: GenObj[T] = gen
         fun generate(rnd: Randomness): GenerateResult[Set[T]] =>
-          let size = rnd.usize(min, max)
+          let size = rnd.usize(lo, hi)
           let result: Set[T] =
             Set[T].create(size) .> union(
               Iter[T^](_gen.value_iter(rnd))
               .take(size)
             )
           let shrink_iter: Iterator[Set[T]^] =
-            Iter[USize](CountdownIter(size, min))
+            Iter[USize](CountdownIter(size, lo))
               .map_stateful[Set[T]^]({
                 (s: USize): Set[T]^ =>
                   Set[T].create(s) .> union(
@@ -562,11 +570,16 @@ primitive Generators
     when the source generator `gen` produces duplicates.
     E.g. if the given generator is for `U8` values and `max` is set to 1024,
     the set will only ever be of size 256.
+
+    If `min > max`, the values are swapped.
     """
+    let lo = min.min(max)
+    let hi = min.max(max)
+
     Generator[SetIs[T]](
       object is GenObj[SetIs[T]]
         fun generate(rnd: Randomness): GenerateResult[SetIs[T]] =>
-          let size = rnd.usize(min, max)
+          let size = rnd.usize(lo, hi)
 
           let result: SetIs[T] =
             SetIs[T].create(size) .> union(
@@ -574,7 +587,7 @@ primitive Generators
                 .take(size)
             )
           let shrink_iter: Iterator[SetIs[T]^] =
-            Iter[USize](CountdownIter(size, min))
+            Iter[USize](CountdownIter(size, lo))
               .map_stateful[SetIs[T]^]({
                 (s: USize): SetIs[T]^ =>
                   SetIs[T].create(s) .> union(
@@ -599,11 +612,16 @@ primitive Generators
     The generated maps can have fewer entries than `min`
     when the source generator `gen` produces duplicate keys.
     Duplicate keys (based on structural equality) overwrite earlier entries.
+
+    If `min > max`, the values are swapped.
     """
+    let lo = min.min(max)
+    let hi = min.max(max)
+
     Generator[Map[K, V]](
       object is GenObj[Map[K, V]]
         fun generate(rnd: Randomness): GenerateResult[Map[K, V]] =>
-          let size = rnd.usize(min, max)
+          let size = rnd.usize(lo, hi)
 
           let result: Map[K, V] =
             Map[K, V].create(size) .> concat(
@@ -611,7 +629,7 @@ primitive Generators
                 .take(size)
             )
           let shrink_iter: Iterator[Map[K, V]^] =
-            Iter[USize](CountdownIter(size, min))
+            Iter[USize](CountdownIter(size, lo))
               .map_stateful[Map[K, V]^]({
                 (s: USize): Map[K, V]^ =>
                   Map[K, V].create(s) .> concat(
@@ -636,11 +654,16 @@ primitive Generators
     The generated maps can have fewer entries than `min`
     when the source generator `gen` produces duplicate keys.
     Duplicate keys (based on identity) overwrite earlier entries.
+
+    If `min > max`, the values are swapped.
     """
+    let lo = min.min(max)
+    let hi = min.max(max)
+
     Generator[MapIs[K, V]](
       object is GenObj[MapIs[K, V]]
         fun generate(rnd: Randomness): GenerateResult[MapIs[K, V]] =>
-          let size = rnd.usize(min, max)
+          let size = rnd.usize(lo, hi)
 
           let result: MapIs[K, V] =
             MapIs[K, V].create(size) .> concat(
@@ -648,7 +671,7 @@ primitive Generators
                 .take(size)
             )
           let shrink_iter: Iterator[MapIs[K, V]^] =
-            Iter[USize](CountdownIter(size, min))
+            Iter[USize](CountdownIter(size, lo))
               .map_stateful[MapIs[K, V]^]({
                 (s: USize): MapIs[K, V]^ =>
                   MapIs[K, V].create(s) .> concat(
@@ -1253,11 +1276,16 @@ primitive Generators
     generated from the bytes returned by the generator `gen`,
     with a minimum length of `min` (default: 0)
     and a maximum length of `max` (default: 100).
+
+    If `min > max`, the values are swapped.
     """
+    let lo = min.min(max)
+    let hi = min.max(max)
+
     Generator[String](
       object is GenObj[String]
         fun generate(rnd: Randomness): GenerateResult[String] =>
-          let size = rnd.usize(min, max)
+          let size = rnd.usize(lo, hi)
           let gen_iter = Iter[U8^](gen.value_iter(rnd))
             .take(size)
           let arr: Array[U8] iso = recover Array[U8](size) end
@@ -1267,19 +1295,16 @@ primitive Generators
           String.from_iso_array(consume arr)
 
         fun shrink(s: String): ValueAndShrink[String] =>
-          """
-          shrink string until `min` length.
-          """
           var str: String = s.trim(0, s.size() - 1)
           let shorten_iter: Iterator[String^] =
             object is Iterator[String^]
-              fun ref has_next(): Bool => str.size() > min
+              fun ref has_next(): Bool => str.size() > lo
               fun ref next(): String^ =>
                 str = str.trim(0, str.size() - 1)
             end
           let min_iter =
-            if s.size() > min then
-              Poperator[String]([s.trim(0, min)])
+            if s.size() > lo then
+              Poperator[String]([s.trim(0, lo)])
             else
               Poperator[String].empty()
             end
@@ -1365,15 +1390,19 @@ primitive Generators
 
     Note that the byte length of the generated string can be up to 4 times
     the size in code points.
+
+    If `min > max`, the values are swapped.
     """
+    let lo = min.min(max)
+    let hi = min.max(max)
+
     Generator[String](
       object is GenObj[String]
         fun generate(rnd: Randomness): GenerateResult[String] =>
-          let size = rnd.usize(min, max)
+          let size = rnd.usize(lo, hi)
           let gen_iter = Iter[U32^](gen.value_iter(rnd))
             .filter(
               {(cp) =>
-                // excluding surrogate pairs
                 (cp <= 0xD7FF) or (cp >= 0xE000)
               })
             .take(size)
@@ -1384,16 +1413,11 @@ primitive Generators
           s
 
         fun shrink(s: String): ValueAndShrink[String] =>
-          """
-          Strip off codepoints from the end, not just bytes, so we
-          maintain a valid utf8 string.
-
-          Only shrink until given `min` is hit.
-          """
+          // Strips codepoints, not bytes, to keep the string valid UTF-8.
           var shrink_base = s
           let s_len = s.codepoints()
           let shrink_iter: Iterator[String^] =
-            if s_len > min then
+            if s_len > lo then
               Iter[String^].repeat_value(consume shrink_base)
                 .map_stateful[String^](
                   object
@@ -1401,9 +1425,7 @@ primitive Generators
                     fun ref apply(str: String): String =>
                       Generators._trim_codepoints(str, len = len - 1)
                   end
-                ).take(s_len - min)
-                // take_while is buggy in pony < 0.21.0
-                // .take_while({(t) => t.codepoints() > min})
+                ).take(s_len - lo)
             else
               Poperator[String].empty()
             end


### PR DESCRIPTION
PonyCheck's collection and string generators silently produced wrong-sized output when `min` was greater than `max`. The unsigned subtraction in `Randomness.usize` wrapped around, producing a collection size from a huge range instead of the intended one.

Each factory function now normalizes with `let lo = min.min(max)` / `let hi = min.max(max)` before using the bounds. Affects `seq_of`, `iso_seq_of`, `set_of`, `set_is_of`, `map_of`, `map_is_of`, `byte_string`, and `utf32_codepoint_string` (plus their wrappers).

Closes #5976
