### PR TITLE
Add pony-dep tool scaffolding

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -374,13 +374,15 @@ jobs:
         run: |
           cmake --preset debug
           cmake --build --preset debug
-          cmake --build --preset debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
+          cmake --build --preset debug --target pony-doc-tests pony-lint-tests pony-lsp-tests pony-dep-tests
       - name: Test pony-doc
         run: ctest --preset debug -R pony-doc-tests
       - name: Test pony-lint
         run: ctest --preset debug -R pony-lint-tests
       - name: Test pony-lsp
         run: ctest --preset debug -R pony-lsp-tests
+      - name: Test pony-dep
+        run: ctest --preset debug -R pony-dep-tests
       - name: Lint tools
         run: cd build/debug && PONYPATH=../../tools/lib/ponylang/pony_compiler ./pony-lint ../../tools/
       - name: Lint examples
@@ -413,13 +415,15 @@ jobs:
         run: |
           cmake --preset armv8-debug
           cmake --build --preset armv8-debug
-          cmake --build --preset armv8-debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
+          cmake --build --preset armv8-debug --target pony-doc-tests pony-lint-tests pony-lsp-tests pony-dep-tests
       - name: Test pony-doc
         run: ctest --preset armv8-debug -R pony-doc-tests
       - name: Test pony-lint
         run: ctest --preset armv8-debug -R pony-lint-tests
       - name: Test pony-lsp
         run: ctest --preset armv8-debug -R pony-lsp-tests
+      - name: Test pony-dep
+        run: ctest --preset armv8-debug -R pony-dep-tests
 
   tools-windows:
     needs: [changes, maybe-build-windows]
@@ -450,10 +454,12 @@ jobs:
         run: |
           cmake --preset windows-x86-64
           cmake --build --preset windows-x86-64-debug
-          cmake --build --preset windows-x86-64-debug --target pony-doc-tests pony-lint-tests pony-lsp-tests
+          cmake --build --preset windows-x86-64-debug --target pony-doc-tests pony-lint-tests pony-lsp-tests pony-dep-tests
       - name: Test pony-doc
         run: ctest --preset windows-x86-64-debug -R pony-doc-tests
       - name: Test pony-lint
         run: ctest --preset windows-x86-64-debug -R pony-lint-tests
       - name: Test pony-lsp
         run: ctest --preset windows-x86-64-debug -R pony-lsp-tests
+      - name: Test pony-dep
+        run: ctest --preset windows-x86-64-debug -R pony-dep-tests

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ packages/stdlib/stdlib
 tools/pony-lsp/version.pony
 tools/pony-lint/version.pony
 tools/pony-doc/version.pony
+tools/pony-dep/version.pony
 
 # Python bytecode
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,13 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Testing the self-hosted tools
 
-The build uses CMake presets (see BUILD.md). The self-hosted tools' test binaries — for the compiler, pony-lsp, pony-lint, and pony-doc — are **built on demand**: a normal `cmake --build` does not build them. Build the test target, then run it through ctest:
+The build uses CMake presets (see BUILD.md). The self-hosted tools' test binaries — for the compiler, pony-lsp, pony-lint, pony-doc, and pony-dep — are **built on demand**: a normal `cmake --build` does not build them. Build the test target, then run it through ctest:
 
 - `cmake --build --preset debug --target pony-compiler-tests && ctest --preset debug -R pony-compiler-tests`
 - `cmake --build --preset debug --target pony-lsp-tests && ctest --preset debug -R pony-lsp-tests`
 - `cmake --build --preset debug --target pony-lint-tests && ctest --preset debug -R pony-lint-tests`
 - `cmake --build --preset debug --target pony-doc-tests && ctest --preset debug -R pony-doc-tests`
+- `cmake --build --preset debug --target pony-dep-tests && ctest --preset debug -R pony-dep-tests`
 
 The first build of a test binary compiles from Pony source (~60s); later runs skip the rebuild when nothing under its source tree changed. On Windows, use the `windows-x86-64-debug` preset the same way.
 
@@ -39,7 +40,7 @@ To lint a tool's own source, run the `pony-lint` binary (built by a normal `cmak
 cd build/debug && PONYPATH=../../tools/lib/ponylang/pony_compiler ./pony-lint ../../tools/pony-lint/
 ```
 
-The same works for `../../tools/pony-lsp/` and `../../tools/pony-doc/`.
+The same works for `../../tools/pony-lsp/`, `../../tools/pony-doc/`, and `../../tools/pony-dep/`.
 
 ## Adding threads or locks
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -730,6 +730,7 @@ else()
     add_subdirectory(tools/pony-lsp)
     add_subdirectory(tools/pony-lint)
     add_subdirectory(tools/pony-doc)
+    add_subdirectory(tools/pony-dep)
 
     # Test binaries compiled with the just-built ponyc. Built on demand, NOT under
     # ALL: each runs ponyc to compile builtin and the stdlib packages, so building
@@ -762,11 +763,17 @@ else()
         PATHS ${CMAKE_SOURCE_DIR}/tools/lib/ponylang/pony_compiler
         WATCH ${CMAKE_SOURCE_DIR}/tools/pony-lsp)
 
+    add_pony_binary(pony-dep-tests
+        NAME pony-dep-tests
+        SOURCE ${CMAKE_SOURCE_DIR}/tools/pony-dep/test
+        WATCH ${CMAKE_SOURCE_DIR}/tools/pony-dep)
+
     # On-demand aggregate: build every self-hosted tool test in one target. Run
     # `cmake --build <dir> --target tool-tests` before `ctest -L tools`.
     add_custom_target(tool-tests)
     add_dependencies(tool-tests
-        pony-compiler-tests pony-doc-tests pony-lint-tests pony-lsp-tests)
+        pony-compiler-tests pony-doc-tests pony-lint-tests pony-lsp-tests
+        pony-dep-tests)
 
     # ctest registration. Every test binary builds under ALL, so ctest only runs
     # them. Labels group the suites: `ci-core` is the core CI suite (the old
@@ -802,6 +809,9 @@ else()
     add_test(NAME pony-lint-tests
         COMMAND ${PONY_OUTPUT_DIR}/pony-lint-tests${CMAKE_EXECUTABLE_SUFFIX} --sequential
         WORKING_DIRECTORY ${PONY_OUTPUT_DIR})
+    add_test(NAME pony-dep-tests
+        COMMAND ${PONY_OUTPUT_DIR}/pony-dep-tests${CMAKE_EXECUTABLE_SUFFIX} --sequential
+        WORKING_DIRECTORY ${PONY_OUTPUT_DIR})
     set_tests_properties(pony-lint-tests pony-doc-tests PROPERTIES
         ENVIRONMENT "PONYPATH=${CMAKE_SOURCE_DIR}/packages")
     add_test(NAME pony-compiler-tests
@@ -819,7 +829,7 @@ else()
             ENVIRONMENT "PONYPATH=${CMAKE_SOURCE_DIR}/tools/lib/ponylang/pony_compiler:${CMAKE_SOURCE_DIR}/packages")
     endif()
     set_tests_properties(pony-doc-tests pony-lsp-tests pony-lint-tests pony-compiler-tests
-        PROPERTIES LABELS tools)
+        pony-dep-tests PROPERTIES LABELS tools)
 
     # Compile-then-run ci-core tests. Each compiles Pony sources with the freshly
     # built ponyc and then runs (or diffs) the result, so they depend on ponyc
@@ -904,6 +914,7 @@ else()
         ${PONY_OUTPUT_DIR}/pony-lsp${CMAKE_EXECUTABLE_SUFFIX}
         ${PONY_OUTPUT_DIR}/pony-lint${CMAKE_EXECUTABLE_SUFFIX}
         ${PONY_OUTPUT_DIR}/pony-doc${CMAKE_EXECUTABLE_SUFFIX}
+        ${PONY_OUTPUT_DIR}/pony-dep${CMAKE_EXECUTABLE_SUFFIX}
         DESTINATION ${PONY_VERSIONED_DIR}/bin)
 
     # Runtime + compiler static libs, into the lib dir ponyc searches at run time
@@ -998,7 +1009,7 @@ else()
                 endif()
             endforeach()
             file(MAKE_DIRECTORY \"\${_prefix}/bin\" \"\${_prefix}/lib\")
-            foreach(_tool ponyc pony-lsp pony-lint pony-doc)
+            foreach(_tool ponyc pony-lsp pony-lint pony-doc pony-dep)
                 set(_t \"\${_prefix}/${PONY_VERSIONED_DIR}/bin/\${_tool}\")
                 if(EXISTS \"\${_t}\")
                     file(CREATE_LINK \"\${_t}\" \"\${_prefix}/bin/\${_tool}\" SYMBOLIC)
@@ -1012,7 +1023,7 @@ else()
             endforeach()
         ")
     elseif(PONY_INSTALL_SYMLINKS AND WIN32)
-        foreach(_tool ponyc pony-lsp pony-lint pony-doc)
+        foreach(_tool ponyc pony-lsp pony-lint pony-doc pony-dep)
             install(PROGRAMS $<TARGET_FILE:ponyc-shim>
                 DESTINATION bin RENAME ${_tool}.exe)
         endforeach()

--- a/cmake/CheckOutputLayout.cmake
+++ b/cmake/CheckOutputLayout.cmake
@@ -3,7 +3,7 @@
 # the top-level CMakeLists), so a build that writes them anywhere else installs a
 # tree with no tools. DIR is ponyc's directory; SUFFIX is the platform executable
 # suffix.
-foreach(_tool pony-lsp pony-lint pony-doc)
+foreach(_tool pony-lsp pony-lint pony-doc pony-dep)
     if(NOT EXISTS "${DIR}/${_tool}${SUFFIX}")
         message(FATAL_ERROR
             "${_tool}${SUFFIX} is not in ${DIR}, where ponyc is and install() reads it")

--- a/tools/corral.json
+++ b/tools/corral.json
@@ -6,7 +6,9 @@
     "pony-lint",
     "pony-lint/test",
     "pony-doc",
-    "pony-doc/test"
+    "pony-doc/test",
+    "pony-dep",
+    "pony-dep/test"
   ],
   "deps": [
     {

--- a/tools/pony-dep/CMakeLists.txt
+++ b/tools/pony-dep/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(tools.pony-dep)
+
+# Generate version.pony from template
+# (.gitignore prevents version.pony from dirtying the git tree)
+configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
+
+add_pony_binary(tools.pony-dep ALL
+    NAME pony-dep
+    SOURCE ${CMAKE_CURRENT_SOURCE_DIR}
+    PATHS ${CMAKE_CURRENT_SOURCE_DIR}
+    WATCH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tools/pony-dep/main.pony
+++ b/tools/pony-dep/main.pony
@@ -1,0 +1,75 @@
+use "cli"
+
+actor Main
+  """
+  CLI entry point for pony-dep. Parses command-line arguments and dispatches
+  to the requested subcommand.
+  """
+  new create(env: Env) =>
+    if _is_version_flag(env.args) then
+      env.out.print("pony-dep " + Version())
+      return
+    end
+
+    let cs =
+      try
+        CommandSpec.parent(
+          "pony-dep",
+          "A dependency manager for Pony packages",
+          [],
+          [
+            CommandSpec.leaf(
+              "pack",
+              "Create an archive from a project's source")?
+            CommandSpec.leaf(
+              "fetch",
+              "Download and extract a package archive from a URL")?
+            CommandSpec.leaf(
+              "add",
+              "Fetch a dependency, hash it, and record it")?
+            CommandSpec.leaf(
+              "remove",
+              "Remove a dependency and its placed files")?
+            CommandSpec.leaf(
+              "clean",
+              "Remove placed packages that nothing references")?
+          ])? .> add_help()?
+      else
+        env.err.print("internal error: invalid command spec")
+        env.exitcode(1)
+        return
+      end
+
+    let cmd =
+      match \exhaustive\ CommandParser(cs).parse(env.args, env.vars)
+      | let c: Command => c
+      | let ch: CommandHelp =>
+        ch.print_help(env.out)
+        return
+      | let se: SyntaxError =>
+        env.err.print(se.string())
+        env.exitcode(1)
+        return
+      end
+
+    match cmd.spec().name()
+    | "pack" => _not_implemented(env, "pack")
+    | "fetch" => _not_implemented(env, "fetch")
+    | "add" => _not_implemented(env, "add")
+    | "remove" => _not_implemented(env, "remove")
+    | "clean" => _not_implemented(env, "clean")
+    else
+      env.err.print("error: no subcommand specified")
+      env.exitcode(1)
+    end
+
+  fun _is_version_flag(args: Array[String val] val): Bool =>
+    try
+      (args(1)? == "--version") or (args(1)? == "-V")
+    else
+      false
+    end
+
+  fun _not_implemented(env: Env, name: String) =>
+    env.err.print(name + ": not yet implemented")
+    env.exitcode(1)

--- a/tools/pony-dep/pony_dep.pony
+++ b/tools/pony-dep/pony_dep.pony
@@ -1,0 +1,18 @@
+"""
+pony-dep: A dependency manager for Pony packages.
+
+Manages external dependencies by fetching, placing, and tracking package
+archives. Dependencies are recorded in a configuration file with content
+hashes so that different versions of the same package coexist without a
+solver.
+
+**Subcommands:**
+
+- `pack` — create an archive from a project's source for distribution.
+- `fetch` — download and extract a package archive from a URL.
+- `add` — fetch a dependency, compute its content hash, and record it in
+  the configuration file.
+- `remove` — remove a dependency's configuration entry and its placed files.
+- `clean` — scan source for `use "ext:..."` references and remove any placed
+  package directory that nothing references.
+"""

--- a/tools/pony-dep/test/main.pony
+++ b/tools/pony-dep/test/main.pony
@@ -1,0 +1,8 @@
+use "pony_test"
+
+actor \nodoc\ Main is TestList
+  new create(env: Env) => PonyTest(env, this)
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    None

--- a/tools/pony-dep/test/test.pony
+++ b/tools/pony-dep/test/test.pony
@@ -1,0 +1,3 @@
+"""
+Tests for pony-dep.
+"""

--- a/tools/pony-dep/version.pony.in
+++ b/tools/pony-dep/version.pony.in
@@ -1,0 +1,12 @@
+// version.pony is generated from version.pony.in by CMake's configure_file().
+// CMake variables (like PONYC_VERSION enclosed in @ symbols) are replaced
+// at configure time.
+// To modify version.pony, edit version.pony.in instead.
+
+primitive Version
+  """
+  Returns the pony-dep version string. The version matches the ponyc
+  compiler version since pony-dep is distributed with ponyc.
+  """
+  fun apply(): String =>
+    "@PONYC_VERSION@"


### PR DESCRIPTION
Stub the pony-dep CLI with five subcommands (pack, fetch, add, remove, clean), all printing "not yet implemented." Wire it into the CMake build, install, ctest, and the PR CI workflow on all three platforms.

Design: #5991
