### PR TITLE
Fix lambda parameter type inference regression

### DIFF
--- a/.release-notes/fix-lambda-param-inference.md
+++ b/.release-notes/fix-lambda-param-inference.md
@@ -1,0 +1,3 @@
+## Fix lambda parameter type inference regression
+
+Lambda parameters that relied on type inference from the calling context stopped compiling after the addition of generic type argument inference. Code like `m.upsert("key", 1, {(old, cur) => old + cur })` produced "a lambda parameter must specify a type or be inferable from context" where it previously compiled without error. Lambda parameter types are once again inferred from the expected function type at the call site.

--- a/src/libponyc/expr/call.c
+++ b/src/libponyc/expr/call.c
@@ -1464,6 +1464,11 @@ static ast_result_t constructor_path_infer(pass_opt_t* opt, ast_t* ast,
   if(!normalise_args(opt, params, positional, namedargs))
     return AST_ERROR;
 
+  // Visit arguments early. Skip arguments that contain dependent
+  // expressions without explicit types (untyped lambdas, untyped arrays)
+  // at positions whose parameter type mentions a type parameter — they
+  // will be typed by the normal post-order visit against the reified
+  // parameter type.
   ast_t* param = ast_child(params);
   ast_t* arg = ast_child(positional);
 
@@ -1471,10 +1476,9 @@ static ast_result_t constructor_path_infer(pass_opt_t* opt, ast_t* ast,
   {
     if(ast_id(arg) != TK_NONE)
     {
-      token_id aid = ast_id(arg);
       bool skip = false;
 
-      if(aid == TK_ARRAY || aid == TK_LAMBDA || aid == TK_BARELAMBDA)
+      if(infer_needs_antecedent_type(arg))
       {
         ast_t* p_type = ast_childidx(param, 1);
 
@@ -1596,9 +1600,11 @@ ast_result_t expr_pre_call(pass_opt_t* opt, ast_t** astp)
   if(!normalise_args(opt, params, positional, namedargs))
     return AST_ERROR;
 
-  // Visit arguments early. Skip array literals, lambdas, and bare lambdas
-  // at bindable positions — they are antecedent-dependent and will be typed
-  // by the normal post-order visit against the reified parameter type.
+  // Visit arguments early. Skip arguments that contain dependent
+  // expressions without explicit types (untyped lambdas, untyped arrays)
+  // at positions whose parameter type mentions a type parameter — they
+  // will be typed by the normal post-order visit against the reified
+  // parameter type.
   ast_t* param = ast_child(params);
   ast_t* arg = ast_child(positional);
 
@@ -1606,10 +1612,9 @@ ast_result_t expr_pre_call(pass_opt_t* opt, ast_t** astp)
   {
     if(ast_id(arg) != TK_NONE)
     {
-      token_id aid = ast_id(arg);
       bool skip = false;
 
-      if(aid == TK_ARRAY || aid == TK_LAMBDA || aid == TK_BARELAMBDA)
+      if(infer_needs_antecedent_type(arg))
       {
         ast_t* p_type = ast_childidx(param, 1);
 

--- a/src/libponyc/expr/infer.c
+++ b/src/libponyc/expr/infer.c
@@ -423,6 +423,106 @@ static bool is_antecedent_dependent(ast_t* arg)
   return subtree_has_dependent(arg, arg);
 }
 
+// True when a lambda or bare lambda has any parameter without an explicit
+// type annotation.
+static bool lambda_has_untyped_params(ast_t* node)
+{
+  // Lambda: child 3 = params, bare lambda: child 4 = params.
+  ast_t* params = (ast_id(node) == TK_LAMBDA)
+    ? ast_childidx(node, 3)
+    : ast_childidx(node, 4);
+
+  if(ast_id(params) == TK_NONE)
+    return false;
+
+  for(ast_t* p = ast_child(params); p != NULL; p = ast_sibling(p))
+  {
+    if(ast_id(ast_childidx(p, 1)) == TK_NONE)
+      return true;
+  }
+
+  return false;
+}
+
+// True when an array literal has no explicit `as` type annotation.
+static bool array_has_no_explicit_type(ast_t* node)
+{
+  return ast_id(ast_child(node)) == TK_NONE;
+}
+
+// Like subtree_has_dependent, but only matches dependent expressions that
+// lack explicit types — ones that will fail if visited before the parameter
+// type is reified. An array with `as String val` or a lambda with all typed
+// parameters can be visited early and provide evidence for inference.
+static bool subtree_needs_antecedent(ast_t* node, ast_t* argument)
+{
+  switch(ast_id(node))
+  {
+    case TK_ARRAY:
+    case TK_LAMBDA:
+    case TK_BARELAMBDA:
+    {
+      bool needs_type = false;
+
+      if(ast_id(node) == TK_ARRAY)
+        needs_type = array_has_no_explicit_type(node);
+      else
+        needs_type = lambda_has_untyped_params(node);
+
+      if(!needs_type)
+        break;
+
+      ast_t* start = node;
+
+      if(ast_id(node) == TK_ARRAY)
+      {
+        ast_t* p = ast_parent(node);
+        if(p != NULL && ast_id(p) == TK_DOT && ast_child(p) == node)
+          start = p;
+      }
+
+      ast_t* walk = start;
+      while(walk != NULL && walk != argument)
+      {
+        ast_t* break_target = NULL;
+
+        if(ast_id(walk) == TK_BREAK)
+          break_target = structural_break_target(walk, argument);
+
+        walk = antecedent_parent(walk, NULL, break_target, NULL);
+      }
+
+      return (walk == argument);
+    }
+
+    // Object literals and `as` casts always have explicit types.
+    case TK_OBJECT:
+    case TK_AS:
+      break;
+
+    default:
+      break;
+  }
+
+  if(ast_id(node) == TK_FUN || ast_id(node) == TK_BE ||
+    ast_id(node) == TK_NEW)
+    return false;
+
+  for(ast_t* child = ast_child(node); child != NULL;
+    child = ast_sibling(child))
+  {
+    if(subtree_needs_antecedent(child, argument))
+      return true;
+  }
+
+  return false;
+}
+
+bool infer_needs_antecedent_type(ast_t* arg)
+{
+  return subtree_needs_antecedent(arg, arg);
+}
+
 // Find the index of a type parameter in the list by root pointer.
 static size_t typeparam_index(ast_t* def, ast_t* typeparams)
 {

--- a/src/libponyc/expr/infer.h
+++ b/src/libponyc/expr/infer.h
@@ -32,6 +32,13 @@ bool type_mentions_typeparams(ast_t* type, ast_t* typeparams);
 // one of its members, or NULL).
 ast_t* antecedent_prune(ast_t* type, ast_t* typeparams);
 
+// True when the argument subtree contains a dependent expression that lacks
+// explicit types and will fail if visited before the parameter type is
+// reified. Unlike is_antecedent_dependent (which marks any dependent
+// expression), this returns false for arrays with an `as` type and lambdas
+// with all parameters typed.
+bool infer_needs_antecedent_type(ast_t* arg);
+
 PONY_EXTERN_C_END
 
 #endif

--- a/test/libponyc/typearg_inference.cc
+++ b/test/libponyc/typearg_inference.cc
@@ -302,6 +302,53 @@ TEST_F(TypeArgInferenceTest, PreOrder_LambdaGetsReifiedType)
   TEST_EQUIV(inferred, explicit_form);
 }
 
+TEST_F(TypeArgInferenceTest, PreOrder_LambdaUntypedParams)
+{
+  // Regression test for issue #5981: lambda parameters without explicit
+  // types should be inferred from the reified parameter type after type
+  // argument inference.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, f: {(A): A} val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1), {(x) => x})\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, f: {(A): A} val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1), {(x) => x})\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, PreOrder_LambdaInRecover)
+{
+  // Untyped lambda inside a recover block at a type-parameter-dependent
+  // position.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, f: {(A): A} val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo(U8(1), recover val {(x) => x} end)\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, f: {(A): A} val) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Bar.foo[U8](U8(1), recover val {(x) => x} end)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
 
 // --- Constructor-path inference ---
 
@@ -349,6 +396,33 @@ TEST_F(TypeArgInferenceTest, ConstructorPath_DotCreate)
     "actor Main\n"
     "  new create(env: Env) =>\n"
     "    Foo[String val].create(\"hello\")\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, ConstructorPath_LambdaUntypedParams)
+{
+  // Constructor path: lambda with untyped parameters at a position whose
+  // type mentions the class type parameter.
+  const char* inferred =
+    "class Foo[A: Any val]\n"
+    "  let _a: A\n"
+    "  let _f: {(A): A} val\n"
+    "  new create(a: A, f: {(A): A} val) => _a = a; _f = f\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo(U8(1), {(x) => x})\n";
+
+  const char* explicit_form =
+    "class Foo[A: Any val]\n"
+    "  let _a: A\n"
+    "  let _f: {(A): A} val\n"
+    "  new create(a: A, f: {(A): A} val) => _a = a; _f = f\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    Foo[U8](U8(1), {(x) => x})\n";
 
   TEST_EQUIV(inferred, explicit_form);
 }


### PR DESCRIPTION
The type argument inference added in #5974 visits non-dependent arguments early in a pre-order hook to infer type args before the normal post-order pass. The skip check that protects lambdas, bare lambdas, and array literals from premature visiting compared `ast_id(arg)` against `TK_LAMBDA`/`TK_ARRAY`/`TK_BARELAMBDA`, but `normalise_args` wraps positional arguments in `TK_SEQ` nodes, so the check never matched. Lambdas were visited against un-reified parameter types, and `antecedent_prune` stripped the parameter type to NULL, producing "a lambda parameter must specify a type or be inferable from context."

The fix adds `infer_needs_antecedent_type()`, which walks the argument subtree for dependent expressions that lack explicit types: arrays without an `as` annotation and lambdas with untyped parameters. This handles both direct lambda arguments and lambdas nested inside control-flow wrappers (`recover`, `if`, `try`) while still allowing arrays with explicit types to provide evidence for type argument inference.

Closes #5981
