### PR TITLE
Fix type argument constraint check rejecting capability subtypes

### DIFF
--- a/.release-notes/fix-typearg-cap-subtype-constraint.md
+++ b/.release-notes/fix-typearg-cap-subtype-constraint.md
@@ -1,0 +1,16 @@
+## Fix type argument constraint check rejecting capability subtypes
+
+A type argument whose capability was a subtype of the constraint's capability was incorrectly rejected. For example, `Array[U8] val` as a type argument for a `ByteSeq box` constraint produced "type argument is outside its constraint" even though `val` is a subtype of `box`.
+
+This most commonly surfaced through type argument inference when a consumed `iso` argument caused the inferred type to use `val` instead of the constraint's `box`.
+
+```pony
+primitive Checker
+  fun apply[S: ByteSeq box = ByteSeq box](xs: S, ys: S): Bool => true
+
+actor Main
+  new create(env: Env) =>
+    let a: Array[U8] val = [as U8: 1; 2; 3]
+    var b: Array[U8] iso = recover iso [as U8: 4; 5; 6] end
+    Checker(a, consume b) // previously: "type argument is outside its constraint"
+```

--- a/src/libponyc/type/reify.c
+++ b/src/libponyc/type/reify.c
@@ -572,12 +572,18 @@ bool check_constraints(ast_t* orig, ast_t* typeparams, ast_t* typeargs,
       true);
 
     // A bound type must be a subtype of the constraint.
-    errorframe_t info = NULL;
-    errorframe_t* infop = (report_errors ? &info : NULL);
-    if(!is_subtype_constraint(typearg, r_constraint, infop, opt))
+    // The constraint check handles generic cap sets correctly
+    // (val is a member of #read = {ref, val, box}), and the subtype check
+    // handles concrete caps correctly (val <: box).
+    // A type argument is valid if either check passes.
+    if(!is_subtype_constraint(typearg, r_constraint, NULL, opt) &&
+      !is_subtype(typearg, r_constraint, NULL, opt))
     {
       if(report_errors)
       {
+        errorframe_t info = NULL;
+        is_subtype_constraint(typearg, r_constraint, &info, opt);
+
         errorframe_t frame = NULL;
         ast_error_frame(&frame, orig,
           "type argument is outside its constraint");

--- a/test/libponyc/type_params.cc
+++ b/test/libponyc/type_params.cc
@@ -739,3 +739,94 @@ TEST_F(TypeParamsTest, ConstrainedByTypeParam_SelfReferentialStillWorks)
 
   TEST_COMPILE(src);
 }
+
+TEST_F(TypeParamsTest, ValSatisfiesBoxConstraint)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: Array[U8] val = [as U8: 1]\n"
+    "    foo[Array[U8] val](a)\n"
+
+    "  fun foo[A: Array[U8] box](x: A) => None";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(TypeParamsTest, RefSatisfiesBoxConstraint)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: Array[U8] ref = Array[U8]\n"
+    "    foo[Array[U8] ref](a)\n"
+
+    "  fun foo[A: Array[U8] box](x: A) => None";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(TypeParamsTest, TrnSatisfiesBoxConstraint)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: Array[U8] trn = recover trn Array[U8] end\n"
+    "    foo[Array[U8] trn](consume a)\n"
+
+    "  fun foo[A: Array[U8] box](x: A) => None";
+
+  TEST_COMPILE(src);
+}
+
+TEST_F(TypeParamsTest, IsoDoesNotSatisfyBoxConstraint)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: Array[U8] iso = recover iso Array[U8] end\n"
+    "    foo[Array[U8] iso](consume a)\n"
+
+    "  fun foo[A: Array[U8] box](x: A) => None";
+
+  TEST_ERRORS_1(src, "type argument is outside its constraint");
+}
+
+TEST_F(TypeParamsTest, TagDoesNotSatisfyBoxConstraint)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: Array[U8] tag = recover tag Array[U8] end\n"
+    "    foo[Array[U8] tag](a)\n"
+
+    "  fun foo[A: Array[U8] box](x: A) => None";
+
+  TEST_ERRORS_1(src, "type argument is outside its constraint");
+}
+
+TEST_F(TypeParamsTest, ValDoesNotSatisfyRefConstraint)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: Array[U8] val = [as U8: 1]\n"
+    "    foo[Array[U8] val](a)\n"
+
+    "  fun foo[A: Array[U8] ref](x: A) => None";
+
+  TEST_ERRORS_1(src, "type argument is outside its constraint");
+}
+
+TEST_F(TypeParamsTest, RefDoesNotSatisfyValConstraint)
+{
+  const char* src =
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let a: Array[U8] ref = Array[U8]\n"
+    "    foo[Array[U8] ref](a)\n"
+
+    "  fun foo[A: Array[U8] val](x: A) => None";
+
+  TEST_ERRORS_1(src, "type argument is outside its constraint");
+}

--- a/test/libponyc/typearg_inference.cc
+++ b/test/libponyc/typearg_inference.cc
@@ -890,3 +890,23 @@ TEST_F(TypeArgInferenceTest, EphemeralIso_ConflictsWithDifferentBaseType)
 
   TEST_ERRORS_1(src, "conflicting types for type parameter");
 }
+
+TEST_F(TypeArgInferenceTest, ConsumedIso_SatisfiesBoxConstraintInUnion)
+{
+  // A consumed iso argument alongside a val argument with a union box
+  // constraint. The inferred type (Array[U8] val) must satisfy the box
+  // constraint even though val != box.
+  const char* src =
+    "type BS is (String | Array[U8] val)\n"
+
+    "primitive Checker\n"
+    "  fun apply[S: BS box = BS box](xs: S, ys: S): Bool => true\n"
+
+    "actor Main\n"
+    "  new create(env: Env) =>\n"
+    "    let expected: Array[U8] val = [as U8: 1; 2; 3]\n"
+    "    var received: Array[U8] iso = recover iso [as U8: 4; 5; 6] end\n"
+    "    Checker(expected, consume received)\n";
+
+  TEST_COMPILE(src);
+}


### PR DESCRIPTION
`check_constraints` in `reify.c` used `is_subtype_constraint` exclusively to validate type arguments against their constraints. That function requires exact capability match for concrete caps (`val == box` → false), so type arguments whose capability is a proper subtype of the constraint's capability were rejected.

This surfaced through type argument inference (PR #5974): when a consumed `iso` argument aliased to `val`, inference chose `Array[U8] val` instead of the default `ByteSeq box`, and the constraint check rejected it.

The constraint check handles generic cap sets correctly (val is a member of `#read = {ref, val, box}`), and the subtype check handles concrete caps correctly (`val <: box`). The fix tries both: a type argument is valid if either check passes.
