### PR TITLE
Make terminal raw mode opt-in and auth-gated

### DIFF
--- a/.release-notes/terminal-raw-mode-opt-in.md
+++ b/.release-notes/terminal-raw-mode-opt-in.md
@@ -1,0 +1,41 @@
+## Make terminal raw mode opt-in and auth-gated
+
+The runtime no longer puts stdin into pseudo-raw mode at startup. Programs that read from `env.input` without using `ANSITerm` now get normal cooked-mode input: echoed, line-buffered, with Ctrl-D interpreted as EOF.
+
+`ANSITerm` now requires a `TerminalAuth` (derived from `AmbientAuth`) and sets raw mode itself on construction. It also restores the original terminal mode on dispose and re-applies raw mode after a suspend/resume (SIGCONT).
+
+Before:
+
+```pony
+use "signals"
+use "term"
+
+actor Main
+  new create(env: Env) =>
+    let term = ANSITerm(SignalAuth(env.root), notify, env.input)
+```
+
+After:
+
+```pony
+use "signals"
+use "term"
+
+actor Main
+  new create(env: Env) =>
+    let term = ANSITerm(
+      SignalAuth(env.root), TerminalAuth(env.root), notify, env.input)
+```
+
+For programs that need raw mode without `ANSITerm`, use `TerminalMode` directly:
+
+```pony
+use "term"
+
+actor Main
+  new create(env: Env) =>
+    let auth = TerminalAuth(env.root)
+    TerminalMode.set_raw(auth)
+    // ... read raw input ...
+    TerminalMode.restore(auth)
+```

--- a/examples/readline/main.pony
+++ b/examples/readline/main.pony
@@ -52,6 +52,7 @@ actor Main
     let term =
       ANSITerm(
         SignalAuth(env.root),
+        TerminalAuth(env.root),
         Readline(recover Handler end, env.out),
         env.input)
     term.prompt("0 > ")

--- a/packages/term/_test.pony
+++ b/packages/term/_test.pony
@@ -242,7 +242,11 @@ class \nodoc\ iso _TestANSITermCSINavigation is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -265,7 +269,11 @@ class \nodoc\ iso _TestANSITermPassthrough is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -288,7 +296,11 @@ class \nodoc\ iso _TestANSITermSS3Navigation is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -311,7 +323,11 @@ class \nodoc\ iso _TestANSITermKeypad is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -336,7 +352,11 @@ class \nodoc\ iso _TestANSITermFunctionKeys is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -366,7 +386,11 @@ class \nodoc\ iso _TestANSITermModifiers is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -386,7 +410,11 @@ class \nodoc\ iso _TestANSITermAltWord is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -414,7 +442,11 @@ class \nodoc\ iso _TestANSITermUnrecognizedEscape is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -436,7 +468,11 @@ class \nodoc\ iso _TestANSITermUnknownKeypad is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -458,7 +494,11 @@ class \nodoc\ iso _TestANSITermParamOverflow is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -480,7 +520,11 @@ class \nodoc\ iso _TestANSITermPrivateParam is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -507,7 +551,11 @@ class \nodoc\ iso _TestANSITermControlAbort is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -527,7 +575,11 @@ class \nodoc\ iso _TestANSITermTimeoutFlush is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -554,7 +606,11 @@ class \nodoc\ iso _TestANSITermStaleTimeout is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _RecordNotify(h, expected), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _RecordNotify(h, expected),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -577,7 +633,11 @@ class \nodoc\ iso _TestANSITermRealTimerFlush is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _FlushNotify(h), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _FlushNotify(h),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -594,7 +654,11 @@ class \nodoc\ iso _TestANSITermDispose is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _DisposeNotify(h), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _DisposeNotify(h),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -632,7 +696,11 @@ class \nodoc\ iso _TestANSITermPromptForward is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _PromptNotify(h, "PS> "), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _PromptNotify(h, "PS> "),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -650,7 +718,11 @@ class \nodoc\ iso _TestANSITermSize is UnitTest
     let timers = Timers
     let term =
       ANSITerm(
-        SignalAuth(h.env.root), _SizeNotify(h), _NullSource, timers)
+        SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
+        _SizeNotify(h),
+        _NullSource,
+        timers)
     h.dispose_when_done(term)
     h.dispose_when_done(timers)
     h.long_test(2_000_000_000)
@@ -786,9 +858,9 @@ class \nodoc\ iso _TestANSIColors is UnitTest
 // Readline test doubles.
 //
 // Readline can only be exercised through a real ANSITerm: its input methods
-// take an `ANSITerm ref` that exists only inside the actor. So each test builds
-// `ANSITerm(auth, Readline(notify, out, ...), source, timers)` and drives it
-// with `term.apply(bytes)`. Observation is through the injected ReadlineNotify
+// take an `ANSITerm ref` that exists only inside the actor. So each test
+// builds an ANSITerm with a Readline notifier and drives it with
+// `term.apply(bytes)`. Observation is through the injected ReadlineNotify
 // (the dispatched line) and, for the synchronous history tests, the history
 // file.
 // ---------------------------------------------------------------------------
@@ -1099,6 +1171,7 @@ class \nodoc\ iso _TestReadlineCtrlKRefresh is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_MatchNotify(h, out, 2), out),
         _NullSource,
         timers)
@@ -1126,6 +1199,7 @@ class \nodoc\ iso _TestReadlineEmptyLineCursor is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_MatchNotify(h, out, 1), out),
         _NullSource,
         timers)
@@ -1163,6 +1237,7 @@ primitive \nodoc\ _DriveReadline
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_DriverNotify(driver), _NullOut),
         _NullSource,
         timers)
@@ -1184,6 +1259,7 @@ class \nodoc\ iso _TestReadlineBlockedQueue is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_ScriptNotify(h, expected), _NullOut),
         _NullSource,
         timers)
@@ -1207,6 +1283,7 @@ class \nodoc\ iso _TestReadlineCtrlDEmptyDisposes is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_NullReadlineNotify, _NullOut),
         _DisposeProbe(h),
         timers)
@@ -1227,6 +1304,7 @@ class \nodoc\ iso _TestReadlineRejectDisposes is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_RejectNotify, _NullOut),
         _DisposeProbe(h),
         timers)
@@ -1257,6 +1335,7 @@ class \nodoc\ iso _TestReadlineHistoryNavigation is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_LineNotify(h, "beta"), _NullOut, path),
         _NullSource,
         timers)
@@ -1283,6 +1362,7 @@ class \nodoc\ iso _TestReadlineDownEmptyHistory is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_LineNotify(h, "abcd"), _NullOut),
         _NullSource,
         timers)
@@ -1312,6 +1392,7 @@ class \nodoc\ iso _TestReadlineHistoryPreservesInput is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_LineNotify(h, "wip"), _NullOut, path),
         _NullSource,
         timers)
@@ -1345,6 +1426,7 @@ class \nodoc\ iso _TestReadlineHistoryPreservesEdits is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_LineNotify(h, "second!"), _NullOut, path),
         _NullSource,
         timers)
@@ -1390,6 +1472,7 @@ class \nodoc\ iso _TestReadlineHistoryStashClearedOnDispatch is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(_DriverNotify(driver), _NullOut, path),
         _NullSource,
         timers)
@@ -1482,6 +1565,7 @@ class \nodoc\ iso _TestReadlineTabNone is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(consume notify, _NullOut),
         _NullSource,
         timers)
@@ -1503,6 +1587,7 @@ class \nodoc\ iso _TestReadlineTabSingle is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(consume notify, _NullOut),
         _NullSource,
         timers)
@@ -1524,6 +1609,7 @@ class \nodoc\ iso _TestReadlineTabCommonPrefix is UnitTest
     let term =
       ANSITerm(
         SignalAuth(h.env.root),
+        TerminalAuth(h.env.root),
         Readline(consume notify, _NullOut),
         _NullSource,
         timers)

--- a/packages/term/ansi_term.pony
+++ b/packages/term/ansi_term.pony
@@ -33,6 +33,16 @@ class _TermResizeNotify is SignalNotify
     _term.size()
     true
 
+class _TermContNotify is SignalNotify
+  let _auth: TerminalAuth
+
+  new create(auth: TerminalAuth) =>
+    _auth = auth
+
+  fun apply(times: U32): Bool =>
+    TerminalMode.set_raw(_auth)
+    true
+
 primitive _TIOCGWINSZ
   fun apply(): ULong =>
     ifdef linux then
@@ -58,29 +68,53 @@ actor ANSITerm
   embed _esc_buf: Array[U8] = Array[U8]
   var _esc_gen: USize = 0
   var _closed: Bool = false
-  let _auth: SignalAuth
+  let _signal_auth: SignalAuth
+  let _terminal_auth: TerminalAuth
   var _winch: (SignalHandler | None) = None
+  var _cont: (SignalHandler | None) = None
 
   new create(
-    auth: SignalAuth,
+    signal_auth: SignalAuth,
+    terminal_auth: TerminalAuth,
     notify: ANSINotify iso,
     source: DisposableActor,
     timers: Timers = Timers)
   =>
     """
-    Create a new ANSI term.
+    Create a new ANSI term. Puts stdin into raw mode and restores it on
+    dispose.
     """
     _timers = timers
     _notify = consume notify
     _source = source
-    _auth = auth
+    _signal_auth = signal_auth
+    _terminal_auth = terminal_auth
+
+    TerminalMode.set_raw(_terminal_auth)
 
     ifdef not windows then
       match \exhaustive\ MakeHandleableSignal(Sig.winch())
       | let sig: HandleableSignal =>
-        _winch = SignalHandler(auth, recover _TermResizeNotify(this) end, sig)
+        _winch =
+          SignalHandler(
+            signal_auth,
+            recover _TermResizeNotify(this) end,
+            sig)
       | let _: ValidationFailure =>
         // SIGWINCH is whitelisted on every platform where this branch
+        // compiles; a rejection means the whitelist regressed.
+        _Unreachable()
+      end
+
+      match \exhaustive\ MakeHandleableSignal(Sig.cont())
+      | let sig: HandleableSignal =>
+        _cont =
+          SignalHandler(
+            signal_auth,
+            recover _TermContNotify(terminal_auth) end,
+            sig)
+      | let _: ValidationFailure =>
+        // SIGCONT is whitelisted on every platform where this branch
         // compiles; a rejection means the whitelist regressed.
         _Unreachable()
       end
@@ -216,15 +250,15 @@ actor ANSITerm
   be dispose() =>
     """
     Stop accepting input, inform the notifier we have closed, dispose of our
-    source, and remove our terminal-resize handler.
+    source, restore the terminal mode, and remove our signal handlers.
     """
     if not _closed then
       _esc_clear()
       _notify.closed()
       _source.dispose()
-      // Unregister the SIGWINCH handler installed in the constructor so it
-      // stops delivering resize callbacks and frees its subscription.
-      try (_winch as SignalHandler).dispose(_auth) end
+      TerminalMode.restore(_terminal_auth)
+      try (_winch as SignalHandler).dispose(_signal_auth) end
+      try (_cont as SignalHandler).dispose(_signal_auth) end
       _closed = true
     end
 

--- a/packages/term/term.pony
+++ b/packages/term/term.pony
@@ -3,4 +3,14 @@
 
 The Term package provides support for building text-based user
 interfaces in ANSI terminals.
+
+Terminal raw mode is opt-in: programs that use `Stdin` directly get
+normal cooked-mode input. To enable raw mode for keystroke-at-a-time
+input, construct an `ANSITerm` with a `TerminalAuth` (derived from
+`AmbientAuth`). Raw mode is restored automatically after a
+suspend/resume (SIGCONT) and reverted to the original mode when the
+`ANSITerm` is disposed.
+
+For programs that need raw mode without `ANSITerm`, use
+`TerminalMode.set_raw()` and `TerminalMode.restore()` directly.
 """

--- a/packages/term/terminal_auth.pony
+++ b/packages/term/terminal_auth.pony
@@ -1,0 +1,9 @@
+primitive TerminalAuth
+  """
+  Authority to change terminal mode settings.
+
+  Derived directly from `AmbientAuth`, with no intermediate grouping
+  capability.
+  """
+  new create(from: AmbientAuth) =>
+    None

--- a/packages/term/terminal_mode.pony
+++ b/packages/term/terminal_mode.pony
@@ -1,0 +1,22 @@
+use @pony_os_tty_set_raw[Bool]()
+use @pony_os_tty_restore[None]()
+
+primitive TerminalMode
+  """
+  Controls the terminal mode for stdin.
+
+  In raw mode, input characters are delivered one at a time without echo
+  or line editing. ISIG remains on, so Ctrl-C still generates SIGINT.
+  """
+  fun set_raw(auth: TerminalAuth): Bool =>
+    """
+    Put stdin into pseudo-raw mode. Returns true if the terminal was
+    changed, false if stdin is not a terminal or the call failed.
+    """
+    @pony_os_tty_set_raw()
+
+  fun restore(auth: TerminalAuth) =>
+    """
+    Restore stdin to its original terminal mode.
+    """
+    @pony_os_tty_restore()

--- a/src/libponyrt/lang/stdfd.c
+++ b/src/libponyrt/lang/stdfd.c
@@ -28,6 +28,7 @@ PONY_API FILE* pony_os_stderr()
 
 static bool is_stdout_tty = false;
 static bool is_stderr_tty = false;
+static bool tty_raw_set = false;
 
 #ifdef PLATFORM_IS_WINDOWS
 
@@ -43,6 +44,7 @@ static bool is_stderr_tty = false;
 
 static WORD stdout_reset;
 static WORD stderr_reset;
+static DWORD orig_console_mode;
 
 static void add_modifier(char* buffer, int* len, DWORD mod)
 {
@@ -340,6 +342,7 @@ static char ansi_parse(const char* buffer, size_t* pos, size_t len,
 #else
 
 static struct termios orig_termios;
+static bool tty_atexit_registered = false;
 
 typedef enum
 {
@@ -387,16 +390,41 @@ static fd_type_t fd_type(int fd)
   return type;
 }
 
-static void stdin_tty_restore()
+static void tty_restore()
 {
   tcsetattr(0, TCSAFLUSH, &orig_termios);
 }
+#endif
 
-static void stdin_tty()
+PONY_API bool pony_os_tty_set_raw()
 {
-  // Turn off canonical mode if we're reading from a tty.
-  if(tcgetattr(STDIN_FILENO, &orig_termios) == -1)
-    return;
+#ifdef PLATFORM_IS_WINDOWS
+  HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
+  DWORD mode;
+
+  if(!GetConsoleMode(handle, &mode))
+    return false;
+
+  if(!tty_raw_set)
+  {
+    orig_console_mode = mode;
+    tty_raw_set = true;
+  }
+
+  SetConsoleMode(handle,
+    orig_console_mode & ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT));
+  return true;
+#else
+  if(fd_type(STDIN_FILENO) != FD_TYPE_TTY)
+    return false;
+
+  if(!tty_raw_set)
+  {
+    if(tcgetattr(STDIN_FILENO, &orig_termios) == -1)
+      return false;
+
+    tty_raw_set = true;
+  }
 
   struct termios io = orig_termios;
 
@@ -407,9 +435,30 @@ static void stdin_tty()
   io.c_cc[VTIME] = 0;
 
   tcsetattr(STDIN_FILENO, TCSAFLUSH, &io);
-  atexit(stdin_tty_restore);
-}
+
+  if(!tty_atexit_registered)
+  {
+    atexit(tty_restore);
+    tty_atexit_registered = true;
+  }
+
+  return true;
 #endif
+}
+
+PONY_API void pony_os_tty_restore()
+{
+#ifdef PLATFORM_IS_WINDOWS
+  if(tty_raw_set)
+  {
+    HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
+    SetConsoleMode(handle, orig_console_mode);
+  }
+#else
+  if(tty_raw_set)
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &orig_termios);
+#endif
+}
 
 PONY_API void pony_os_stdout_setup()
 {
@@ -474,25 +523,13 @@ PONY_API bool pony_os_stdin_setup()
   bool stdin_event_based = true;
   // Return true if reading stdin should be event based.
 #ifdef PLATFORM_IS_WINDOWS
-  if(ponyint_stdin_kind() == STDIN_CONSOLE)
-  {
-    HANDLE handle = GetStdHandle(STD_INPUT_HANDLE);
-    DWORD mode;
-
-    if(GetConsoleMode(handle, &mode))
-      SetConsoleMode(handle, mode & ~(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT));
-  }
-
   // A file (or NUL) returns data at once from ReadFile — there is nothing to
   // wait for — so read it in a loop. A pipe or a console needs the event.
   if(ponyint_stdin_kind() == STDIN_OTHER)
     stdin_event_based = false;
 #else
   // Skip events when stdin is a redirected file.
-  fd_type_t stdin_type = fd_type(STDIN_FILENO);
-  if((stdin_type == FD_TYPE_TTY) && is_stdout_tty)
-    stdin_tty();
-  if(stdin_type == FD_TYPE_FILE)
+  if(fd_type(STDIN_FILENO) == FD_TYPE_FILE)
     stdin_event_based = false;
 #endif
   return stdin_event_based;


### PR DESCRIPTION
The runtime no longer puts stdin into pseudo-raw mode at startup. Programs that read from `env.input` without using `ANSITerm` now get normal cooked-mode input.

`ANSITerm` now takes a `TerminalAuth` (derived from `AmbientAuth`) and sets raw mode itself. It restores the original mode on dispose and re-applies raw mode after suspend/resume (SIGCONT).

New public API:
- `TerminalAuth` — authority token for terminal mode changes
- `TerminalMode` — `set_raw(auth)` and `restore(auth)` for programs that need raw mode without `ANSITerm`

Closes #802
