### PR TITLE
Fix compiler crash on unresolved type names in object literal bodies

### DIFF
--- a/.release-notes/fix-crash-unresolved-nominal-in-lambda.md
+++ b/.release-notes/fix-crash-unresolved-nominal-in-lambda.md
@@ -1,0 +1,3 @@
+## Fix compiler crash on unresolved type names in object literal bodies
+
+The compiler crashed when invalid code used an undefined type name inside a lambda or object literal body and the source was split across multiple files. The same code in a single file correctly reported "can't find definition of 'X'". The compiler now reports that error in both cases.

--- a/src/libponyc/expr/reference.c
+++ b/src/libponyc/expr/reference.c
@@ -1002,7 +1002,9 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
 
   // If still nominal, check constraints.
   ast_t* def = (ast_t*)ast_data(ast);
-  pony_assert(def != NULL);
+
+  if(def == NULL)
+    return false;
 
   // Special case: don't check the constraint of a Pointer or an Array. These
   // builtin types have no contraint on their type parameter, and it is safe
@@ -1030,18 +1032,16 @@ bool expr_nominal(pass_opt_t* opt, ast_t** astp)
       case TK_NOMINAL:
       {
         ast_t* def = (ast_t*)ast_data(typearg);
-        pony_assert(def != NULL);
 
-        ok = ast_id(def) == TK_STRUCT;
+        ok = (def != NULL) && (ast_id(def) == TK_STRUCT);
         break;
       }
 
       case TK_TYPEPARAMREF:
       {
         ast_t* def = (ast_t*)ast_data(typearg);
-        pony_assert(def != NULL);
 
-        ok = def == typeparam;
+        ok = (def != NULL) && (def == typeparam);
         break;
       }
 

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -507,7 +507,7 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
       {
         ast_t* def = (ast_t*)ast_data(typearg);
 
-        if(ast_id(def) == TK_STRUCT)
+        if((def != NULL) && (ast_id(def) == TK_STRUCT))
         {
           if(report_errors)
           {

--- a/src/libponyc/type/subtype.c
+++ b/src/libponyc/type/subtype.c
@@ -779,6 +779,9 @@ static bool is_isect_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
     {
       ast_t* super_def = (ast_t*)ast_data(super);
 
+      if(super_def == NULL)
+        return false;
+
       // TODO: can satisfy the interface in aggregate
       // (T1 & T2) <: I k
       if(ast_id(super_def) == TK_INTERFACE)
@@ -1919,6 +1922,12 @@ static bool is_x_sub_x(ast_t* sub, ast_t* super, check_cap_t check_cap,
   pony_assert(sub != NULL);
   pony_assert(super != NULL);
 
+  if((ast_id(sub) == TK_NOMINAL) && (ast_data(sub) == NULL))
+    return false;
+
+  if((ast_id(super) == TK_NOMINAL) && (ast_data(super) == NULL))
+    return false;
+
   size_t my_depth = type_assume_depth(TYPE_ASSUME_SUBTYPE);
 
   // Top-level boundary: drop any cache state from a prior user-level
@@ -2363,6 +2372,9 @@ bool is_constructable(ast_t* type)
     {
       ast_t* def = (ast_t*)ast_data(type);
 
+      if(def == NULL)
+        return false;
+
       switch(ast_id(def))
       {
         case TK_INTERFACE:
@@ -2446,6 +2458,9 @@ bool is_concrete(ast_t* type)
     {
       ast_t* def = (ast_t*)ast_data(type);
 
+      if(def == NULL)
+        return false;
+
       switch(ast_id(def))
       {
         case TK_INTERFACE:
@@ -2515,6 +2530,9 @@ bool is_known(ast_t* type)
     case TK_NOMINAL:
     {
       ast_t* def = (ast_t*)ast_data(type);
+
+      if(def == NULL)
+        return false;
 
       switch(ast_id(def))
       {
@@ -2588,6 +2606,8 @@ bool is_bare(ast_t* type, pass_opt_t* opt)
     case TK_NOMINAL:
     {
       ast_t* def = (ast_t*)ast_data(type);
+      if(def == NULL)
+        return false;
       return ast_has_annotation(def, "ponyint_bare", opt->strtab);
     }
 
@@ -2648,6 +2668,9 @@ bool is_top_type(ast_t* type, bool ignore_cap, pass_opt_t* opt)
 
       // An empty interface is a top type.
       ast_t* def = (ast_t*)ast_data(type);
+
+      if(def == NULL)
+        return false;
 
       if(ast_id(def) != TK_INTERFACE)
         return false;
@@ -2744,6 +2767,8 @@ bool is_entity(ast_t* type, token_id entity)
     case TK_NOMINAL:
     {
       ast_t* def = (ast_t*)ast_data(type);
+      if(def == NULL)
+        return false;
       return ast_id(def) == entity;
     }
 

--- a/test/libponyc/badpony.cc
+++ b/test/libponyc/badpony.cc
@@ -4195,3 +4195,23 @@ TEST_F(BadPonyTest, RuntimeOverrideDefaultsDefaultedTypeParamsOnPrimitive)
   TEST_COMPILE(src);
 }
 
+TEST_F(BadPonyTest, UnresolvedTypeParamInObjectLiteralBody)
+{
+  const char* src =
+    "class HashFunction[H]\n"
+
+    "class AnyMap[K, V]\n"
+    "  fun values(): Iterator[V] =>\n"
+    "    object ref is Iterator[V]\n"
+    "      fun ref has_next(): Bool =>\n"
+    "        let x: HashFunction[box->A!] = HashFunction[box->A!]\n"
+    "        false\n"
+    "      fun ref next(): V ? => error\n"
+    "    end\n"
+
+    "actor Main\n"
+    "  new create(env: Env) => None";
+
+  TEST_ERRORS_1(src, "can't find definition of 'A'");
+}
+


### PR DESCRIPTION
Lambda and object-literal bodies skip the names pass (AST_FLAG_PRESERVE), so an undefined type name inside one leaves a TK_NOMINAL with NULL ast_data. The subtype checker and type-query functions dereference that pointer and crash. A single file produces the correct "can't find definition" error; multiple files crash with an assertion failure.

Add NULL guards at every ast_data dereference on TK_NOMINAL in the crash paths: `expr_nominal`, `check_constraints`, `is_x_sub_x`, `is_isect_sub_x`, and the standalone type predicates (`is_constructable`, `is_concrete`, `is_known`, `is_bare`, `is_top_type`, `is_entity`). An unresolved nominal conservatively returns false; the names pass catches the real error when the body is unpreserved during desugaring.

The regression test uses a single file because the test infrastructure (`package_add_magic_src`) doesn't support multi-file packages. The test exercises the names pass error path and verifies the compiler produces an error message instead of crashing.

Closes #3529
