### PR TITLE
Fix type argument inference for consumed arguments

### DIFF
--- a/.release-notes/fix-inference-ephemeral-caps.md
+++ b/.release-notes/fix-inference-ephemeral-caps.md
@@ -1,0 +1,16 @@
+## Fix type argument inference for consumed arguments
+
+When two arguments to a generic function gave different capabilities for the same type parameter, and one was an ephemeral subtype of the other, inference reported a conflict instead of picking the supertype. Consuming an `iso` or `trn` variable and passing it alongside a `val` argument would fail even though the consumed value can satisfy `val`.
+
+```pony
+primitive Checker
+  fun apply[S: ByteSeq val](xs: S, ys: S): Bool => true
+
+actor Main
+  new create(env: Env) =>
+    let a: Array[U8] val = [1; 2; 3]
+    let b: Array[U8] iso = recover iso [as U8: 4; 5; 6] end
+    Checker.apply(a, consume b) // previously: "conflicting types for type parameter 'S'"
+```
+
+Consumed `iso^` and `trn^` values are now treated as subtypes of `val` when resolving the type parameter, so the supertype is picked instead of raising a conflict. Writing explicit type arguments is no longer needed.

--- a/src/libponyc/expr/infer.c
+++ b/src/libponyc/expr/infer.c
@@ -469,7 +469,24 @@ static void record_direct(infer_record_t* records, ast_t* typeparams,
         rec->bound.type = ast_dup(candidate);
         rec->bound.arg = arg;
       }
-      else if(!is_subtype(candidate, rec->bound.type, NULL, opt))
+      else if(is_subtype(candidate, rec->bound.type, NULL, opt))
+      {
+        // Existing bound is the supertype already.
+      }
+      else if(is_subtype(ast_type(arg), rec->bound.type, NULL, opt))
+      {
+        // The argument's un-aliased type (e.g. iso^) is a subtype of the
+        // existing bound; the bound is the supertype.
+      }
+      else if(is_subtype(ast_type(rec->bound.arg), candidate, NULL, opt))
+      {
+        // The previous argument's un-aliased type is a subtype of the new
+        // candidate; the candidate is the supertype.
+        ast_free_unattached(rec->bound.type);
+        rec->bound.type = ast_dup(candidate);
+        rec->bound.arg = arg;
+      }
+      else
       {
         ast_t* first_arg = rec->bound.arg;
         ast_free_unattached(rec->bound.type);

--- a/test/libponyc/typearg_inference.cc
+++ b/test/libponyc/typearg_inference.cc
@@ -669,3 +669,150 @@ TEST_F(TypeArgInferenceTest, SubtypeMerge_WidensToSupertype)
 
   TEST_EQUIV(inferred, explicit_form);
 }
+
+TEST_F(TypeArgInferenceTest, EphemeralIso_MergesWithVal)
+{
+  // An iso^ argument is a subtype of val; inference should pick val.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] val = [as U8: 1]\n"
+    "    let y: Array[U8] iso = recover iso [as U8: 2] end\n"
+    "    Bar.foo(x, consume y)\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] val = [as U8: 1]\n"
+    "    let y: Array[U8] iso = recover iso [as U8: 2] end\n"
+    "    Bar.foo[Array[U8] val](x, consume y)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, EphemeralIso_ReversedOrder_MergesWithVal)
+{
+  // Same as above but with iso^ first and val second.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] iso = recover iso [as U8: 1] end\n"
+    "    let y: Array[U8] val = [as U8: 2]\n"
+    "    Bar.foo(consume x, y)\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] iso = recover iso [as U8: 1] end\n"
+    "    let y: Array[U8] val = [as U8: 2]\n"
+    "    Bar.foo[Array[U8] val](consume x, y)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, EphemeralTrn_MergesWithVal)
+{
+  // A trn^ argument is a subtype of val; inference should pick val.
+  // Non-ephemeral trn is NOT a subtype of val, so this reaches the
+  // un-aliased subtype check that the iso tests do not.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] val = [as U8: 1]\n"
+    "    let y: Array[U8] trn = recover trn [as U8: 2] end\n"
+    "    Bar.foo(x, consume y)\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] val = [as U8: 1]\n"
+    "    let y: Array[U8] trn = recover trn [as U8: 2] end\n"
+    "    Bar.foo[Array[U8] val](x, consume y)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, EphemeralTrn_ReversedOrder_MergesWithVal)
+{
+  // trn^ first, val second — reversed argument order for trn^.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] trn = recover trn [as U8: 1] end\n"
+    "    let y: Array[U8] val = [as U8: 2]\n"
+    "    Bar.foo(consume x, y)\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] trn = recover trn [as U8: 1] end\n"
+    "    let y: Array[U8] val = [as U8: 2]\n"
+    "    Bar.foo[Array[U8] val](consume x, y)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, EphemeralIso_MergesWithRef)
+{
+  // iso^ is also a subtype of ref; inference should pick ref.
+  const char* inferred =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] ref](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] ref = Array[U8]\n"
+    "    let y: Array[U8] iso = recover iso Array[U8] end\n"
+    "    Bar.foo(x, consume y)\n";
+
+  const char* explicit_form =
+    "primitive Bar\n"
+    "  fun foo[A: Array[U8] ref](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: Array[U8] ref = Array[U8]\n"
+    "    let y: Array[U8] iso = recover iso Array[U8] end\n"
+    "    Bar.foo[Array[U8] ref](x, consume y)\n";
+
+  TEST_EQUIV(inferred, explicit_form);
+}
+
+TEST_F(TypeArgInferenceTest, EphemeralIso_ConflictsWithDifferentBaseType)
+{
+  // Consumed iso with a different base type must still conflict.
+  const char* src =
+    "primitive Bar\n"
+    "  fun foo[A: Any val](a: A, b: A) => None\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let x: String iso = recover iso String end\n"
+    "    Bar.foo(U8(1), consume x)\n";
+
+  TEST_ERRORS_1(src, "conflicting types for type parameter");
+}


### PR DESCRIPTION
When two arguments to a generic function gave different capabilities for the same type parameter, and one was an ephemeral subtype of the other (e.g. `iso^` from a `consume`), inference reported a conflict instead of picking the supertype.

The aliasing step in `collect_evidence` strips the ephemeral marker, so `iso^` becomes `iso`, which is not a subtype of `val` — even though `iso^` is. This adds fallback subtype checks in `record_direct` using the un-aliased argument types when aliased comparisons fail. The aliased type is still stored as the bound; the un-aliased type is only used for the comparison.

Closes #5982
