### PR TITLE
PonyCheck: choice-sequence-based internal shrinking

### DIFF
--- a/.release-notes/ponycheck-choice-sequence-shrinking.md
+++ b/.release-notes/ponycheck-choice-sequence-shrinking.md
@@ -1,0 +1,133 @@
+## PonyCheck: choice-sequence-based internal shrinking
+
+PonyCheck's shrinking system has been replaced. Generators no longer provide shrink logic — the framework records every random draw during generation and replays mutated sequences to find smaller failing inputs. Custom generators become simpler because they only produce a value; shrinking is automatic.
+
+### Custom generators
+
+The `generate` method now returns `T^` instead of `GenerateResult[T]`. The old shrink-iterator machinery (`generate_and_shrink`, `value_iter`, `GenerateResult`, `ValueAndShrink`) is removed.
+
+Before:
+
+```pony
+object is GenObj[MyPony]
+  fun generate(rnd: Randomness): GenerateResult[MyPony] ? =>
+    (let name, let name_shrinks) =
+      name_gen.generate_and_shrink(rnd)?
+    (let score, let score_shrinks) =
+      score_gen.generate_and_shrink(rnd)?
+    let result = MyPony(consume name, consume score)
+    let shrinks =
+      Iter[String^](name_shrinks)
+        .zip2[U64^](score_shrinks)
+        .map[MyPony^]({(z) =>
+          (let n, let s) = consume z
+          MyPony(consume n, consume s)
+        })
+    (consume result, shrinks)
+end
+```
+
+After:
+
+```pony
+object is GenObj[MyPony]
+  fun generate(rnd: Randomness): MyPony^ ? =>
+    let name = name_gen.generate(rnd)?
+    let score = score_gen.generate(rnd)?
+    MyPony(consume name, consume score)
+end
+```
+
+### Randomness draw methods are now partial
+
+All draw methods on `Randomness` (`u8`, `u16`, `u32`, `u64`, `u128`, `usize`, `ulong`, `i8`, `i16`, `i32`, `i64`, `i128`, `isize`, `ilong`, `f32`, `f64`, `bool`, `shuffle`) are now partial. Add `?` to every call site:
+
+```pony
+// Before
+let n = rnd.u32(0, 100)
+
+// After
+let n = rnd.u32(0, 100)?
+```
+
+In plain mode (a `Randomness` you construct directly), draws never error.
+
+### `Randomness.end_span` is now partial
+
+`end_span` errors when called with no open span, catching mismatched `start_span`/`end_span` calls at the point of misuse rather than silently ignoring them. Add `?` to every call site:
+
+```pony
+// Before
+rnd.end_span()
+
+// After
+rnd.end_span()?
+```
+
+### Removed API
+
+Each removed method either has a direct replacement or is no longer needed because shrinking is automatic.
+
+#### `Generator.generate_value` → `Generator.generate`
+
+`generate_value` returned only the value, discarding the shrink iterator. `generate` does the same thing — it's the only generate method now.
+
+```pony
+// Before
+let value = my_gen.generate_value(rnd)?
+
+// After
+let value = my_gen.generate(rnd)?
+```
+
+#### `Generator.generate_and_shrink` — delete the shrink plumbing
+
+`generate_and_shrink` returned `(T^, Iterator[T^])` — a value and its shrink iterator. Custom generators that composed multiple sub-generators had to destructure each result and manually zip the shrink iterators together. All of that is gone. Call `generate` on each sub-generator and combine the values directly.
+
+The before/after example in "Custom generators" above shows this migration.
+
+#### `Generator.value_iter` and `Generator.shrink` — delete entirely
+
+`value_iter` took a value and returned an iterator of progressively shrunk versions. `shrink` did the same thing. Both were building blocks for composing shrink iterators by hand. The framework now shrinks by replaying generators against mutated choice sequences, so there is no user-facing shrink API and no code to replace these calls with — delete them.
+
+```pony
+// Before — manually iterating shrunk values
+let shrinks: Iterator[U32^] = my_gen.value_iter(failing_value)
+for shrunk in shrinks do
+  // test each shrunk value
+end
+
+// After — nothing. The framework does this internally.
+```
+
+#### `GenerateResult`, `ValueAndShrink` type aliases — delete entirely
+
+These typed the old return value of `generate`. `GenerateResult[T]` was `(T^ | (T^, Iterator[T^]))`. With `generate` returning `T^` directly, neither alias is needed.
+
+#### `Generator.iter` and `Generator.value_and_shrink_iter` — delete entirely
+
+`iter` returned an `Iterator[GenerateResult[T]]` and `value_and_shrink_iter` returned an `Iterator[ValueAndShrink[T]]`. Both depended on removed types. Delete calls to them.
+
+#### `do_shrink` parameter on `Generators.one_of` and `Generators.unit` — delete the argument
+
+`one_of` and `unit` no longer take a `do_shrink` parameter. Remove it from the call site; shrinking is handled automatically.
+
+```pony
+// Before
+Generators.one_of[Color]([Blue; Green; Pink] where do_shrink = false)
+
+// After
+Generators.one_of[Color]([Blue; Green; Pink])
+```
+
+#### `PropertyParams.max_shrink_rounds` → `PropertyParams.max_shrink_reductions`
+
+The parameter that limits shrinking effort has been renamed and its default changed from 10 to 100. The old name counted shrink pass rounds; the new name counts accepted reductions, which is what the convergence loop actually tracks.
+
+```pony
+// Before
+PropertyParams(where max_shrink_rounds' = 20)
+
+// After
+PropertyParams(where max_shrink_reductions' = 20)
+```

--- a/examples/pony_check/custom_class.pony
+++ b/examples/pony_check/custom_class.pony
@@ -1,4 +1,3 @@
-use "itertools"
 use "pony_check"
 
 primitive Blue is Stringable
@@ -63,10 +62,6 @@ class _CustomClassMapProperty is Property1[MyLittlePony]
   `Generators.map2`, `Generators.map3` and `Generators.map4`
   combinators and of course the `map` method on `Generator`
   itself (for single argument constructors).
-
-  Generators created like this have better shrinking support
-  and their creation is much more readable than the `flat_map`
-  solution below.
   """
   fun name(): String => "custom_class/map"
 
@@ -75,8 +70,7 @@ class _CustomClassMapProperty is Property1[MyLittlePony]
     let cuteness_gen = Generators.u64(11, 100)
     let color_gen =
       Generators.one_of[Color](
-        [Blue; Green; Pink; Rose]
-        where do_shrink=true)
+        [Blue; Green; Pink; Rose])
     Generators.map3[String, U64, Color, MyLittlePony](
       name_gen,
       cuteness_gen,
@@ -96,14 +90,10 @@ class _CustomClassFlatMapProperty is Property1[MyLittlePony]
   generators into a single one that is based on multiple
   generators, one for each constructor argument.
 
-  ### Drawbacks
-
-  * The nested `flat_map` syntax is a little bit cumbersome
-    (e.g. the captured from the surrounding scope need to be
-    provided explicitly).
-  * The resulting generator has only limited shrinking support.
-    Only on the innermost created generator in the last
-    `flat_map` function will be properly shrunken.
+  The nested `flat_map` syntax is a little bit cumbersome
+  (e.g. the captured variables from the surrounding scope need
+  to be provided explicitly). Prefer `Generators.map2`/`map3`
+  when possible.
   """
   fun name(): String => "custom_class/flat_map"
 
@@ -112,8 +102,7 @@ class _CustomClassFlatMapProperty is Property1[MyLittlePony]
     let cuteness_gen = Generators.u64(11, 100)
     let color_gen =
       Generators.one_of[Color](
-        [Blue; Green; Pink; Rose]
-        where do_shrink=true)
+        [Blue; Green; Pink; Rose])
     color_gen
       .flat_map[MyLittlePony](
         {(color: Color)(cuteness_gen, name_gen) =>
@@ -135,25 +124,9 @@ class _CustomClassFlatMapProperty is Property1[MyLittlePony]
 class _CustomClassCustomGeneratorProperty
   is Property1[MyLittlePony]
   """
-  Generating your class given a custom generator is the most
-  flexible but also the most complicated approach.
-
-  You need to understand the types `GenerateResult[T]` and
-  `ValueAndShrink[T]` and how a basic `Generator` works.
-
-  You basically have two options on how to implement a
-  Generator:
-
-  * Return only the generated value from `generate` (and
-    optionally implement the `shrink` method to return an
-    `(T^, Iterator[T^])` whose values need to meet the
-    Generator's requirements
-  * Return both the generated value and the shrink-Iterator
-    from `generate`. This way you have the values from any
-    Generators available your Generator is based upon.
-
-  This Property is presenting the second option, returning a
-  `ValueAndShrink[MyLittlePony]` from `generate`.
+  Generating your class given a custom generator using a
+  GenObj. The generate method draws from Randomness to build
+  each field. Shrinking is automatic.
   """
 
   fun name(): String => "custom_class/custom_generator"
@@ -167,41 +140,17 @@ class _CustomClassCustomGeneratorProperty
           Generators.u64(11, 100)
         let color_gen: Generator[Color] =
           Generators.one_of[Color](
-            [Blue; Green; Pink; Rose]
-            where do_shrink=true)
+            [Blue; Green; Pink; Rose])
 
-        fun generate(
-          rnd: Randomness)
-          : GenerateResult[MyLittlePony] ?
-        =>
-          (let name, let name_shrinks) =
-            name_gen.generate_and_shrink(rnd)?
-          (let cuteness, let cuteness_shrinks) =
-            cuteness_gen.generate_and_shrink(rnd)?
-          (let color, let color_shrinks) =
-            color_gen.generate_and_shrink(rnd)?
-          let res =
-            MyLittlePony(
-              consume name,
-              consume cuteness,
-              consume color)
-          let shrinks =
-            Iter[String^](name_shrinks)
-              .zip2[U64^, Color^](
-                cuteness_shrinks, color_shrinks)
-              .map[MyLittlePony^](
-                {(zipped) =>
-                  (let n: String,
-                    let cute: U64,
-                    let col: Color) = consume zipped
-                  MyLittlePony(
-                    consume n,
-                    consume cute,
-                    consume col)
-                })
-          (consume res, shrinks)
-      end
-      )
+        fun generate(rnd: Randomness): MyLittlePony^ ? =>
+          let name' = name_gen.generate(rnd)?
+          let cuteness' = cuteness_gen.generate(rnd)?
+          let color' = color_gen.generate(rnd)?
+          MyLittlePony(
+            consume name',
+            consume cuteness',
+            consume color')
+      end)
 
   fun ref property(pony: MyLittlePony, ph: PropertyHelper) =>
     ph.assert_true(pony.is_cute())

--- a/packages/iregex/_test.pony
+++ b/packages/iregex/_test.pony
@@ -32,28 +32,28 @@ primitive \nodoc\ _IRegexpGen
     let that = this
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness): String =>
-          that._gen(rnd, max_depth)
+        fun generate(rnd: Randomness): String^ ? =>
+          that._gen(rnd, max_depth)?
       end)
 
-  fun _gen(rnd: Randomness, depth: USize): String =>
+  fun _gen(rnd: Randomness, depth: USize): String ? =>
     if depth == 0 then
-      return _gen_atom(rnd)
+      return _gen_atom(rnd)?
     end
-    match rnd.usize(0, 6)
-    | 0 => _gen_atom(rnd)
-    | 1 => _gen(rnd, depth - 1) + "|" + _gen(rnd, depth - 1)
-    | 2 => _gen_atom(rnd) + _gen_atom(rnd)
-    | 3 => "(" + _gen(rnd, depth - 1) + ")" + _gen_quant(rnd)
-    | 4 => _gen_atom(rnd) + _gen_quant_nonempty(rnd)
-    | 5 => _gen(rnd, depth - 1) + _gen_atom(rnd)
-    | 6 => _gen_atom(rnd) + _gen(rnd, depth - 1)
-    else _gen_atom(rnd)
+    match rnd.usize(0, 6)?
+    | 0 => _gen_atom(rnd)?
+    | 1 => _gen(rnd, depth - 1)? + "|" + _gen(rnd, depth - 1)?
+    | 2 => _gen_atom(rnd)? + _gen_atom(rnd)?
+    | 3 => "(" + _gen(rnd, depth - 1)? + ")" + _gen_quant(rnd)?
+    | 4 => _gen_atom(rnd)? + _gen_quant_nonempty(rnd)?
+    | 5 => _gen(rnd, depth - 1)? + _gen_atom(rnd)?
+    | 6 => _gen_atom(rnd)? + _gen(rnd, depth - 1)?
+    else _gen_atom(rnd)?
     end
 
-  fun _gen_atom(rnd: Randomness): String =>
-    match rnd.usize(0, 6)
-    | 0 => String.from_array([rnd.u8('a', 'z')])
+  fun _gen_atom(rnd: Randomness): String ? =>
+    match rnd.usize(0, 6)?
+    | 0 => String.from_array([rnd.u8('a', 'z')?])
     | 1 => "."
     | 2 => "\\n"
     | 3 => "\\t"
@@ -63,30 +63,30 @@ primitive \nodoc\ _IRegexpGen
     else "a"
     end
 
-  fun _gen_quant(rnd: Randomness): String =>
-    match rnd.usize(0, 4)
+  fun _gen_quant(rnd: Randomness): String ? =>
+    match rnd.usize(0, 4)?
     | 0 => ""
     | 1 => "*"
     | 2 => "+"
     | 3 => "?"
     | 4 =>
-      let n = rnd.usize(0, 2)
-      let m = n + rnd.usize(1, 3)
+      let n = rnd.usize(0, 2)?
+      let m = n + rnd.usize(1, 3)?
       "{" + n.string() + "," + m.string() + "}"
     else ""
     end
 
-  fun _gen_quant_nonempty(rnd: Randomness): String =>
-    match rnd.usize(0, 4)
+  fun _gen_quant_nonempty(rnd: Randomness): String ? =>
+    match rnd.usize(0, 4)?
     | 0 => "*"
     | 1 => "+"
     | 2 => "?"
     | 3 =>
-      let n = rnd.usize(0, 2)
-      let m = n + rnd.usize(1, 3)
+      let n = rnd.usize(0, 2)?
+      let m = n + rnd.usize(1, 3)?
       "{" + n.string() + "," + m.string() + "}"
     | 4 =>
-      let n = rnd.usize(1, 3)
+      let n = rnd.usize(1, 3)?
       "{" + n.string() + "}"
     else "*"
     end

--- a/packages/json/_stream_test.pony
+++ b/packages/json/_stream_test.pony
@@ -876,10 +876,10 @@ primitive \nodoc\ _JSONDocStringGen
   fun apply(max_depth: USize = 3): Generator[String] =>
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness): String =>
-          if rnd.bool() then
-            _JSONValueStringGen._gen_array(rnd, max_depth)
+        fun generate(rnd: Randomness): String^ ? =>
+          if rnd.bool()? then
+            _JSONValueStringGen._gen_array(rnd, max_depth)?
           else
-            _JSONValueStringGen._gen_object(rnd, max_depth)
+            _JSONValueStringGen._gen_object(rnd, max_depth)?
           end
       end)

--- a/packages/json/_test.pony
+++ b/packages/json/_test.pony
@@ -129,35 +129,35 @@ primitive \nodoc\ _JSONValueStringGen
     let that = this
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness): String =>
-          that._gen_value(rnd, max_depth)
+        fun generate(rnd: Randomness): String^ ? =>
+          that._gen_value(rnd, max_depth)?
       end)
 
-  fun _gen_value(rnd: Randomness, depth: USize): String =>
+  fun _gen_value(rnd: Randomness, depth: USize): String ? =>
     let choice =
       if depth == 0 then
-        rnd.usize(0, 4)
+        rnd.usize(0, 4)?
       else
-        rnd.usize(0, 6)
+        rnd.usize(0, 6)?
       end
     match choice
-    | 0 => _gen_int(rnd)
-    | 1 => _gen_float(rnd)
-    | 2 => if rnd.bool() then "true" else "false" end
+    | 0 => _gen_int(rnd)?
+    | 1 => _gen_float(rnd)?
+    | 2 => if rnd.bool()? then "true" else "false" end
     | 3 => "null"
-    | 4 => _gen_string(rnd)
-    | 5 => _gen_object(rnd, depth - 1)
-    | 6 => _gen_array(rnd, depth - 1)
+    | 4 => _gen_string(rnd)?
+    | 5 => _gen_object(rnd, depth - 1)?
+    | 6 => _gen_array(rnd, depth - 1)?
     else "null"
     end
 
-  fun _gen_int(rnd: Randomness): String =>
-    rnd.i64(-1000, 1000).string()
+  fun _gen_int(rnd: Randomness): String ? =>
+    rnd.i64(-1000, 1000)?.string()
 
-  fun _gen_float(rnd: Randomness): String =>
-    let numerator = rnd.i64(-100, 100)
+  fun _gen_float(rnd: Randomness): String ? =>
+    let numerator = rnd.i64(-100, 100)?
     let denom: I64 =
-      match rnd.usize(0, 3)
+      match rnd.usize(0, 3)?
       | 0 => 2
       | 1 => 4
       | 2 => 5
@@ -175,8 +175,8 @@ primitive \nodoc\ _JSONValueStringGen
       s
     end
 
-  fun _gen_string(rnd: Randomness): String =>
-    let len = rnd.usize(0, 15)
+  fun _gen_string(rnd: Randomness): String ? =>
+    let len = rnd.usize(0, 15)?
     var buf: String ref = String(len + 2)
     buf.push('"')
     var i: USize = 0
@@ -184,14 +184,14 @@ primitive \nodoc\ _JSONValueStringGen
       // Mix in escape and \uXXXX/surrogate sequences so property tests exercise
       // the escape and unicode decode paths (and their resume across chunks),
       // not just plain ASCII. Every branch is valid JSON.
-      match rnd.usize(0, 9)
+      match rnd.usize(0, 9)?
       | 0 => buf.append("\\n")
       | 1 => buf.append("\\t")
       | 2 => buf.append("\\r")
       | 3 => buf.append("\\u00e9")        // a BMP \uXXXX escape
       | 4 => buf.append("\\uD83D\\uDE00") // a surrogate pair
       else
-        let c = rnd.u8(0x20, 0x7E)
+        let c = rnd.u8(0x20, 0x7E)?
         if c == '"' then
           buf.append("\\\"")
         elseif c == '\\' then
@@ -205,39 +205,38 @@ primitive \nodoc\ _JSONValueStringGen
     buf.push('"')
     buf.clone()
 
-  fun _gen_object(rnd: Randomness, depth: USize): String =>
-    let count = rnd.usize(0, 3)
+  fun _gen_object(rnd: Randomness, depth: USize): String ? =>
+    let count = rnd.usize(0, 3)?
     if count == 0 then return "{}" end
     var buf: String ref = String(64)
     buf.push('{')
     var i: USize = 0
     while i < count do
       if i > 0 then buf.push(',') end
-      // generate a simple key
-      let key_len = rnd.usize(1, 6)
+      let key_len = rnd.usize(1, 6)?
       buf.push('"')
       var k: USize = 0
       while k < key_len do
-        buf.push(rnd.u8('a', 'z'))
+        buf.push(rnd.u8('a', 'z')?)
         k = k + 1
       end
       buf.push('"')
       buf.push(':')
-      buf.append(_gen_value(rnd, depth))
+      buf.append(_gen_value(rnd, depth)?)
       i = i + 1
     end
     buf.push('}')
     buf.clone()
 
-  fun _gen_array(rnd: Randomness, depth: USize): String =>
-    let count = rnd.usize(0, 4)
+  fun _gen_array(rnd: Randomness, depth: USize): String ? =>
+    let count = rnd.usize(0, 4)?
     if count == 0 then return "[]" end
     var buf: String ref = String(64)
     buf.push('[')
     var i: USize = 0
     while i < count do
       if i > 0 then buf.push(',') end
-      buf.append(_gen_value(rnd, depth))
+      buf.append(_gen_value(rnd, depth)?)
       i = i + 1
     end
     buf.push(']')
@@ -306,10 +305,10 @@ class \nodoc\ iso _F64RoundtripProperty is Property1[F64]
     // long-digit values that most stress the printer's precision.
     Generator[F64](
       object is GenObj[F64]
-        fun generate(rnd: Randomness): F64 =>
-          let sign = rnd.u64(0, 1) << 63
-          let exp = rnd.u64(0, 2046) << 52
-          let mant = rnd.u64() and 0x000F_FFFF_FFFF_FFFF
+        fun generate(rnd: Randomness): F64 ? =>
+          let sign = rnd.u64(0, 1)? << 63
+          let exp = rnd.u64(0, 2046)? << 52
+          let mant = rnd.u64()? and 0x000F_FFFF_FFFF_FFFF
           F64.from_bits(sign or exp or mant)
       end)
 
@@ -1886,33 +1885,33 @@ primitive \nodoc\ _SafeIRegexpGen
     let that = this
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness): String =>
-          that._gen(rnd, max_depth)
+        fun generate(rnd: Randomness): String^ ? =>
+          that._gen(rnd, max_depth)?
       end)
 
-  fun _gen(rnd: Randomness, depth: USize): String =>
-    if depth == 0 then return _gen_atom(rnd) end
-    match rnd.usize(0, 5)
-    | 0 => _gen_atom(rnd)
-    | 1 => _gen(rnd, depth - 1) + "|" + _gen(rnd, depth - 1)
-    | 2 => _gen_atom(rnd) + _gen_atom(rnd)
-    | 3 => "(" + _gen(rnd, depth - 1) + ")" + _gen_quant(rnd)
-    | 4 => _gen_atom(rnd) + _gen_quant(rnd)
-    | 5 => _gen(rnd, depth - 1) + _gen_atom(rnd)
-    else _gen_atom(rnd)
+  fun _gen(rnd: Randomness, depth: USize): String ? =>
+    if depth == 0 then return _gen_atom(rnd)? end
+    match rnd.usize(0, 5)?
+    | 0 => _gen_atom(rnd)?
+    | 1 => _gen(rnd, depth - 1)? + "|" + _gen(rnd, depth - 1)?
+    | 2 => _gen_atom(rnd)? + _gen_atom(rnd)?
+    | 3 => "(" + _gen(rnd, depth - 1)? + ")" + _gen_quant(rnd)?
+    | 4 => _gen_atom(rnd)? + _gen_quant(rnd)?
+    | 5 => _gen(rnd, depth - 1)? + _gen_atom(rnd)?
+    else _gen_atom(rnd)?
     end
 
-  fun _gen_atom(rnd: Randomness): String =>
-    match rnd.usize(0, 3)
-    | 0 => String.from_array([rnd.u8('a', 'z')])
+  fun _gen_atom(rnd: Randomness): String ? =>
+    match rnd.usize(0, 3)?
+    | 0 => String.from_array([rnd.u8('a', 'z')?])
     | 1 => "."
     | 2 => "[a-z]"
     | 3 => "[0-9]"
     else "a"
     end
 
-  fun _gen_quant(rnd: Randomness): String =>
-    match rnd.usize(0, 3)
+  fun _gen_quant(rnd: Randomness): String ? =>
+    match rnd.usize(0, 3)?
     | 0 => ""
     | 1 => "*"
     | 2 => "+"

--- a/packages/pony_check/_choice.pony
+++ b/packages/pony_check/_choice.pony
@@ -1,0 +1,111 @@
+class val _IntChoice is (Equatable[_IntChoice] & Stringable)
+  let value: I128
+  let min: I128
+  let max: I128
+  let shrink_towards: I128
+
+  new val create(
+    value': I128,
+    min': I128,
+    max': I128,
+    shrink_towards': I128 = 0)
+  =>
+    value = value'
+    min = min'
+    max = max'
+    shrink_towards = shrink_towards'
+
+  fun eq(other: box->_IntChoice): Bool =>
+    (value == other.value) and (min == other.min) and
+      (max == other.max) and (shrink_towards == other.shrink_towards)
+
+  fun string(): String iso^ =>
+    recover
+      String()
+        .> append("IntChoice(")
+        .> append(value.string())
+        .> append(", min=")
+        .> append(min.string())
+        .> append(", max=")
+        .> append(max.string())
+        .> append(", towards=")
+        .> append(shrink_towards.string())
+        .> append(")")
+    end
+
+class val _FloatChoice is (Equatable[_FloatChoice] & Stringable)
+  let value: F64
+  let min: F64
+  let max: F64
+
+  new val create(value': F64, min': F64, max': F64) =>
+    value = value'
+    min = min'
+    max = max'
+
+  fun eq(other: box->_FloatChoice): Bool =>
+    (value == other.value) and (min == other.min) and (max == other.max)
+
+  fun string(): String iso^ =>
+    recover
+      String()
+        .> append("FloatChoice(")
+        .> append(value.string())
+        .> append(", min=")
+        .> append(min.string())
+        .> append(", max=")
+        .> append(max.string())
+        .> append(")")
+    end
+
+class val _U128Choice is (Equatable[_U128Choice] & Stringable)
+  let value: U128
+  let min: U128
+  let max: U128
+  let shrink_towards: U128
+
+  new val create(
+    value': U128,
+    min': U128,
+    max': U128,
+    shrink_towards': U128 = 0)
+  =>
+    value = value'
+    min = min'
+    max = max'
+    shrink_towards = shrink_towards'
+
+  fun eq(other: box->_U128Choice): Bool =>
+    (value == other.value) and (min == other.min) and
+      (max == other.max) and (shrink_towards == other.shrink_towards)
+
+  fun string(): String iso^ =>
+    recover
+      String()
+        .> append("U128Choice(")
+        .> append(value.string())
+        .> append(", min=")
+        .> append(min.string())
+        .> append(", max=")
+        .> append(max.string())
+        .> append(", towards=")
+        .> append(shrink_towards.string())
+        .> append(")")
+    end
+
+class val _BoolChoice is (Equatable[_BoolChoice] & Stringable)
+  let value: Bool
+  let forced: Bool
+
+  new val create(value': Bool, forced': Bool = false) =>
+    value = value'
+    forced = forced'
+
+  fun eq(other: box->_BoolChoice): Bool =>
+    (value == other.value) and (forced == other.forced)
+
+  fun string(): String iso^ =>
+    let f = if forced then ", forced" else "" end
+    ("BoolChoice(" + value.string() + f + ")").string()
+
+type _Choice is (_IntChoice | _FloatChoice | _BoolChoice | _U128Choice)

--- a/packages/pony_check/_random_case.pony
+++ b/packages/pony_check/_random_case.pony
@@ -2,7 +2,6 @@ use "pony_test"
 
 use "collections"
 use persistent = "collections/persistent"
-use "itertools"
 use "random"
 use "time"
 
@@ -13,10 +12,8 @@ actor \nodoc\ Main is TestList
 
   fun tag tests(test: PonyTest) =>
     test(_ASCIIRangeTest)
-    test(_ASCIIStringShrinkTest)
     test(_ErroringPropertyTest)
     test(_FailingPropertyTest)
-    test(_FilterMapShrinkTest)
     test(_ForAllTest)
     test(_ForAll2Test)
     test(_ForAll3Test)
@@ -28,43 +25,33 @@ actor \nodoc\ Main is TestList
     test(_GenOneOfTest)
     test(_GenRndTest)
     test(_GenUnionTest)
-    test(_IsoSeqOfTest)
     test(_MapIsOfEmptyTest)
     test(_MapIsOfIdentityTest)
     test(_MapIsOfMaxTest)
-    test(_MapIsOfMinShrinkTest)
     test(_MapIsOfMinTest)
     test(_MapOfEmptyTest)
     test(_MapOfIdentityTest)
     test(_MapOfMaxTest)
-    test(_MapOfMinShrinkTest)
     test(_MapOfMinTest)
-    test(_MinASCIIStringShrinkTest)
-    test(_MinUnicodeStringShrinkTest)
     test(_MultipleForAllTest)
     test(_PersistentListOfEmptyTest)
     test(_PersistentListOfMaxTest)
     test(_PersistentListOfMinTest)
-    test(_PersistentListOfMinShrinkTest)
     test(_PersistentMapIsOfEmptyTest)
     test(_PersistentMapIsOfIdentityTest)
     test(_PersistentMapIsOfMaxTest)
     test(_PersistentMapIsOfMinTest)
-    test(_PersistentMapIsOfMinShrinkTest)
     test(_PersistentMapOfEmptyTest)
     test(_PersistentMapOfIdentityTest)
     test(_PersistentMapOfMaxTest)
     test(_PersistentMapOfMinTest)
-    test(_PersistentMapOfMinShrinkTest)
     test(_PersistentSetIsOfEmptyTest)
     test(_PersistentSetIsOfIdentityTest)
     test(_PersistentSetIsOfMaxTest)
     test(_PersistentSetIsOfMinTest)
-    test(_PersistentSetIsOfMinShrinkTest)
     test(_PersistentSetOfEmptyTest)
     test(_PersistentSetOfMaxTest)
     test(_PersistentSetOfMinTest)
-    test(_PersistentSetOfMinShrinkTest)
     test(Property1UnitTest[(I8, I8)](
       _RandomnessProperty[I8, _RandomCaseI8]("I8")))
     test(Property1UnitTest[(I16, I16)](
@@ -98,20 +85,33 @@ actor \nodoc\ Main is TestList
     test(_RunnerAsyncPropertyCompleteFalseTest)
     test(_RunnerAsyncPropertyCompleteTest)
     test(_RunnerErroringGeneratorTest)
-    test(_RunnerInfiniteShrinkTest)
     test(_RunnerReportFailedSampleTest)
+    test(_ShrinkIntToMinTest)
+    test(_ShrinkIntAboveThresholdTest)
+    test(_ShrinkArrayToMinTest)
+    test(_ShrinkFilterPreservationTest)
+    test(_ShrinkFlatMapTest)
+    test(_ReplayDeterminismTest)
+    test(_BooleanPerElementStructureTest)
+    test(_ShrinkerDeleteSpanTest)
+    test(_ShrinkerLowerChoicesTest)
+    test(_ShrinkerConvergenceLoopTest)
+    test(_ShrinkerRedistributeTest)
+    test(_ShrinkerShortenTest)
+    test(_ShrinkerSortSpansTest)
+    test(_ShrinkerBoolLoweringTest)
+    test(_ShrinkerForcedBoolSkipTest)
+    test(_ShrinkerLowerU128Test)
+    test(_ShrinkerDeleteDiscardedSpanTest)
+    test(_ShrinkerSortSpansLengthTest)
     test(_RunnerSometimesErroringGeneratorTest)
     test(_SeqOfTest)
     test(_SetIsOfIdentityTest)
-    test(_SetIsOfMinShrinkTest)
     test(_SetIsOfMinTest)
     test(_SetOfEmptyTest)
     test(_SetOfMaxTest)
-    test(_SetOfMinMaxEqualTest)
-    test(_SetOfMinShrinkTest)
     test(_SetOfMinTest)
     test(_SetOfTest)
-    test(_SignedShrinkTest)
     test(_StringifyTest)
     test(Property1UnitTest[U8](_SuccessfulProperty))
     test(Property2UnitTest[U8, U8](_SuccessfulProperty2))
@@ -125,14 +125,10 @@ actor \nodoc\ Main is TestList
     test(_SuccessfulProperty2Test)
     test(_SuccessfulProperty3Test)
     test(_SuccessfulProperty4Test)
-    test(_UnicodeStringShrinkTest)
     test(_VecOfEmptyTest)
     test(_VecOfFromToReversedTest)
     test(_VecOfMaxTest)
-    test(_VecOfMinMaxEqualTest)
     test(_VecOfMinTest)
-    test(_VecOfMinShrinkTest)
-    test(_UnsignedShrinkTest)
     test(_UTF32CodePointStringTest)
 
 class \nodoc\ iso _StringifyTest is UnitTest
@@ -485,9 +481,9 @@ class \nodoc\ iso _GenRndTest is UnitTest
     let rnd3 = Randomness(1)
     var same: U32 = 0
     for x in Range(0, 100) do
-      let g1 = gen.generate_value(rnd1)?
-      let g2 = gen.generate_value(rnd2)?
-      let g3 = gen.generate_value(rnd3)?
+      let g1 = gen.generate(rnd1)?
+      let g2 = gen.generate(rnd2)?
+      let g3 = gen.generate(rnd3)?
       h.assert_eq[U32](g1, g2)
       if g1 == g3 then
         same = same + 1
@@ -509,7 +505,7 @@ class \nodoc\ iso _GenFilterTest is UnitTest
       })
     let rnd = Randomness(Time.millis())
     for x in Range(0, 100) do
-      let v = gen.generate_value(rnd)?
+      let v = gen.generate(rnd)?
       h.assert_true((v % 2) == 0)
     end
 
@@ -518,34 +514,28 @@ class \nodoc\ iso _GenUnionTest is UnitTest
 
   fun apply(h: TestHelper) ? =>
     """
-    assert that a unioned Generator
-    produces shrinks of the same type than the generated value.
+    assert that a unioned Generator produces values of both types.
     """
     let gen = Generators.ascii().union[U8](Generators.u8())
     let rnd = Randomness(Time.millis())
+    var got_string: Bool = false
+    var got_u8: Bool = false
     for x in Range(0, 100) do
-      let gs = gen.generate(rnd)?
-      match gs
-      | (let vs: String, let shrink_iter: Iterator[String^]) =>
-        h.assert_true(true)
-      | (let vs: U8, let shrink_iter: Iterator[U8^]) =>
-        h.assert_true(true)
-      | (let vs: U8, let shrink_iter: Iterator[String^]) =>
-        h.fail("u8 value, string shrink iter")
-      | (let vs: String, let shrink_iter: Iterator[U8^]) =>
-        h.fail("string value, u8 shrink iter")
-      else
-        h.fail("invalid type generated")
+      match \exhaustive\ gen.generate(rnd)?
+      | let vs: String => got_string = true
+      | let vs: U8 => got_u8 = true
       end
     end
+    h.assert_true(got_string, "union never generated String")
+    h.assert_true(got_u8, "union never generated U8")
 
 class \nodoc\ iso _GenFrequencyTest is UnitTest
   fun name(): String => "Gen/frequency"
 
   fun apply(h: TestHelper) ? =>
     """
-    ensure that Generators.frequency(...) generators actually return different
-    values with given frequency
+    ensure that frequency generates values with given weights
+    and does not generate values with weight of 0
     """
     let gen =
       Generators.frequency[U8](
@@ -558,7 +548,7 @@ class \nodoc\ iso _GenFrequencyTest is UnitTest
 
     let generated = Array[U8](100)
     for i in Range(0, 100) do
-      generated.push(gen.generate_value(rnd)?)
+      generated.push(gen.generate(rnd)?)
     end
     h.assert_false(
       generated.contains(U8(42)),
@@ -573,7 +563,7 @@ class \nodoc\ iso _GenFrequencyTest is UnitTest
     let empty_gen = Generators.frequency[U8](Array[WeightedGenerator[U8]](0))
 
     h.assert_error({() ? =>
-      empty_gen.generate_value(Randomness(Time.millis()))?
+      empty_gen.generate(Randomness(Time.millis()))?
     })
 
 class \nodoc\ iso _GenFrequencySafeTest is UnitTest
@@ -587,18 +577,19 @@ class \nodoc\ iso _GenFrequencySafeTest is UnitTest
 class \nodoc\ iso _GenOneOfTest is UnitTest
   fun name(): String => "Gen/one_of"
 
-  fun apply(h: TestHelper) =>
+  fun apply(h: TestHelper) ? =>
     let gen = Generators.one_of[U8]([as U8: 0; 1])
     let rnd = Randomness(Time.millis())
-    h.assert_true(
-      Iter[U8^](gen.value_iter(rnd))
-        .take(100)
-        .all({(u: U8): Bool => (u == 0) or (u == 1) }),
-      "one_of generator generated illegal values")
+    for x in Range(0, 100) do
+      let v = gen.generate(rnd)?
+      h.assert_true(
+        (v == 0) or (v == 1),
+        "one_of generator generated illegal value")
+    end
     let empty_gen = Generators.one_of[U8](Array[U8](0))
 
     h.assert_error({() ? =>
-      empty_gen.generate_value(Randomness(Time.millis()))?
+      empty_gen.generate(Randomness(Time.millis()))?
     })
 
 class \nodoc\ iso _GenOneOfSafeTest is UnitTest
@@ -619,74 +610,11 @@ class \nodoc\ iso _SeqOfTest is UnitTest
         0,
         10)
     let rnd = Randomness(Time.millis())
-    h.assert_true(
-      Iter[Array[U8]^](seq_gen.value_iter(rnd))
-        .take(100)
-        .all(
-          {(a: Array[U8]): Bool =>
-            (a.size() >= 0) and (a.size() <= 10)
-          }),
-      "Seqs generated with Generators.seq_of are out of bounds")
-
-    match seq_gen.generate(rnd)?
-    | (let gen_sample: Array[U8], let shrinks: Iter[Array[U8]^]) =>
-      let max_size = gen_sample.size()
+    for i in Range(0, 100) do
+      let sample = seq_gen.generate(rnd)?
       h.assert_true(
-        Iter[Array[U8]^](shrinks)
-          .all({(a: Array[U8]): Bool =>
-            if not (a.size() < max_size) then
-              h.log(a.size().string() + " >= " + max_size.string())
-              false
-            else
-              true
-            end
-          }),
-        "shrinking of Generators.seq_of produces too big Seqs")
-    else
-      h.fail("Generators.seq_of did not produce any shrinks")
-    end
-
-class \nodoc\ iso _IsoSeqOfTest is UnitTest
-  let min: USize = 0
-  let max: USize = 200
-
-  fun name(): String => "Gen/iso_seq_of"
-
-  fun apply(h: TestHelper) ? =>
-    let seq_gen =
-      Generators.iso_seq_of[String, Array[String] iso](
-        Generators.ascii(),
-        min,
-        max
-      )
-    let rnd = Randomness(Time.millis())
-    h.assert_true(
-      Iter[Array[String] iso^](seq_gen.value_iter(rnd))
-        .take(100)
-        .all(
-          {(a: Array[String] iso): Bool =>
-            (a.size() >= min) and (a.size() <= max)
-          }),
-      "Seqs generated with Generators.iso_seq_of are out of bounds")
-
-    match seq_gen.generate(rnd)?
-    | (let gen_sample: Array[String] iso,
-      let shrinks: Iter[Array[String] iso^])
-    =>
-      let max_size = gen_sample.size()
-      h.assert_true(
-        Iter[Array[String] iso^](shrinks)
-          .all({(a: Array[String] iso): Bool =>
-            if not (a.size() < max_size) then
-              h.log(a.size().string() + " >= " + max_size.string())
-              false
-            else
-              true
-            end
-          }),
-        "shrinking of Generators.iso_seq_of produces too big Seqs")
-    else
-      h.fail("Generators.iso_seq_of did not produce any shrinks")
+        (sample.size() >= 0) and (sample.size() <= 10),
+        "Seqs generated with Generators.seq_of are out of bounds")
     end
 
 class \nodoc\ iso _SetOfTest is UnitTest
@@ -703,7 +631,7 @@ class \nodoc\ iso _SetOfTest is UnitTest
         where to = 1024)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample: Set[U8] = set_gen.generate_value(rnd)?
+      let sample: Set[U8] = set_gen.generate(rnd)?
       h.assert_true(sample.size() <= 256, "something about U8 is not right")
     end
 
@@ -711,15 +639,13 @@ class \nodoc\ iso _SetOfMaxTest is UnitTest
   fun name(): String => "Gen/set_of_max"
 
   fun apply(h: TestHelper) ? =>
-    """
-    """
     let rnd = Randomness(Time.millis())
     for size in Range[USize](1, U8.max_value().usize()) do
       let set_gen =
         Generators.set_of[U8](
           Generators.u8()
           where to = size)
-      let sample: Set[U8] = set_gen.generate_value(rnd)?
+      let sample: Set[U8] = set_gen.generate(rnd)?
       h.assert_true(sample.size() <= size, "generated set is too big.")
     end
 
@@ -727,15 +653,13 @@ class \nodoc\ iso _SetOfEmptyTest is UnitTest
   fun name(): String => "Gen/set_of_empty"
 
   fun apply(h: TestHelper) ? =>
-    """
-    """
     let set_gen =
       Generators.set_of[U8](
         Generators.u8()
         where to = 0)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample: Set[U8] = set_gen.generate_value(rnd)?
+      let sample: Set[U8] = set_gen.generate(rnd)?
       h.assert_true(sample.size() == 0, "non-empty set created.")
     end
 
@@ -743,14 +667,12 @@ class \nodoc\ iso _SetIsOfIdentityTest is UnitTest
   fun name(): String => "Gen/set_is_of_identity"
 
   fun apply(h: TestHelper) ? =>
-    """
-    """
     let set_is_gen_same =
       Generators.set_is_of[String](
         Generators.unit[String]("the highlander")
         where to = 100)
     let rnd = Randomness(Time.millis())
-    let sample: SetIs[String] = set_is_gen_same.generate_value(rnd)?
+    let sample: SetIs[String] = set_is_gen_same.generate(rnd)?
     h.assert_true(
       sample.size() <= 1,
       "invalid SetIs instances generated: size " + sample.size().string())
@@ -759,8 +681,6 @@ class \nodoc\ iso _MapOfEmptyTest is UnitTest
   fun name(): String => "Gen/map_of_empty"
 
   fun apply(h: TestHelper) ? =>
-    """
-    """
     let map_gen =
       Generators.map_of[String, I64](
         Generators.zip2[String, I64](
@@ -772,7 +692,7 @@ class \nodoc\ iso _MapOfEmptyTest is UnitTest
           Generators.i64(-10, 10))
         where to = 0)
     let rnd = Randomness(Time.millis())
-    let sample = map_gen.generate_value(rnd)?
+    let sample = map_gen.generate(rnd)?
     h.assert_eq[USize](sample.size(), 0, "non-empty map created")
 
 class \nodoc\ iso _MapOfMaxTest is UnitTest
@@ -790,7 +710,7 @@ class \nodoc\ iso _MapOfMaxTest is UnitTest
             }),
             Generators.i64(-10, 10))
           where to = size)
-      let sample = map_gen.generate_value(rnd)?
+      let sample = map_gen.generate(rnd)?
       h.assert_true(sample.size() <= size, "generated map is too big.")
     end
 
@@ -810,15 +730,13 @@ class \nodoc\ iso _MapOfIdentityTest is UnitTest
             }),
           Generators.i64(-10, 10))
         where to = 100)
-    let sample = map_gen.generate_value(rnd)?
+    let sample = map_gen.generate(rnd)?
     h.assert_true(sample.size() <= 1)
 
 class \nodoc\ iso _MapIsOfEmptyTest is UnitTest
   fun name(): String => "Gen/map_is_of_empty"
 
   fun apply(h: TestHelper) ? =>
-    """
-    """
     let map_is_gen =
       Generators.map_is_of[String, I64](
         Generators.zip2[String, I64](
@@ -830,7 +748,7 @@ class \nodoc\ iso _MapIsOfEmptyTest is UnitTest
           Generators.i64(-10, 10))
         where to = 0)
     let rnd = Randomness(Time.millis())
-    let sample = map_is_gen.generate_value(rnd)?
+    let sample = map_is_gen.generate(rnd)?
     h.assert_eq[USize](sample.size(), 0, "non-empty map created")
 
 class \nodoc\ iso _MapIsOfMaxTest is UnitTest
@@ -850,7 +768,7 @@ class \nodoc\ iso _MapIsOfMaxTest is UnitTest
               }),
             Generators.i64(-10, 10))
           where to = size)
-      let sample = map_is_gen.generate_value(rnd)?
+      let sample = map_is_gen.generate(rnd)?
       h.assert_true(sample.size() <= size, "generated map is too big.")
     end
 
@@ -865,7 +783,7 @@ class \nodoc\ iso _MapIsOfIdentityTest is UnitTest
           Generators.unit[String]("the highlander"),
           Generators.i64(-10, 10))
         where to = 100)
-    let sample = map_gen.generate_value(rnd)?
+    let sample = map_gen.generate(rnd)?
     h.assert_true(sample.size() <= 1)
 
 class \nodoc\ iso _SetOfMinTest is UnitTest
@@ -878,33 +796,10 @@ class \nodoc\ iso _SetOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample: Set[U8] = set_gen.generate_value(rnd)?
+      let sample: Set[U8] = set_gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty set created with min = 1")
-    end
-
-class \nodoc\ iso _SetOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/set_of_min_shrink"
-
-  fun apply(h: TestHelper) ? =>
-    let set_gen =
-      Generators.set_of[U8](
-        Generators.u8()
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match set_gen.generate(rnd)?
-    | (let sample: Set[U8], let shrinks: Iterator[Set[U8]^]) =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated set has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk set has fewer than 5 elements")
-      end
-    else
-      h.fail("set_of did not produce shrinks")
     end
 
 class \nodoc\ iso _SetIsOfMinTest is UnitTest
@@ -917,7 +812,7 @@ class \nodoc\ iso _SetIsOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample: SetIs[String] = set_is_gen.generate_value(rnd)?
+      let sample: SetIs[String] = set_is_gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty SetIs created with min = 1")
@@ -937,7 +832,7 @@ class \nodoc\ iso _MapOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = map_gen.generate_value(rnd)?
+      let sample = map_gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty map created with min = 1")
@@ -957,109 +852,10 @@ class \nodoc\ iso _MapIsOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = map_is_gen.generate_value(rnd)?
+      let sample = map_is_gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty MapIs created with min = 1")
-    end
-
-class \nodoc\ iso _SetIsOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/set_is_of_min_shrink"
-
-  fun apply(h: TestHelper) ? =>
-    let set_is_gen =
-      Generators.set_is_of[String](
-        Generators.ascii(where from = 1, to = 10)
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match set_is_gen.generate(rnd)?
-    | (let sample: SetIs[String], let shrinks: Iterator[SetIs[String]^]) =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated SetIs has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk SetIs has fewer than 5 elements")
-      end
-    else
-      h.fail("set_is_of did not produce shrinks")
-    end
-
-class \nodoc\ iso _MapOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/map_of_min_shrink"
-
-  fun apply(h: TestHelper) ? =>
-    let map_gen =
-      Generators.map_of[String, I64](
-        Generators.zip2[String, I64](
-          Generators.u16().map[String^]({(u: U16): String^ =>
-            u.string()
-          }),
-          Generators.i64(-10, 10))
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match map_gen.generate(rnd)?
-    | (let sample: Map[String, I64],
-      let shrinks: Iterator[Map[String, I64]^])
-    =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated Map has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk Map has fewer than 5 elements")
-      end
-    else
-      h.fail("map_of did not produce shrinks")
-    end
-
-class \nodoc\ iso _MapIsOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/map_is_of_min_shrink"
-
-  fun apply(h: TestHelper) ? =>
-    let map_is_gen =
-      Generators.map_is_of[String, I64](
-        Generators.zip2[String, I64](
-          Generators.u16().map[String^]({(u: U16): String^ =>
-            u.string()
-          }),
-          Generators.i64(-10, 10))
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match map_is_gen.generate(rnd)?
-    | (let sample: MapIs[String, I64],
-      let shrinks: Iterator[MapIs[String, I64]^])
-    =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated MapIs has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk MapIs has fewer than 5 elements")
-      end
-    else
-      h.fail("map_is_of did not produce shrinks")
-    end
-
-class \nodoc\ iso _SetOfMinMaxEqualTest is UnitTest
-  fun name(): String => "Gen/set_of_min_max_equal"
-
-  fun apply(h: TestHelper) ? =>
-    let set_gen =
-      Generators.set_of[U8](
-        Generators.u8()
-        where from = 5, to = 5)
-    let rnd = Randomness(Time.millis())
-    match set_gen.generate(rnd)?
-    | (let sample: Set[U8], let shrinks: Iterator[Set[U8]^]) =>
-      h.assert_false(
-        shrinks.has_next(),
-        "shrink iterator should be empty when min == max")
-    else
-      h.fail("set_of did not produce shrinks")
     end
 
 class \nodoc\ iso _ASCIIRangeTest is UnitTest
@@ -1071,7 +867,7 @@ class \nodoc\ iso _ASCIIRangeTest is UnitTest
       Generators.ascii(where from = 1, to = 1, range = ASCIIAll)
 
     for i in Range[USize](0, 100) do
-      let sample = ascii_gen.generate_value(rnd)?
+      let sample = ascii_gen.generate(rnd)?
       h.assert_true(
         ASCIIAll().contains(sample),
         "\"" + sample + "\" not valid ascii")
@@ -1089,7 +885,7 @@ class \nodoc\ iso _UTF32CodePointStringTest is UnitTest
         100)
 
     for i in Range[USize](0, 100) do
-      let sample = string_gen.generate_value(rnd)?
+      let sample = string_gen.generate(rnd)?
       for cp in sample.runes() do
         h.assert_true(
           (cp <= 0xD7FF) or (cp >= 0xE000),
@@ -1146,44 +942,6 @@ class \nodoc\ iso _SuccessfulIntPairPropertyTest is UnitTest
         h.env)
     runner.run()
 
-class \nodoc\ iso _InfiniteShrinkProperty is Property1[String]
-  fun name(): String => "property_runner/inifinite_shrink/property"
-
-  fun gen(): Generator[String] =>
-    Generator[String](
-      object is GenObj[String]
-        fun generate(r: Randomness): String^ =>
-          "decided by fair dice roll, totally random"
-
-        fun shrink(t: String): ValueAndShrink[String] =>
-          (t, Iter[String^].repeat_value(t))
-      end)
-
-  fun ref property(arg1: String, ph: PropertyHelper) =>
-    ph.assert_true(arg1.size() > 100) // assume this failing
-
-class \nodoc\ iso _RunnerInfiniteShrinkTest is UnitTest
-  """
-  ensure that having a failing property with an infinite generator
-  is not shrinking infinitely
-  """
-  fun name(): String => "property_runner/infinite_shrink"
-
-  fun apply(h: TestHelper) =>
-    let property = recover iso _InfiniteShrinkProperty end
-    let params = property.params()
-
-    h.long_test(params.timeout)
-
-    let runner =
-      PropertyRunner[String](
-        consume property,
-        params,
-        _UnitTestPropertyNotify(h, false),
-        _UnitTestPropertyLogger(h),
-        h.env)
-    runner.run()
-
 class \nodoc\ iso _ErroringGeneratorProperty is Property1[String]
   fun name(): String => "property_runner/erroring_generator/property"
 
@@ -1221,7 +979,7 @@ class \nodoc\ iso _SometimesErroringGeneratorProperty is Property1[String]
   fun params(): PropertyParams =>
     PropertyParams(where
       num_samples' = 3,
-      seed' = 6, // known seed to produce a value, an error and a value
+      seed' = 6,
       max_generator_retries' = 1
     )
 
@@ -1229,7 +987,7 @@ class \nodoc\ iso _SometimesErroringGeneratorProperty is Property1[String]
     Generator[String](
       object is GenObj[String]
         fun generate(r: Randomness): String^ ? =>
-          match (r.u64() % 2)
+          match (r.u64()? % 2)
           | 0 => "foo"
           else
             error
@@ -1302,198 +1060,6 @@ class \nodoc\ iso _RunnerReportFailedSampleTest is UnitTest
         logger,
         h.env)
     runner.run()
-
-trait \nodoc\ _ShrinkTest is UnitTest
-  fun shrink[T](gen: Generator[T], shrink_elem: T): Iterator[T^] =>
-    (_, let shrinks': Iterator[T^]) = gen.shrink(consume shrink_elem)
-    shrinks'
-
-  fun _collect_shrinks[T](gen: Generator[T], shrink_elem: T): Array[T] =>
-    Iter[T^](shrink[T](gen, consume shrink_elem)).collect[Array[T]](Array[T])
-
-  fun _size(shrinks: Iterator[Any^]): USize =>
-    Iter[Any^](shrinks).count()
-
-  fun _test_int_constraints[T: (Int & Integer[T] val)](
-    h: TestHelper,
-    gen: Generator[T],
-    x: T,
-    min: T = T.min_value()
-  ) ?
-  =>
-    let shrinks = shrink[T](gen, min)
-    h.assert_false(
-      shrinks.has_next(),
-      "non-empty shrinks for minimal value " + min.string())
-
-    let shrinks1 = _collect_shrinks[T](gen, min + 1)
-    h.assert_array_eq[T](
-      [min],
-      shrinks1,
-      "didn't include min in shrunken list of samples")
-
-    let shrinks2 = shrink[T](gen, x)
-    h.assert_true(
-      Iter[T^](shrinks2)
-        .all(
-          {(u: T): Bool =>
-            match \exhaustive\ x.compare(min)
-            | Less =>
-              (u <= min) and (u > x)
-            | Equal => true
-            | Greater =>
-              (u >= min) and (u < x)
-            end
-          }),
-      "generated shrinks from " + x.string() +
-        " that violate minimum or maximum")
-
-    let count_shrinks = shrink[T](gen, x)
-    let max_count =
-      if (x - min) < 0 then
-        -(x - min)
-      else
-        x - min
-      end
-    let actual_count = T.from[USize](Iter[T^](count_shrinks).count())
-    h.assert_true(
-      actual_count <= max_count,
-      "generated too much values from " + x.string() +
-        " : " + actual_count.string() +
-        " > " + max_count.string())
-
-class \nodoc\ iso _UnsignedShrinkTest is _ShrinkTest
-  fun name(): String => "shrink/unsigned_generators"
-
-  fun apply(h: TestHelper) ? =>
-    let gen = Generators.u8()
-    _test_int_constraints[U8](h, gen, U8(42))?
-    _test_int_constraints[U8](h, gen, U8.max_value())?
-
-    let min = U64(10)
-    let gen_min = Generators.u64(where from = min)
-    _test_int_constraints[U64](h, gen_min, 42, min)?
-
-class \nodoc\ iso _SignedShrinkTest is _ShrinkTest
-  fun name(): String => "shrink/signed_generators"
-
-  fun apply(h: TestHelper) ? =>
-    let gen = Generators.i64()
-    _test_int_constraints[I64](h, gen, (I64.min_value() + 100))?
-
-    let gen2 = Generators.i64(-10, 20)
-    _test_int_constraints[I64](h, gen2, 20, -10)?
-    _test_int_constraints[I64](h, gen2, 30, -10)?
-    // weird case but should still work
-    _test_int_constraints[I64](h, gen2, -12, -10)?
-
-class \nodoc\ iso _ASCIIStringShrinkTest is _ShrinkTest
-  fun name(): String => "shrink/ascii_string_generators"
-
-  fun apply(h: TestHelper) =>
-    let gen = Generators.ascii(where from = 0)
-
-    let shrinks_min = shrink[String](gen, "")
-    h.assert_false(
-      shrinks_min.has_next(),
-      "non-empty shrinks for minimal value")
-
-    let sample = "ABCDEF"
-    let shrinks = _collect_shrinks[String](gen, sample)
-    h.assert_array_eq[String](
-      ["ABCDE"; "ABCD"; "ABC"; "AB"; "A"; ""],
-      shrinks)
-
-    let short_sample = "A"
-    let short_shrinks = _collect_shrinks[String](gen, short_sample)
-    h.assert_array_eq[String](
-      [""],
-      short_shrinks,
-      "shrinking 'A' returns wrong results")
-
-class \nodoc\ iso _MinASCIIStringShrinkTest is _ShrinkTest
-  fun name(): String => "shrink/min_ascii_string_generators"
-
-  fun apply(h: TestHelper) =>
-    let min: USize = 10
-    let gen = Generators.ascii(where from = min)
-
-    let shrinks_min = shrink[String](gen, "abcdefghi")
-    h.assert_false(
-      shrinks_min.has_next(),
-      "generated non-empty shrinks for string smaller than minimum")
-
-    let shrinks = shrink[String](gen, "abcdefghijlkmnop")
-    h.assert_true(
-      Iter[String](shrinks)
-        .all({(s: String): Bool => s.size() >= min }),
-      "generated shrinks that violate minimum string length")
-
-class \nodoc\ iso _UnicodeStringShrinkTest is _ShrinkTest
-  fun name(): String => "shrink/unicode_string_generators"
-
-  fun apply(h: TestHelper) =>
-    let gen = Generators.unicode()
-
-    let shrinks_min = shrink[String](gen, "")
-    h.assert_false(
-      shrinks_min.has_next(),
-      "non-empty shrinks for minimal value")
-
-    let sample2 = "ΣΦΩ"
-    let shrinks2 = _collect_shrinks[String](gen, sample2)
-    h.assert_false(shrinks2.contains(sample2))
-    h.assert_true(
-      shrinks2.size() > 0,
-      "empty shrinks for non-minimal unicode string")
-
-    let sample3 = "Σ"
-    let shrinks3 = _collect_shrinks[String](gen, sample3)
-    h.assert_array_eq[String](
-      [""],
-      shrinks3,
-      "minimal non-empty string not properly shrunk")
-
-class \nodoc\ iso _MinUnicodeStringShrinkTest is _ShrinkTest
-  fun name(): String => "shrink/min_unicode_string_generators"
-
-  fun apply(h: TestHelper) =>
-    let min = USize(5)
-    let gen = Generators.unicode(where from = min)
-
-    let min_sample = "ΣΦΩ"
-    let shrinks_min = shrink[String](gen, min_sample)
-    h.assert_false(
-      shrinks_min.has_next(),
-      "non-empty shrinks for minimal value")
-
-    let sample = "ΣΦΩΣΦΩ"
-    let shrinks = _collect_shrinks[String](gen, sample)
-    h.assert_true(
-      Iter[String](shrinks.values())
-        .all({(s: String): Bool => s.codepoints() >= min }),
-      "generated shrinks that violate minimum string length")
-    h.assert_false(
-      shrinks.contains(sample),
-      "shrinks contain sample value")
-
-class \nodoc\ iso _FilterMapShrinkTest is _ShrinkTest
-  fun name(): String => "shrink/filter_map"
-
-  fun apply(h: TestHelper) =>
-    let gen: Generator[U64] =
-      Generators.u8()
-        .filter({(byte) => (byte, byte > 10) })
-        .map[U64]({(byte) => (byte * 2).u64() })
-    // shrink from 100 and only expect even values > 20
-    let shrink_iter = shrink[U64](gen, U64(100))
-    h.assert_true(
-      Iter[U64](shrink_iter)
-        .all(
-          {(u) =>
-            (u > 20) and ((u % 2) == 0)
-          }),
-      "shrinking does not maintain filter invariants")
 
 primitive \nodoc\ _Async
   """
@@ -1592,102 +1158,102 @@ class \nodoc\ iso _AsyncProperty is Property1[String]
 interface \nodoc\ val _RandomCase[A: Comparable[A] #read]
   new val create()
 
-  fun test(min: A, max: A): A
+  fun test(min: A, max: A): A ?
 
   fun generator(): Generator[A]
 
 primitive \nodoc\ _RandomCaseU8 is _RandomCase[U8]
-  fun test(min: U8, max: U8): U8 =>
+  fun test(min: U8, max: U8): U8 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.u8(min, max)
+    rnd.u8(min, max)?
 
   fun generator(): Generator[U8] =>
     Generators.u8()
 
 primitive \nodoc\ _RandomCaseU16 is _RandomCase[U16]
-  fun test(min: U16, max: U16): U16 =>
+  fun test(min: U16, max: U16): U16 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.u16(min, max)
+    rnd.u16(min, max)?
 
   fun generator(): Generator[U16] =>
     Generators.u16()
 
 primitive \nodoc\ _RandomCaseU32 is _RandomCase[U32]
-  fun test(min: U32, max: U32): U32 =>
+  fun test(min: U32, max: U32): U32 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.u32(min, max)
+    rnd.u32(min, max)?
 
   fun generator(): Generator[U32] =>
     Generators.u32()
 
 primitive \nodoc\ _RandomCaseU64 is _RandomCase[U64]
-  fun test(min: U64, max: U64): U64 =>
+  fun test(min: U64, max: U64): U64 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.u64(min, max)
+    rnd.u64(min, max)?
 
   fun generator(): Generator[U64] =>
     Generators.u64()
 
 primitive \nodoc\ _RandomCaseU128 is _RandomCase[U128]
-  fun test(min: U128, max: U128): U128 =>
+  fun test(min: U128, max: U128): U128 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.u128(min, max)
+    rnd.u128(min, max)?
 
   fun generator(): Generator[U128] =>
     Generators.u128()
 
 primitive \nodoc\ _RandomCaseI8 is _RandomCase[I8]
-  fun test(min: I8, max: I8): I8 =>
+  fun test(min: I8, max: I8): I8 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.i8(min, max)
+    rnd.i8(min, max)?
 
   fun generator(): Generator[I8] =>
     Generators.i8()
 
 primitive \nodoc\ _RandomCaseI16 is _RandomCase[I16]
-  fun test(min: I16, max: I16): I16 =>
+  fun test(min: I16, max: I16): I16 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.i16(min, max)
+    rnd.i16(min, max)?
 
   fun generator(): Generator[I16] =>
     Generators.i16()
 
 primitive \nodoc\ _RandomCaseI32 is _RandomCase[I32]
-  fun test(min: I32, max: I32): I32 =>
+  fun test(min: I32, max: I32): I32 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.i32(min, max)
+    rnd.i32(min, max)?
 
   fun generator(): Generator[I32] =>
     Generators.i32()
 
 primitive \nodoc\ _RandomCaseI64 is _RandomCase[I64]
-  fun test(min: I64, max: I64): I64 =>
+  fun test(min: I64, max: I64): I64 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.i64(min, max)
+    rnd.i64(min, max)?
 
   fun generator(): Generator[I64] =>
     Generators.i64()
 
 primitive \nodoc\ _RandomCaseI128 is _RandomCase[I128]
-  fun test(min: I128, max: I128): I128 =>
+  fun test(min: I128, max: I128): I128 ? =>
     let rnd = Randomness(Time.millis())
-    rnd.i128(min, max)
+    rnd.i128(min, max)?
 
   fun generator(): Generator[I128] =>
     Generators.i128()
 
 primitive \nodoc\ _RandomCaseISize is _RandomCase[ISize]
-  fun test(min: ISize, max: ISize): ISize =>
+  fun test(min: ISize, max: ISize): ISize ? =>
     let rnd = Randomness(Time.millis())
-    rnd.isize(min, max)
+    rnd.isize(min, max)?
 
   fun generator(): Generator[ISize] =>
     Generators.isize()
 
 primitive \nodoc\ _RandomCaseILong is _RandomCase[ILong]
-  fun test(min: ILong, max: ILong): ILong =>
+  fun test(min: ILong, max: ILong): ILong ? =>
     let rnd = Randomness(Time.millis())
-    rnd.ilong(min, max)
+    rnd.ilong(min, max)?
 
   fun generator(): Generator[ILong] =>
     Generators.ilong()
@@ -1713,10 +1279,10 @@ class \nodoc\ iso _RandomnessProperty[
         {(pair) => (pair, (pair._1 <= pair._2)) }
       )
 
-  fun property(arg1: (A, A), ph: PropertyHelper) =>
+  fun property(arg1: (A, A), ph: PropertyHelper) ? =>
     (let min, let max) = arg1
 
-    let value = R.test(min, max)
+    let value = R.test(min, max)?
     ph.assert_true(value >= min)
     ph.assert_true(value <= max)
 
@@ -1730,7 +1296,7 @@ class \nodoc\ iso _VecOfEmptyTest is UnitTest
         where to = 0)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_eq[USize](sample.size(), 0, "non-empty vec created")
     end
 
@@ -1744,37 +1310,13 @@ class \nodoc\ iso _VecOfFromToReversedTest is UnitTest
         where from = 10, to = 5)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 5,
         "vec smaller than lo when from > to")
       h.assert_true(
         sample.size() <= 10,
         "vec larger than hi when from > to")
-    end
-
-class \nodoc\ iso _VecOfMinMaxEqualTest is UnitTest
-  fun name(): String => "Gen/vec_of_min_max_equal"
-
-  fun apply(h: TestHelper) ? =>
-    let gen =
-      Generators.vec_of[U8](
-        Generators.u8()
-        where from = 5, to = 5)
-    let rnd = Randomness(Time.millis())
-    match gen.generate(rnd)?
-    | (let sample: persistent.Vec[U8],
-      let shrinks: Iterator[persistent.Vec[U8]^])
-    =>
-      h.assert_eq[USize](
-        sample.size(),
-        5,
-        "vec should have exactly 5 elements when from == to")
-      h.assert_false(
-        shrinks.has_next(),
-        "shrink iterator should be empty when from == to")
-    else
-      h.fail("vec_of did not produce shrinks")
     end
 
 class \nodoc\ iso _VecOfMaxTest is UnitTest
@@ -1787,7 +1329,7 @@ class \nodoc\ iso _VecOfMaxTest is UnitTest
         Generators.vec_of[U8](
           Generators.u8()
           where to = size)
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(sample.size() <= size, "generated vec is too big")
     end
 
@@ -1801,35 +1343,10 @@ class \nodoc\ iso _VecOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty vec created with from = 1")
-    end
-
-class \nodoc\ iso _VecOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/vec_of_min_shrink"
-
-  fun apply(h: TestHelper) ? =>
-    let gen =
-      Generators.vec_of[U8](
-        Generators.u8()
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match gen.generate(rnd)?
-    | (let sample: persistent.Vec[U8],
-      let shrinks: Iterator[persistent.Vec[U8]^])
-    =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated vec has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk vec has fewer than 5 elements")
-      end
-    else
-      h.fail("vec_of did not produce shrinks")
     end
 
 class \nodoc\ iso _PersistentListOfEmptyTest is UnitTest
@@ -1842,7 +1359,7 @@ class \nodoc\ iso _PersistentListOfEmptyTest is UnitTest
         where to = 0)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_eq[USize](sample.size(), 0, "non-empty list created")
     end
 
@@ -1856,7 +1373,7 @@ class \nodoc\ iso _PersistentListOfMaxTest is UnitTest
         Generators.persistent_list_of[U8](
           Generators.u8()
           where to = size)
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(sample.size() <= size, "generated list is too big")
     end
 
@@ -1870,35 +1387,10 @@ class \nodoc\ iso _PersistentListOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty list created with from = 1")
-    end
-
-class \nodoc\ iso _PersistentListOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/persistent_list_of_min_shrink"
-
-  fun apply(h: TestHelper) ? =>
-    let gen =
-      Generators.persistent_list_of[U8](
-        Generators.u8()
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match gen.generate(rnd)?
-    | (let sample: persistent.List[U8],
-      let shrinks: Iterator[persistent.List[U8]^])
-    =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated list has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk list has fewer than 5 elements")
-      end
-    else
-      h.fail("persistent_list_of did not produce shrinks")
     end
 
 class \nodoc\ iso _PersistentSetIsOfIdentityTest is UnitTest
@@ -1910,7 +1402,7 @@ class \nodoc\ iso _PersistentSetIsOfIdentityTest is UnitTest
         Generators.unit[String]("the highlander")
         where to = 100)
     let rnd = Randomness(Time.millis())
-    let sample = gen.generate_value(rnd)?
+    let sample = gen.generate(rnd)?
     h.assert_true(
       sample.size() <= 1,
       "invalid persistent SetIs: size " + sample.size().string())
@@ -1925,7 +1417,7 @@ class \nodoc\ iso _PersistentSetOfEmptyTest is UnitTest
         where to = 0)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_eq[USize](sample.size(), 0, "non-empty set created")
     end
 
@@ -1939,7 +1431,7 @@ class \nodoc\ iso _PersistentSetOfMaxTest is UnitTest
         Generators.persistent_set_of[U8](
           Generators.u8()
           where to = size)
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(sample.size() <= size, "generated set is too big")
     end
 
@@ -1953,35 +1445,10 @@ class \nodoc\ iso _PersistentSetOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty set created with from = 1")
-    end
-
-class \nodoc\ iso _PersistentSetOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/persistent_set_of_min_shrink"
-
-  fun apply(h: TestHelper) ? =>
-    let gen =
-      Generators.persistent_set_of[U8](
-        Generators.u8()
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match gen.generate(rnd)?
-    | (let sample: persistent.Set[U8],
-      let shrinks: Iterator[persistent.Set[U8]^])
-    =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated set has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk set has fewer than 5 elements")
-      end
-    else
-      h.fail("persistent_set_of did not produce shrinks")
     end
 
 class \nodoc\ iso _PersistentSetIsOfEmptyTest is UnitTest
@@ -1994,7 +1461,7 @@ class \nodoc\ iso _PersistentSetIsOfEmptyTest is UnitTest
         where to = 0)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_eq[USize](sample.size(), 0, "non-empty SetIs created")
     end
 
@@ -2008,7 +1475,7 @@ class \nodoc\ iso _PersistentSetIsOfMaxTest is UnitTest
         Generators.persistent_set_is_of[U8](
           Generators.u8()
           where to = size)
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(sample.size() <= size, "generated SetIs is too big")
     end
 
@@ -2022,35 +1489,10 @@ class \nodoc\ iso _PersistentSetIsOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty SetIs created with from = 1")
-    end
-
-class \nodoc\ iso _PersistentSetIsOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/persistent_set_is_of_min_shrink"
-
-  fun apply(h: TestHelper) ? =>
-    let gen =
-      Generators.persistent_set_is_of[String](
-        Generators.ascii(where from = 1, to = 10)
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match gen.generate(rnd)?
-    | (let sample: persistent.SetIs[String],
-      let shrinks: Iterator[persistent.SetIs[String]^])
-    =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated SetIs has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk SetIs has fewer than 5 elements")
-      end
-    else
-      h.fail("persistent_set_is_of did not produce shrinks")
     end
 
 class \nodoc\ iso _PersistentMapOfIdentityTest is UnitTest
@@ -2069,7 +1511,7 @@ class \nodoc\ iso _PersistentMapOfIdentityTest is UnitTest
             }),
           Generators.u8())
         where to = 100)
-    let sample = gen.generate_value(rnd)?
+    let sample = gen.generate(rnd)?
     h.assert_true(sample.size() <= 1)
 
 class \nodoc\ iso _PersistentMapIsOfIdentityTest is UnitTest
@@ -2083,7 +1525,7 @@ class \nodoc\ iso _PersistentMapIsOfIdentityTest is UnitTest
           Generators.unit[String]("the highlander"),
           Generators.u8())
         where to = 100)
-    let sample = gen.generate_value(rnd)?
+    let sample = gen.generate(rnd)?
     h.assert_true(sample.size() <= 1)
 
 class \nodoc\ iso _PersistentMapOfEmptyTest is UnitTest
@@ -2097,7 +1539,7 @@ class \nodoc\ iso _PersistentMapOfEmptyTest is UnitTest
           Generators.u8())
         where to = 0)
     let rnd = Randomness(Time.millis())
-    let sample = gen.generate_value(rnd)?
+    let sample = gen.generate(rnd)?
     h.assert_eq[USize](sample.size(), 0, "non-empty map created")
 
 class \nodoc\ iso _PersistentMapOfMaxTest is UnitTest
@@ -2112,7 +1554,7 @@ class \nodoc\ iso _PersistentMapOfMaxTest is UnitTest
             Generators.u8(),
             Generators.u8())
           where to = size)
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(sample.size() <= size, "generated map is too big")
     end
 
@@ -2128,39 +1570,10 @@ class \nodoc\ iso _PersistentMapOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty map created with from = 1")
-    end
-
-class \nodoc\ iso _PersistentMapOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/persistent_map_of_min_shrink"
-
-  fun apply(h: TestHelper) ? =>
-    let gen =
-      Generators.persistent_map_of[String, I64](
-        Generators.zip2[String, I64](
-          Generators.u16().map[String^]({(u: U16): String^ =>
-            u.string()
-          }),
-          Generators.i64(-10, 10))
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match gen.generate(rnd)?
-    | (let sample: persistent.Map[String, I64],
-      let shrinks: Iterator[persistent.Map[String, I64]^])
-    =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated map has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk map has fewer than 5 elements")
-      end
-    else
-      h.fail("persistent_map_of did not produce shrinks")
     end
 
 class \nodoc\ iso _PersistentMapIsOfEmptyTest is UnitTest
@@ -2174,7 +1587,7 @@ class \nodoc\ iso _PersistentMapIsOfEmptyTest is UnitTest
           Generators.u8())
         where to = 0)
     let rnd = Randomness(Time.millis())
-    let sample = gen.generate_value(rnd)?
+    let sample = gen.generate(rnd)?
     h.assert_eq[USize](sample.size(), 0, "non-empty MapIs created")
 
 class \nodoc\ iso _PersistentMapIsOfMaxTest is UnitTest
@@ -2189,7 +1602,7 @@ class \nodoc\ iso _PersistentMapIsOfMaxTest is UnitTest
             Generators.u8(),
             Generators.u8())
           where to = size)
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(sample.size() <= size, "generated MapIs is too big")
     end
 
@@ -2205,37 +1618,672 @@ class \nodoc\ iso _PersistentMapIsOfMinTest is UnitTest
         where from = 1)
     let rnd = Randomness(Time.millis())
     for i in Range(0, 100) do
-      let sample = gen.generate_value(rnd)?
+      let sample = gen.generate(rnd)?
       h.assert_true(
         sample.size() >= 1,
         "empty MapIs created with from = 1")
     end
 
-class \nodoc\ iso _PersistentMapIsOfMinShrinkTest is UnitTest
-  fun name(): String => "Gen/persistent_map_is_of_min_shrink"
+// --- Shrinking tests ---
+class \nodoc\ iso _ShrinkIntToMinProperty is Property1[U32]
+  fun name(): String => "shrink/int_to_min/property"
+
+  fun gen(): Generator[U32] => Generators.u32(0, 1000)
+
+  fun ref property(sample: U32, h: PropertyHelper) =>
+    h.assert_eq[U32](sample, U32(0))
+
+class \nodoc\ iso _ShrinkIntToMinTest is UnitTest
+  """
+  Any non-zero U32 fails the property. The shrinker should reduce it to 1.
+  """
+  fun name(): String => "shrink/int_to_min"
+
+  fun apply(h: TestHelper) =>
+    let property = recover iso _ShrinkIntToMinProperty end
+    let params =
+      PropertyParams(where num_samples' = 100,
+        max_shrink_reductions' = 100, seed' = 42)
+
+    h.long_test(params.timeout)
+
+    let notify =
+      object val is PropertyResultNotify
+        fun fail(msg: String) =>
+          if msg.contains("Property failed for sample 1 ") then
+            h.complete(true)
+          else
+            h.fail("expected shrunk sample to be 1, got: " + msg)
+            h.complete(false)
+          end
+
+        fun complete(success: Bool) =>
+          if success then
+            h.fail("property should have failed")
+            h.complete(false)
+          end
+      end
+    let logger = _UnitTestPropertyLogger(h)
+
+    let runner =
+      PropertyRunner[U32](
+        consume property,
+        params,
+        notify,
+        logger,
+        h.env)
+    runner.run()
+
+class \nodoc\ iso _ShrinkIntAboveThresholdProperty is Property1[U32]
+  fun name(): String => "shrink/int_above_threshold/property"
+
+  fun gen(): Generator[U32] => Generators.u32(0, 1000)
+
+  fun ref property(sample: U32, h: PropertyHelper) =>
+    h.assert_true(sample <= 5)
+
+class \nodoc\ iso _ShrinkIntAboveThresholdTest is UnitTest
+  """
+  U32 values above 5 fail. The shrinker should reduce to 6.
+  """
+  fun name(): String => "shrink/int_above_threshold"
+
+  fun apply(h: TestHelper) =>
+    let property = recover iso _ShrinkIntAboveThresholdProperty end
+    let params =
+      PropertyParams(where num_samples' = 100,
+        max_shrink_reductions' = 100, seed' = 42)
+
+    h.long_test(params.timeout)
+
+    let notify =
+      object val is PropertyResultNotify
+        fun fail(msg: String) =>
+          if msg.contains("Property failed for sample 6 ") then
+            h.complete(true)
+          else
+            h.fail("expected shrunk sample to be 6, got: " + msg)
+            h.complete(false)
+          end
+
+        fun complete(success: Bool) =>
+          if success then
+            h.fail("property should have failed")
+            h.complete(false)
+          end
+      end
+    let logger = _UnitTestPropertyLogger(h)
+
+    let runner =
+      PropertyRunner[U32](
+        consume property,
+        params,
+        notify,
+        logger,
+        h.env)
+    runner.run()
+
+class \nodoc\ iso _ShrinkArrayToMinProperty is Property1[Array[U8]]
+  fun name(): String => "shrink/array_to_min/property"
+
+  fun gen(): Generator[Array[U8]] =>
+    Generators.array_of[U8](Generators.u8() where from = 1, to = 20)
+
+  fun ref property(sample: Array[U8], h: PropertyHelper) =>
+    h.assert_true(sample.size() == 0)
+
+class \nodoc\ iso _ShrinkArrayToMinTest is UnitTest
+  """
+  Any non-empty array fails. The shrinker should reduce it to a 1-element
+  array with the element shrunk toward 0.
+  """
+  fun name(): String => "shrink/array_to_min"
+
+  fun apply(h: TestHelper) =>
+    let property = recover iso _ShrinkArrayToMinProperty end
+    let params =
+      PropertyParams(where num_samples' = 100,
+        max_shrink_reductions' = 100, seed' = 42)
+
+    h.long_test(params.timeout)
+
+    let notify =
+      object val is PropertyResultNotify
+        fun fail(msg: String) =>
+          if msg.contains("Property failed for sample [0] ") then
+            h.complete(true)
+          else
+            h.fail("expected shrunk sample to be [0], got: " + msg)
+            h.complete(false)
+          end
+
+        fun complete(success: Bool) =>
+          if success then
+            h.fail("property should have failed")
+            h.complete(false)
+          end
+      end
+    let logger = _UnitTestPropertyLogger(h)
+
+    let runner =
+      PropertyRunner[Array[U8]](
+        consume property,
+        params,
+        notify,
+        logger,
+        h.env)
+    runner.run()
+
+// --- Filter predicate preservation test ---
+class \nodoc\ iso _ShrinkFilterPreservationProperty is Property1[U32]
+  """
+  Generate even U32 values via filter. Property fails for values > 10.
+  The shrinker must produce the smallest even value above the threshold: 12.
+  """
+  fun name(): String => "shrink/filter_preservation/property"
+
+  fun gen(): Generator[U32] =>
+    Generators.u32(0, 1000)
+      .filter({(u: U32): (U32^, Bool) => (u, (u % 2) == 0) })
+
+  fun ref property(sample: U32, h: PropertyHelper) =>
+    h.assert_true(sample <= 10)
+
+class \nodoc\ iso _ShrinkFilterPreservationTest is UnitTest
+  """
+  Filtered generator that only produces even values. Values above 10 fail.
+  The shrinker should find 12, not an odd number.
+  """
+  fun name(): String => "shrink/filter_preservation"
+
+  fun apply(h: TestHelper) =>
+    let property = recover iso _ShrinkFilterPreservationProperty end
+    let params =
+      PropertyParams(where num_samples' = 100,
+        max_shrink_reductions' = 100, seed' = 42)
+
+    h.long_test(params.timeout)
+
+    let notify =
+      object val is PropertyResultNotify
+        fun fail(msg: String) =>
+          if msg.contains("Property failed for sample 12 ") then
+            h.complete(true)
+          else
+            h.fail("expected shrunk sample to be 12, got: " + msg)
+            h.complete(false)
+          end
+
+        fun complete(success: Bool) =>
+          if success then
+            h.fail("property should have failed")
+            h.complete(false)
+          end
+      end
+    let logger = _UnitTestPropertyLogger(h)
+
+    let runner =
+      PropertyRunner[U32](
+        consume property,
+        params,
+        notify,
+        logger,
+        h.env)
+    runner.run()
+
+// --- flat_map outer+inner shrinking test ---
+class \nodoc\ iso _ShrinkFlatMapProperty is Property1[(U32, U32)]
+  """
+  Use flat_map so the outer value determines the inner generator's range.
+  Property fails when the product exceeds 50. Both values should shrink.
+  """
+  fun name(): String => "shrink/flat_map/property"
+
+  fun gen(): Generator[(U32, U32)] =>
+    Generators.u32(1, 100)
+      .flat_map[(U32, U32)](
+        {(outer: U32): Generator[(U32, U32)] =>
+          Generators.map2[U32, U32, (U32, U32)](
+            Generators.unit[U32](outer),
+            Generators.u32(1, 100),
+            {(a: U32, b: U32): (U32, U32) => (a, b) })
+        })
+
+  fun ref property(sample: (U32, U32), h: PropertyHelper) =>
+    h.assert_true((sample._1 * sample._2) <= 50)
+
+class \nodoc\ iso _ShrinkFlatMapTest is UnitTest
+  """
+  flat_map: outer U32 determines inner range. Product > 50 fails.
+  Both outer and inner should shrink toward the boundary.
+  """
+  fun name(): String => "shrink/flat_map"
+
+  fun apply(h: TestHelper) =>
+    let property = recover iso _ShrinkFlatMapProperty end
+    let params =
+      PropertyParams(where num_samples' = 100,
+        max_shrink_reductions' = 200, seed' = 42)
+
+    h.long_test(params.timeout)
+
+    let notify =
+      object val is PropertyResultNotify
+        fun fail(msg: String) =>
+          if msg.contains("Property failed for sample (1, 51) ") then
+            h.complete(true)
+          else
+            h.fail(
+              "expected shrunk sample to be (1, 51), got: " + msg)
+            h.complete(false)
+          end
+
+        fun complete(success: Bool) =>
+          if success then
+            h.fail("property should have failed")
+            h.complete(false)
+          end
+      end
+    let logger = _UnitTestPropertyLogger(h)
+
+    let runner =
+      PropertyRunner[(U32, U32)](
+        consume property,
+        params,
+        notify,
+        logger,
+        h.env)
+    runner.run()
+
+// --- Replay determinism test ---
+class \nodoc\ iso _ReplayDeterminismTest is UnitTest
+  """
+  Record choices during generation, then replay and verify the same
+  value is produced.
+  """
+  fun name(): String => "replay/determinism"
+
+  fun apply(h: TestHelper) ? =>
+    let gen = Generators.u32(0, 1000)
+    let rnd = Randomness(42)
+    rnd._start_recording()
+    let v1 = gen.generate(rnd)?
+    let choices = rnd._get_choices()
+
+    let rnd2 = Randomness(0)
+    rnd2._replay(choices)
+    let v2 = gen.generate(rnd2)?
+
+    h.assert_eq[U32](v1, v2)
+
+// --- Boolean-per-element structure test ---
+class \nodoc\ iso _BooleanPerElementStructureTest is UnitTest
+  """
+  Verify that array_of records boolean choices for element continuation
+  and that spans are created for each element.
+  """
+  fun name(): String => "structure/boolean_per_element"
 
   fun apply(h: TestHelper) ? =>
     let gen =
-      Generators.persistent_map_is_of[String, I64](
-        Generators.zip2[String, I64](
-          Generators.u16().map[String^]({(u: U16): String^ =>
-            u.string()
-          }),
-          Generators.i64(-10, 10))
-        where from = 5)
-    let rnd = Randomness(Time.millis())
-    match gen.generate(rnd)?
-    | (let sample: persistent.MapIs[String, I64],
-      let shrinks: Iterator[persistent.MapIs[String, I64]^])
-    =>
-      h.assert_true(
-        sample.size() >= 5,
-        "generated MapIs has fewer than 5 elements")
-      for shrunk in shrinks do
-        h.assert_true(
-          shrunk.size() >= 5,
-          "shrunk MapIs has fewer than 5 elements")
+      Generators.array_of[U8](Generators.u8() where from = 0, to = 5)
+    let rnd = Randomness(42)
+    rnd._start_recording()
+    let arr = gen.generate(rnd)?
+    let choices: Array[_Choice val] val = rnd._get_choices()
+    let spans: Array[_Span val] val = rnd._get_spans()
+
+    var bool_count: USize = 0
+    var int_count: USize = 0
+    for choice in choices.values() do
+      match choice
+      | let _: _BoolChoice => bool_count = bool_count + 1
+      | let _: _IntChoice => int_count = int_count + 1
       end
+    end
+
+    // One bool per element plus one terminating false (unless max was hit)
+    h.assert_true(
+      bool_count >= arr.size(),
+      "expected at least " + arr.size().string() +
+        " bool choices, got " + bool_count.string())
+
+    // Each element draws exactly one integer value
+    h.assert_eq[USize](int_count, arr.size())
+
+    // One span per element, plus the terminating false also opens a span
+    h.assert_true(
+      spans.size() >= arr.size(),
+      "expected at least " + arr.size().string() +
+        " spans, got " + spans.size().string())
+
+    // All spans should be SpanElement
+    for span in spans.values() do
+      h.assert_true(
+        span.label is SpanElement,
+        "expected SpanElement label, got " + span.label.string())
+    end
+
+// --- Shrinker unit tests with hand-constructed choice sequences ---
+class \nodoc\ iso _ShrinkerDeleteSpanTest is UnitTest
+  """
+  Construct a choice sequence with a span, verify that the delete-spans
+  pass produces a candidate with the span's choices removed.
+  """
+  fun name(): String => "shrinker/delete_span"
+
+  fun apply(h: TestHelper) ? =>
+    let choices: Array[_Choice val] val =
+      [_IntChoice(10, 0, 100, 0); _IntChoice(20, 0, 100, 0)]
+    let spans: Array[_Span val] val =
+      [_Span(0, 2, SpanShuffle, false)]
+    let shrinker = _Shrinker(choices, spans)
+    let candidates = shrinker.candidates()
+
+    h.assert_true(candidates.has_next())
+    let candidate = candidates.next()?
+    h.assert_eq[USize](candidate.size(), 0)
+
+class \nodoc\ iso _ShrinkerLowerChoicesTest is UnitTest
+  """
+  A single IntChoice with value 100 and shrink_towards 0. The lower-choices
+  pass should produce candidates approaching 0 via binary search.
+  """
+  fun name(): String => "shrinker/lower_choices"
+
+  fun apply(h: TestHelper) ? =>
+    let choices: Array[_Choice val] val =
+      [_IntChoice(100, 0, 100, 0)]
+    let spans: Array[_Span val] val =
+      recover val Array[_Span val] end
+    let shrinker = _Shrinker(choices, spans)
+    let candidates = shrinker.candidates()
+
+    // First candidate from lower_choices: mid = 0 + (100 - 0) / 2 = 50
+    h.assert_true(candidates.has_next())
+    let c1 = candidates.next()?
+    h.assert_eq[USize](c1.size(), 1)
+    match c1(0)?
+    | let ic: _IntChoice =>
+      h.assert_eq[I128](ic.value, 50)
     else
-      h.fail("persistent_map_is_of did not produce shrinks")
+      h.fail("expected IntChoice")
+    end
+
+class \nodoc\ iso _ShrinkerConvergenceLoopTest is UnitTest
+  """
+  Verify that the convergence loop restarts passes after a successful
+  reduction. Set up choices where pass 2 (lower) succeeds, which should
+  cause passes to restart from 1.
+  """
+  fun name(): String => "shrinker/convergence_loop"
+
+  fun apply(h: TestHelper) ? =>
+    let choices: Array[_Choice val] val =
+      [_IntChoice(100, 0, 100, 0)]
+    let spans: Array[_Span val] val =
+      recover val Array[_Span val] end
+    let shrinker =
+      _Shrinker(choices, spans where max_reductions = 10)
+    let candidates = shrinker.candidates()
+
+    // Get and accept the first lower-choices candidate (50)
+    h.assert_true(candidates.has_next())
+    let c1 = candidates.next()?
+    let new_spans: Array[_Span val] val =
+      recover val Array[_Span val] end
+    shrinker.accept(c1, new_spans)
+
+    // The convergence loop should restart and produce more candidates
+    // (pass 2 again with the new baseline of 50 -> mid = 25)
+    var found_25 = false
+    var count: USize = 0
+    while candidates.has_next() and (count < 20) do
+      let c = candidates.next()?
+      match try c(0)? end
+      | let ic: _IntChoice =>
+        if ic.value == 25 then
+          found_25 = true
+          break
+        end
+      end
+      count = count + 1
+    end
+    h.assert_true(found_25, "convergence loop should produce value 25")
+
+class \nodoc\ iso _ShrinkerRedistributeTest is UnitTest
+  """
+  Two adjacent IntChoices with values (80, 20) and shrink_towards 0.
+  The redistribute pass should shift weight from the later toward the
+  earlier choice's shrink target, producing (0, 100).
+  """
+  fun name(): String => "shrinker/redistribute"
+
+  fun apply(h: TestHelper) ? =>
+    let choices: Array[_Choice val] val =
+      [_IntChoice(80, 0, 100, 0); _IntChoice(20, 0, 100, 0)]
+    let spans: Array[_Span val] val =
+      recover val Array[_Span val] end
+    let shrinker = _Shrinker(choices, spans)
+    let candidates = shrinker.candidates()
+
+    var found = false
+    var count: USize = 0
+    while candidates.has_next() and (count < 50) do
+      let c = candidates.next()?
+      if c.size() == 2 then
+        match (c(0)?, c(1)?)
+        | (let a: _IntChoice, let b: _IntChoice) =>
+          if (a.value == 0) and (b.value == 100) then
+            found = true
+            break
+          end
+        end
+      end
+      count = count + 1
+    end
+    h.assert_true(found, "redistribute should produce (0, 100)")
+
+class \nodoc\ iso _ShrinkerShortenTest is UnitTest
+  """
+  A 4-element choice sequence should produce progressively shorter prefixes.
+  """
+  fun name(): String => "shrinker/shorten"
+
+  fun apply(h: TestHelper) ? =>
+    let choices: Array[_Choice val] val =
+      [ _IntChoice(10, 0, 100, 0)
+        _IntChoice(20, 0, 100, 0)
+        _IntChoice(30, 0, 100, 0)
+        _IntChoice(40, 0, 100, 0) ]
+    let spans: Array[_Span val] val =
+      recover val Array[_Span val] end
+    let shrinker = _Shrinker(choices, spans where max_reductions = 1)
+    let iter = _ShortenIter(shrinker)
+
+    h.assert_true(iter.has_next())
+    let c1 = iter.next()?
+    h.assert_eq[USize](c1.size(), 3)
+
+    h.assert_true(iter.has_next())
+    let c2 = iter.next()?
+    h.assert_eq[USize](c2.size(), 1)
+
+    h.assert_false(iter.has_next())
+
+class \nodoc\ iso _ShrinkerSortSpansTest is UnitTest
+  """
+  Two adjacent spans where the first is shortlex-greater. The sort-spans
+  pass should produce a candidate with the spans swapped.
+  """
+  fun name(): String => "shrinker/sort_spans"
+
+  fun apply(h: TestHelper) ? =>
+    // Span 1: choices 0..2 (50, 60), Span 2: choices 2..4 (10, 20)
+    // Span 1 is lex-greater, so sort swaps to [10, 20, 50, 60].
+    let choices: Array[_Choice val] val =
+      [ _IntChoice(50, 0, 100, 0)
+        _IntChoice(60, 0, 100, 0)
+        _IntChoice(10, 0, 100, 0)
+        _IntChoice(20, 0, 100, 0) ]
+    let spans: Array[_Span val] val =
+      [_Span(0, 2, SpanElement, false); _Span(2, 4, SpanElement, false)]
+    let shrinker = _Shrinker(choices, spans where max_reductions = 1)
+    let iter = _SortSpansIter(shrinker)
+
+    h.assert_true(iter.has_next())
+    let candidate = iter.next()?
+    h.assert_eq[USize](candidate.size(), 4)
+
+    match candidate(0)?
+    | let ic: _IntChoice => h.assert_eq[I128](ic.value, 10)
+    else h.fail("expected IntChoice at 0")
+    end
+    match candidate(1)?
+    | let ic: _IntChoice => h.assert_eq[I128](ic.value, 20)
+    else h.fail("expected IntChoice at 1")
+    end
+    match candidate(2)?
+    | let ic: _IntChoice => h.assert_eq[I128](ic.value, 50)
+    else h.fail("expected IntChoice at 2")
+    end
+    match candidate(3)?
+    | let ic: _IntChoice => h.assert_eq[I128](ic.value, 60)
+    else h.fail("expected IntChoice at 3")
+    end
+
+class \nodoc\ iso _ShrinkerBoolLoweringTest is UnitTest
+  """
+  A BoolChoice with value true should be lowered to false by the
+  lower-choices pass.
+  """
+  fun name(): String => "shrinker/bool_lowering"
+
+  fun apply(h: TestHelper) ? =>
+    let choices: Array[_Choice val] val =
+      [_BoolChoice(true)]
+    let spans: Array[_Span val] val =
+      recover val Array[_Span val] end
+    let shrinker = _Shrinker(choices, spans)
+    let iter = _LowerChoicesIter(shrinker)
+
+    h.assert_true(iter.has_next())
+    let candidate = iter.next()?
+    h.assert_eq[USize](candidate.size(), 1)
+    match candidate(0)?
+    | let bc: _BoolChoice =>
+      h.assert_false(bc.value)
+    else
+      h.fail("expected BoolChoice")
+    end
+
+class \nodoc\ iso _ShrinkerForcedBoolSkipTest is UnitTest
+  """
+  A forced BoolChoice should be skipped by the lower-choices pass.
+  """
+  fun name(): String => "shrinker/forced_bool_skip"
+
+  fun apply(h: TestHelper) =>
+    let choices: Array[_Choice val] val =
+      [_BoolChoice(true, true)]
+    let spans: Array[_Span val] val =
+      recover val Array[_Span val] end
+    let shrinker = _Shrinker(choices, spans)
+    let iter = _LowerChoicesIter(shrinker)
+
+    h.assert_false(iter.has_next())
+
+class \nodoc\ iso _ShrinkerLowerU128Test is UnitTest
+  """
+  Binary search on a U128Choice should produce a midpoint candidate.
+  """
+  fun name(): String => "shrinker/lower_u128"
+
+  fun apply(h: TestHelper) ? =>
+    let choices: Array[_Choice val] val =
+      [_U128Choice(U128(100), 0, 100, 0)]
+    let spans: Array[_Span val] val =
+      recover val Array[_Span val] end
+    let shrinker = _Shrinker(choices, spans)
+    let iter = _LowerChoicesIter(shrinker)
+
+    h.assert_true(iter.has_next())
+    let candidate = iter.next()?
+    h.assert_eq[USize](candidate.size(), 1)
+    match candidate(0)?
+    | let uc: _U128Choice =>
+      h.assert_eq[U128](uc.value, 50)
+    else
+      h.fail("expected U128Choice")
+    end
+
+class \nodoc\ iso _ShrinkerDeleteDiscardedSpanTest is UnitTest
+  """
+  Discarded spans should be skipped by the delete-spans pass.
+  Only the non-discarded span produces a deletion candidate.
+  """
+  fun name(): String => "shrinker/delete_discarded_span"
+
+  fun apply(h: TestHelper) ? =>
+    let choices: Array[_Choice val] val =
+      [ _IntChoice(10, 0, 100, 0)
+        _IntChoice(20, 0, 100, 0)
+        _IntChoice(30, 0, 100, 0)
+        _IntChoice(40, 0, 100, 0) ]
+    let spans: Array[_Span val] val =
+      [ _Span(0, 2, SpanFilter, true)
+        _Span(2, 4, SpanElement, false) ]
+    let shrinker = _Shrinker(choices, spans)
+    let iter = _DeleteSpansIter(shrinker)
+
+    h.assert_true(iter.has_next())
+    let candidate = iter.next()?
+    // Only the non-discarded span (indices 2..4) is deleted,
+    // leaving choices from the discarded span.
+    h.assert_eq[USize](candidate.size(), 2)
+    match candidate(0)?
+    | let ic: _IntChoice => h.assert_eq[I128](ic.value, 10)
+    else h.fail("expected IntChoice at 0")
+    end
+
+    h.assert_false(iter.has_next())
+
+class \nodoc\ iso _ShrinkerSortSpansLengthTest is UnitTest
+  """
+  Two adjacent spans of different lengths where the first is longer.
+  Shortlex ordering treats the longer span as greater regardless of values.
+  """
+  fun name(): String => "shrinker/sort_spans_length"
+
+  fun apply(h: TestHelper) ? =>
+    // Span 1: 3 choices (0..3), Span 2: 2 choices (3..5).
+    // Span 1 is longer so shortlex-greater; sort swaps them.
+    let choices: Array[_Choice val] val =
+      [ _IntChoice(1, 0, 100, 0)
+        _IntChoice(2, 0, 100, 0)
+        _IntChoice(3, 0, 100, 0)
+        _IntChoice(4, 0, 100, 0)
+        _IntChoice(5, 0, 100, 0) ]
+    let spans: Array[_Span val] val =
+      [_Span(0, 3, SpanElement, false); _Span(3, 5, SpanElement, false)]
+    let shrinker = _Shrinker(choices, spans where max_reductions = 1)
+    let iter = _SortSpansIter(shrinker)
+
+    h.assert_true(iter.has_next())
+    let candidate = iter.next()?
+    h.assert_eq[USize](candidate.size(), 5)
+
+    // After swap: choices from span 2 (4, 5) come first,
+    // then choices from span 1 (1, 2, 3).
+    match candidate(0)?
+    | let ic: _IntChoice => h.assert_eq[I128](ic.value, 4)
+    else h.fail("expected IntChoice at 0")
+    end
+    match candidate(1)?
+    | let ic: _IntChoice => h.assert_eq[I128](ic.value, 5)
+    else h.fail("expected IntChoice at 1")
+    end
+    match candidate(2)?
+    | let ic: _IntChoice => h.assert_eq[I128](ic.value, 1)
+    else h.fail("expected IntChoice at 2")
     end

--- a/packages/pony_check/_shrinker.pony
+++ b/packages/pony_check/_shrinker.pony
@@ -1,0 +1,586 @@
+class ref _Shrinker
+  """
+  Given a failing choice sequence, produces candidate sequences that are
+  shortlex-smaller and attempts to replay the generator against each one.
+  If replay succeeds and the property still fails, the candidate becomes
+  the new baseline. Repeats until no more reductions are found or the
+  budget is exhausted.
+
+  Shrinking passes (in order):
+  1. Delete spans — remove entire structural units
+  2. Lower choices toward shrink_towards — binary search each choice
+  3. Redistribute adjacent int choices — shift weight toward earlier choice
+  4. Shorten sequence — truncate trailing choices
+  5. Sort adjacent spans — swap out-of-order span pairs
+  """
+  var _choices: Array[_Choice val] val
+  var _spans: Array[_Span val] val
+  var _reductions: USize = 0
+  let _max_reductions: USize
+
+  new ref create(
+    choices: Array[_Choice val] val,
+    spans: Array[_Span val] val,
+    max_reductions: USize = 100)
+  =>
+    _choices = choices
+    _spans = spans
+    _max_reductions = max_reductions
+
+  fun ref candidates(): Iterator[Array[_Choice val] val] =>
+    """
+    Return an iterator that lazily produces candidate choice sequences.
+    Each accepted candidate (via `accept`) updates the baseline.
+    """
+    _ShrinkCandidates(this)
+
+  fun ref accept(
+    choices: Array[_Choice val] val,
+    spans: Array[_Span val] val)
+  =>
+    _choices = choices
+    _spans = spans
+    _reductions = _reductions + 1
+
+  fun ref budget_remaining(): Bool =>
+    _reductions < _max_reductions
+
+  fun reductions(): USize =>
+    _reductions
+
+  fun current_choices(): Array[_Choice val] val =>
+    _choices
+
+  fun current_spans(): Array[_Span val] val =>
+    _spans
+
+class ref _ShrinkCandidates is Iterator[Array[_Choice val] val]
+  let _shrinker: _Shrinker ref
+  var _pass: USize = 0
+  var _pass_iter: Iterator[Array[_Choice val] val] = _EmptyCandidates
+  var _cycle_start_reductions: USize = 0
+
+  new ref create(shrinker: _Shrinker ref) =>
+    _shrinker = shrinker
+    _cycle_start_reductions = shrinker.reductions()
+    _advance_pass()
+
+  fun ref has_next(): Bool =>
+    if not _shrinker.budget_remaining() then return false end
+    if _pass_iter.has_next() then return true end
+    _advance_pass()
+    _pass_iter.has_next()
+
+  fun ref next(): Array[_Choice val] val ? =>
+    if not has_next() then error end
+    _pass_iter.next()?
+
+  fun ref _advance_pass() =>
+    while _pass < 5 do
+      _pass = _pass + 1
+      _pass_iter =
+        match _pass
+        | 1 => _delete_spans_pass()
+        | 2 => _lower_choices_pass()
+        | 3 => _redistribute_pass()
+        | 4 => _shorten_pass()
+        | 5 => _sort_spans_pass()
+        else
+          _EmptyCandidates
+        end
+      if _pass_iter.has_next() then return end
+    end
+    if _shrinker.reductions() > _cycle_start_reductions then
+      _pass = 0
+      _cycle_start_reductions = _shrinker.reductions()
+      _advance_pass()
+    end
+
+  fun ref _delete_spans_pass(): Iterator[Array[_Choice val] val] =>
+    _DeleteSpansIter(_shrinker)
+
+  fun ref _lower_choices_pass(): Iterator[Array[_Choice val] val] =>
+    _LowerChoicesIter(_shrinker)
+
+  fun ref _redistribute_pass(): Iterator[Array[_Choice val] val] =>
+    _RedistributeIter(_shrinker)
+
+  fun ref _shorten_pass(): Iterator[Array[_Choice val] val] =>
+    _ShortenIter(_shrinker)
+
+  fun ref _sort_spans_pass(): Iterator[Array[_Choice val] val] =>
+    _SortSpansIter(_shrinker)
+
+class ref _EmptyCandidates is Iterator[Array[_Choice val] val]
+  fun ref has_next(): Bool => false
+  fun ref next(): Array[_Choice val] val ? => error
+
+class ref _DeleteSpansIter is Iterator[Array[_Choice val] val]
+  """
+  Try deleting each non-discarded span. Produces one candidate per span,
+  with the span's choices removed from the sequence.
+  """
+  let _shrinker: _Shrinker ref
+  var _idx: USize = 0
+
+  new ref create(shrinker: _Shrinker ref) =>
+    _shrinker = shrinker
+
+  fun ref has_next(): Bool =>
+    _skip_invalid()
+    _idx < _shrinker.current_spans().size()
+
+  fun ref next(): Array[_Choice val] val ? =>
+    if not has_next() then error end
+    let span = _shrinker.current_spans()(_idx)?
+    _idx = _idx + 1
+    _delete_span(span)?
+
+  fun ref _skip_invalid() =>
+    try
+      let spans = _shrinker.current_spans()
+      while _idx < spans.size() do
+        let span = spans(_idx)?
+        if span.discarded or (span.start_index == span.end_index) then
+          _idx = _idx + 1
+        else
+          break
+        end
+      end
+    end
+
+  fun _delete_span(span: _Span val): Array[_Choice val] val ? =>
+    let choices = _shrinker.current_choices()
+    if span.end_index > choices.size() then error end
+    let result =
+      recover iso
+        Array[_Choice val](
+          choices.size() - (span.end_index - span.start_index))
+      end
+    var i: USize = 0
+    while i < span.start_index do
+      result.push(choices(i)?)
+      i = i + 1
+    end
+    i = span.end_index
+    while i < choices.size() do
+      result.push(choices(i)?)
+      i = i + 1
+    end
+    consume result
+
+class ref _LowerChoicesIter is Iterator[Array[_Choice val] val]
+  """
+  For each IntChoice or U128Choice, binary-search its value toward
+  shrink_towards. For each BoolChoice with value true, try false.
+
+  After producing a candidate, the iterator checks whether the shrinker's
+  baseline changed (candidate accepted) or stayed the same (rejected).
+  On acceptance: hi = mid (search lower). On rejection: lo = mid (search
+  higher toward the boundary where the property starts failing).
+  """
+  let _shrinker: _Shrinker ref
+  var _idx: USize = 0
+  var _lo: I128 = 0
+  var _hi: I128 = 0
+  var _lo_u: U128 = 0
+  var _hi_u: U128 = 0
+  var _active: Bool = false
+  var _pending_mid: (I128 | None) = None
+  var _pending_mid_u: (U128 | None) = None
+
+  new ref create(shrinker: _Shrinker ref) =>
+    _shrinker = shrinker
+
+  fun ref has_next(): Bool =>
+    _resolve_pending()
+    if _active then return true end
+    _advance()
+    _active
+
+  fun ref next(): Array[_Choice val] val ? =>
+    if not has_next() then error end
+    let choices = _shrinker.current_choices()
+    let choice = choices(_idx)?
+
+    match choice
+    | let ic: _IntChoice =>
+      let mid = _lo + ((_hi - _lo) / 2)
+      let candidate =
+        _replace_choice(
+          _idx,
+          _IntChoice(mid, ic.min, ic.max, ic.shrink_towards))?
+      if mid == _lo then
+        _active = false
+        _idx = _idx + 1
+        _pending_mid = None
+      else
+        _pending_mid = mid
+      end
+      candidate
+    | let uc: _U128Choice =>
+      let mid = _lo_u + ((_hi_u - _lo_u) / 2)
+      let candidate =
+        _replace_choice(
+          _idx,
+          _U128Choice(mid, uc.min, uc.max, uc.shrink_towards))?
+      if mid == _lo_u then
+        _active = false
+        _idx = _idx + 1
+        _pending_mid_u = None
+      else
+        _pending_mid_u = mid
+      end
+      candidate
+    | let bc: _BoolChoice =>
+      _active = false
+      _idx = _idx + 1
+      _pending_mid = None
+      _pending_mid_u = None
+      _replace_choice(_idx - 1, _BoolChoice(false))?
+    else
+      _active = false
+      _idx = _idx + 1
+      _pending_mid = None
+      _pending_mid_u = None
+      error
+    end
+
+  fun ref _resolve_pending() =>
+    match _pending_mid
+    | let mid: I128 =>
+      try
+        let choices = _shrinker.current_choices()
+        match choices(_idx)?
+        | let ic: _IntChoice =>
+          if ic.value == mid then
+            _hi = mid
+          else
+            _lo = mid
+          end
+        end
+      end
+      _pending_mid = None
+    end
+    match _pending_mid_u
+    | let mid: U128 =>
+      try
+        let choices = _shrinker.current_choices()
+        match choices(_idx)?
+        | let uc: _U128Choice =>
+          if uc.value == mid then
+            _hi_u = mid
+          else
+            _lo_u = mid
+          end
+        end
+      end
+      _pending_mid_u = None
+    end
+
+  fun ref _advance() =>
+    try
+      let choices = _shrinker.current_choices()
+      while _idx < choices.size() do
+        match choices(_idx)?
+        | let ic: _IntChoice =>
+          if ic.value != ic.shrink_towards then
+            _lo = ic.shrink_towards
+            _hi = ic.value
+            _active = true
+            return
+          end
+        | let uc: _U128Choice =>
+          if uc.value != uc.shrink_towards then
+            _lo_u = uc.shrink_towards
+            _hi_u = uc.value
+            _active = true
+            return
+          end
+        | let bc: _BoolChoice =>
+          if bc.value and (not bc.forced) then
+            _active = true
+            return
+          end
+        end
+        _idx = _idx + 1
+      end
+    end
+
+  fun _replace_choice(idx: USize, new_choice: _Choice val)
+    : Array[_Choice val] val ?
+  =>
+    let choices = _shrinker.current_choices()
+    let result = recover iso Array[_Choice val](choices.size()) end
+    var i: USize = 0
+    while i < choices.size() do
+      if i == idx then
+        result.push(new_choice)
+      else
+        result.push(choices(i)?)
+      end
+      i = i + 1
+    end
+    consume result
+
+class ref _RedistributeIter is Iterator[Array[_Choice val] val]
+  """
+  For adjacent IntChoice or U128Choice pairs, try shifting value from
+  the later toward the earlier (closer to shrink_towards for both).
+  """
+  let _shrinker: _Shrinker ref
+  var _idx: USize = 0
+
+  new ref create(shrinker: _Shrinker ref) =>
+    _shrinker = shrinker
+
+  fun ref has_next(): Bool =>
+    _skip_invalid()
+    (_idx + 1) < _shrinker.current_choices().size()
+
+  fun ref next(): Array[_Choice val] val ? =>
+    if not has_next() then error end
+    let choices = _shrinker.current_choices()
+    match (choices(_idx)?, choices(_idx + 1)?)
+    | (let ic1: _IntChoice, let ic2: _IntChoice) =>
+      _idx = _idx + 1
+      let total = ic1.value +? ic2.value
+      let new1 =
+        ic1.shrink_towards.max(ic1.min).min(ic1.max)
+          .max(total -? ic2.max).min(total -? ic2.min)
+      let new2 = total -? new1
+
+      let result = recover iso Array[_Choice val](choices.size()) end
+      var i: USize = 0
+      while i < choices.size() do
+        if i == (_idx - 1) then
+          result.push(
+            _IntChoice(new1, ic1.min, ic1.max, ic1.shrink_towards))
+        elseif i == _idx then
+          result.push(
+            _IntChoice(new2, ic2.min, ic2.max, ic2.shrink_towards))
+        else
+          result.push(choices(i)?)
+        end
+        i = i + 1
+      end
+      consume result
+    | (let uc1: _U128Choice, let uc2: _U128Choice) =>
+      _idx = _idx + 1
+      let total = uc1.value +? uc2.value
+      let new1 =
+        uc1.shrink_towards.max(uc1.min).min(uc1.max)
+          .max(
+            if total >= uc2.max then total - uc2.max
+            else U128(0)
+            end)
+          .min(total -? uc2.min)
+      let new2 = total -? new1
+
+      let result = recover iso Array[_Choice val](choices.size()) end
+      var i: USize = 0
+      while i < choices.size() do
+        if i == (_idx - 1) then
+          result.push(
+            _U128Choice(new1, uc1.min, uc1.max, uc1.shrink_towards))
+        elseif i == _idx then
+          result.push(
+            _U128Choice(new2, uc2.min, uc2.max, uc2.shrink_towards))
+        else
+          result.push(choices(i)?)
+        end
+        i = i + 1
+      end
+      consume result
+    else
+      error
+    end
+
+  fun ref _skip_invalid() =>
+    try
+      let choices = _shrinker.current_choices()
+      while (_idx + 1) < choices.size() do
+        if _can_redistribute(choices(_idx)?, choices(_idx + 1)?) then
+          return
+        end
+        _idx = _idx + 1
+      end
+      _idx = choices.size()
+    end
+
+  fun _can_redistribute(c1: _Choice val, c2: _Choice val): Bool =>
+    match (c1, c2)
+    | (let ic1: _IntChoice, let ic2: _IntChoice) =>
+      try
+        let total = ic1.value +? ic2.value
+        let new1 =
+          ic1.shrink_towards.max(ic1.min).min(ic1.max)
+            .max(total -? ic2.max).min(total -? ic2.min)
+        let new2 = total -? new1
+        (new1 != ic1.value) or (new2 != ic2.value)
+      else
+        false
+      end
+    | (let uc1: _U128Choice, let uc2: _U128Choice) =>
+      try
+        let total = uc1.value +? uc2.value
+        let new1 =
+          uc1.shrink_towards.max(uc1.min).min(uc1.max)
+            .max(
+              if total >= uc2.max then total - uc2.max
+              else U128(0)
+              end)
+            .min(total -? uc2.min)
+        let new2 = total -? new1
+        (new1 != uc1.value) or (new2 != uc2.value)
+      else
+        false
+      end
+    else
+      false
+    end
+
+class ref _ShortenIter is Iterator[Array[_Choice val] val]
+  """
+  Try progressively shorter prefixes of the choice sequence.
+  """
+  let _shrinker: _Shrinker ref
+  var _len: USize
+
+  new ref create(shrinker: _Shrinker ref) =>
+    _shrinker = shrinker
+    _len =
+      if shrinker.current_choices().size() > 0 then
+        shrinker.current_choices().size() - 1
+      else
+        0
+      end
+
+  fun ref has_next(): Bool =>
+    _len > 0
+
+  fun ref next(): Array[_Choice val] val ? =>
+    if not has_next() then error end
+    let choices = _shrinker.current_choices()
+    let result = recover iso Array[_Choice val](_len) end
+    var i: USize = 0
+    while i < _len do
+      result.push(choices(i)?)
+      i = i + 1
+    end
+    _len = _len / 2
+    consume result
+
+class ref _SortSpansIter is Iterator[Array[_Choice val] val]
+  """
+  Try swapping adjacent out-of-order span pairs. Two spans are out of
+  order when the first is shortlex-greater than the second.
+  """
+  let _shrinker: _Shrinker ref
+  var _idx: USize = 0
+
+  new ref create(shrinker: _Shrinker ref) =>
+    _shrinker = shrinker
+
+  fun ref has_next(): Bool =>
+    _skip_invalid()
+    (_idx + 1) < _shrinker.current_spans().size()
+
+  fun ref next(): Array[_Choice val] val ? =>
+    if not has_next() then error end
+    let spans = _shrinker.current_spans()
+    let s1 = spans(_idx)?
+    let s2 = spans(_idx + 1)?
+    _idx = _idx + 1
+
+    if not _is_adjacent(s1, s2) then error end
+    if not _shortlex_greater(s1, s2) then error end
+
+    _swap_spans(s1, s2)?
+
+  fun ref _skip_invalid() =>
+    try
+      let spans = _shrinker.current_spans()
+      while (_idx + 1) < spans.size() do
+        let s1 = spans(_idx)?
+        let s2 = spans(_idx + 1)?
+        if _is_adjacent(s1, s2) and _shortlex_greater(s1, s2) then
+          return
+        end
+        _idx = _idx + 1
+      end
+    end
+
+  fun _is_adjacent(s1: _Span val, s2: _Span val): Bool =>
+    s1.end_index == s2.start_index
+
+  fun _shortlex_greater(s1: _Span val, s2: _Span val): Bool =>
+    let len1 = s1.end_index - s1.start_index
+    let len2 = s2.end_index - s2.start_index
+    if len1 != len2 then
+      len1 > len2
+    else
+      _lex_greater(s1, s2)
+    end
+
+  fun _lex_greater(s1: _Span val, s2: _Span val): Bool =>
+    let choices = _shrinker.current_choices()
+    var i: USize = 0
+    let len =
+      (s1.end_index - s1.start_index).min(
+        s2.end_index - s2.start_index)
+    try
+      while i < len do
+        let c1 = choices(s1.start_index + i)?
+        let c2 = choices(s2.start_index + i)?
+        match (c1, c2)
+        | (let ic1: _IntChoice, let ic2: _IntChoice) =>
+          if ic1.value > ic2.value then return true end
+          if ic1.value < ic2.value then return false end
+        | (let bc1: _BoolChoice, let bc2: _BoolChoice) =>
+          if (bc1.value and (not bc2.value)) then return true end
+          if ((not bc1.value) and bc2.value) then return false end
+        | (let uc1: _U128Choice, let uc2: _U128Choice) =>
+          if uc1.value > uc2.value then return true end
+          if uc1.value < uc2.value then return false end
+        | (let fc1: _FloatChoice, let fc2: _FloatChoice) =>
+          if fc1.value > fc2.value then return true end
+          if fc1.value < fc2.value then return false end
+        else
+          return false
+        end
+        i = i + 1
+      end
+    end
+    false
+
+  fun ref _swap_spans(s1: _Span val, s2: _Span val)
+    : Array[_Choice val] val ?
+  =>
+    let choices = _shrinker.current_choices()
+    let result = recover iso Array[_Choice val](choices.size()) end
+
+    var i: USize = 0
+    while i < s1.start_index do
+      result.push(choices(i)?)
+      i = i + 1
+    end
+
+    i = s2.start_index
+    while i < s2.end_index do
+      result.push(choices(i)?)
+      i = i + 1
+    end
+
+    i = s1.start_index
+    while i < s1.end_index do
+      result.push(choices(i)?)
+      i = i + 1
+    end
+
+    i = s2.end_index
+    while i < choices.size() do
+      result.push(choices(i)?)
+      i = i + 1
+    end
+    consume result

--- a/packages/pony_check/_span.pony
+++ b/packages/pony_check/_span.pony
@@ -1,0 +1,59 @@
+primitive SpanShuffle
+  """
+  Shuffle operations.
+  """
+  fun string(): String iso^ => "shuffle".clone()
+
+primitive SpanFilter
+  """
+  Filter rejection spans.
+  """
+  fun string(): String iso^ => "filter".clone()
+
+primitive SpanElement
+  """
+  Collection element spans.
+  """
+  fun string(): String iso^ => "element".clone()
+
+type SpanLabel is (SpanShuffle | SpanFilter | SpanElement)
+  """
+  Labels that identify what kind of structure a span represents.
+  Pass one to `Randomness.start_span` when building custom generators.
+  """
+
+class val _Span is (Equatable[_Span] & Stringable)
+  let start_index: USize
+  let end_index: USize
+  let label: SpanLabel
+  let discarded: Bool
+
+  new val create(
+    start_index': USize,
+    end_index': USize,
+    label': SpanLabel,
+    discarded': Bool = false)
+  =>
+    start_index = start_index'
+    end_index = end_index'
+    label = label'
+    discarded = discarded'
+
+  fun eq(other: box->_Span): Bool =>
+    (start_index == other.start_index) and
+      (end_index == other.end_index) and
+      (label is other.label) and
+      (discarded == other.discarded)
+
+  fun string(): String iso^ =>
+    recover
+      String()
+        .> append("Span(")
+        .> append(start_index.string())
+        .> append("..")
+        .> append(end_index.string())
+        .> append(", ")
+        .> append(label.string())
+        .> append(if discarded then ", discarded" else "" end)
+        .> append(")")
+    end

--- a/packages/pony_check/gen_obj.pony
+++ b/packages/pony_check/gen_obj.pony
@@ -1,413 +1,176 @@
 use "collections"
 use persistent = "collections/persistent"
-use "assert"
 use "itertools"
-use "debug"
 
-type ValueAndShrink[T1] is (T1^, Iterator[T1^])
-  """
-  Possible return type for
-  [`Generator.generate`](pony_check-Generator.md#generate).
-  Represents a generated value and an Iterator of shrunken values.
-  """
-
-type GenerateResult[T2] is (T2^ | ValueAndShrink[T2])
-  """
-  Return type for
-  [`Generator.generate`](pony_check-Generator.md#generate).
-
-  Either a single value or a Tuple of a value and an Iterator
-  of shrunken values based upon this value.
-  """
-
-class CountdownIter[T: (Int & Integer[T] val) = USize] is Iterator[T]
-  """
-  Counts down from an exclusive upper bound to an inclusive lower bound.
-  """
-  var _cur: T
-  let _to: T
-
-  new create(from: T, to: T = T.min_value()) =>
-    """
-    Create am `Iterator` that counts down according to the specified arguments.
-
-    `from` is exclusive, `to` is inclusive.
-    """
-    _cur = from
-    _to = to
-
-  fun ref has_next(): Bool =>
-    _cur > _to
-
-  fun ref next(): T =>
-    let res = _cur - 1
-    _cur = res
-    res
-
-// COUPLING: GenObj combined with `type GenerateResult[T2] is (T2^ |
-// ValueAndShrink[T2])` and uses like `shuffled_iter[T](): Generator[
-// Iterator[this->T!]]` produce drifting same-def recursion chains in
-// the structural subtype check. The recursion-divergence guard in
-// is_x_sub_x (src/libponyc/type/subtype.c) bounds those chains at
-// SAME_DEF_LIMIT = 4, an empirical floor chosen to leave headroom
-// above the depths these shapes need to converge. If you restructure
-// GenObj or GenerateResult — especially to add another nesting level
-// or another self-reference — rebuild ponyc and confirm pony_check
-// still type-checks. If it doesn't, the guard's threshold is now too
-// low for this stdlib; raise SAME_DEF_LIMIT and update the comment
-// in subtype.c.
 trait box GenObj[T]
   """
-  Defines how to produce a random value for property-based testing.
+  Pure function of a `Randomness` source that produces a random value. The
+  framework records every random decision during generation, then replays
+  generators against mutated decision sequences to produce shrunk values.
   """
-  fun generate(rnd: Randomness): GenerateResult[T] ?
+  fun generate(rnd: Randomness): T^ ?
     """
-    Produce a random value of type `T`.
+    Produce a random value from the given source of randomness.
     """
-
-  fun shrink(t: T): ValueAndShrink[T] =>
-    (consume t, Poperator[T].empty())
-
-  fun generate_value(rnd: Randomness): T^ ? =>
-    """
-    Simply generate a value and ignore any possible
-    shrink values.
-    """
-    let g = this
-    match \exhaustive\ g.generate(rnd)?
-    | let t: T => consume t
-    | (let t: T, _) => consume t
-    end
-
-  fun generate_and_shrink(rnd: Randomness): ValueAndShrink[T] ? =>
-    """
-    Generate a value and also return a shrink result,
-    even if the generator does not return any when calling `generate`.
-    """
-    let g = this
-    match \exhaustive\ g.generate(rnd)?
-    | let t: T => g.shrink(consume t)
-    | (let t: T, let shrinks: Iterator[T^])=> (consume t, shrinks)
-    end
-
-  fun iter(rnd: Randomness): Iterator[GenerateResult[T]]^ =>
-    let that: GenObj[T] = this
-
-    object is Iterator[GenerateResult[T]]
-      fun ref has_next(): Bool => true
-      fun ref next(): GenerateResult[T] ? => that.generate(rnd)?
-    end
-
-  fun value_iter(rnd: Randomness): Iterator[T^] =>
-    let that: GenObj[T] = this
-
-    object is Iterator[T^]
-      fun ref has_next(): Bool => true
-      fun ref next(): T^ ? =>
-        match \exhaustive\ that.generate(rnd)?
-        | let value_only: T => consume value_only
-        | (let v: T, _) => consume v
-        end
-    end
-
-  fun value_and_shrink_iter(rnd: Randomness): Iterator[ValueAndShrink[T]] =>
-    let that: GenObj[T] = this
-
-    object is Iterator[ValueAndShrink[T]]
-      fun ref has_next(): Bool => true
-      fun ref next(): ValueAndShrink[T] ? =>
-        match \exhaustive\ that.generate(rnd)?
-        | let value_only: T => that.shrink(consume value_only)
-        | (let v: T, let shrinks: Iterator[T^]) => (consume v, consume shrinks)
-        end
-    end
 
 class box Generator[T] is GenObj[T]
   """
-  A Generator is capable of generating random values of a certain type `T`
-  given a source of `Randomness`
-  and knows how to shrink or simplify values of that type.
-
-  When testing a property against one or more given Generators,
-  those generators' `generate` methods are being called many times
-  to generate sample values that are then used to validate the property.
-
-  When a failing sample is found, the PonyCheck engine is trying to find a
-  smaller or more simple sample by shrinking it with `shrink`.
-  If the generator did not provide any shrunk samples
-  as a result of `generate`, its `shrink` method is called
-  to obtain simpler results. PonyCheck obtains more shrunken samples until
-  the property is not failing anymore.
-  The last failing sample, which is considered the most simple one,
-  is then reported to the user.
+  Wraps a `GenObj` with composition methods (`map`, `filter`, `flat_map`,
+  `union`). Shrinking is automatic through choice-sequence replay.
   """
   let _gen: GenObj[T]
 
   new create(gen: GenObj[T]) =>
     _gen = gen
 
-  fun generate(rnd: Randomness): GenerateResult[T] ? =>
+  fun generate(rnd: Randomness): T^ ? =>
     """
-    Let this generator generate a value
-    given a source of `Randomness`.
-
-    Also allow for returning a value and pre-generated shrink results
-    as a `ValueAndShrink[T]` instance, a tuple of `(T^, Seq[T])`.
-    This helps propagating shrink results through all kinds of Generator
-    combinators like `filter`, `map` and `flat_map`.
-
-    If implementing a custom `Generator` based on another one,
-    with a Generator Combinator, you should use shrunken values
-    returned by `generate` to also return shrunken values based on them.
-
-    If generating an example value is costly, it might be more efficient
-    to simply return the generated value and only shrink in big steps or do no
-    shrinking at all.
-    If generating values is lightweight, shrunken values should also be
-    returned.
+    Produce a random value from the given source of randomness.
     """
     _gen.generate(rnd)?
 
-  fun shrink(t: T): ValueAndShrink[T] =>
-    """
-    Simplify the given value.
-
-    As the returned value can also be `iso`, it needs to be consumed and
-    returned.
-
-    It is preferred to already return a `ValueAndShrink` from `generate`.
-    """
-    _gen.shrink(consume t)
-
-  fun generate_value(rnd: Randomness): T^ ? =>
-    _gen.generate_value(rnd)?
-
-  fun generate_and_shrink(rnd: Randomness): ValueAndShrink[T] ? =>
-    _gen.generate_and_shrink(rnd)?
-
   fun filter(predicate: {(T): (T^, Bool)} box): Generator[T] =>
     """
-    Apply `predicate` to the values generated by this Generator
-    and only yields values for which `predicate` returns `true`.
+    Only yield values for which `predicate` returns `true`.
 
-    Example:
-
-    ```pony
-    let even_i32s =
-      Generators.i32()
-        .filter(
-          {(t) => (t, ((t % 2) == 0)) })
-    ```
+    Rejected values are retried up to 100 times. Each attempt is
+    recorded in its own discardable span so the shrinker can remove
+    the failed draws cleanly. Errors after exhausting retries.
     """
     Generator[T](
       object is GenObj[T]
-        fun generate(rnd: Randomness): GenerateResult[T] ? =>
-          (let t: T, let shrunken: Iterator[T^]) =
-            _gen.generate_and_shrink(rnd)?
-          (let t1, let matches) = predicate(consume t)
-          if not matches then
-            generate(rnd)? // recurse, this might recurse infinitely
-          else
-            // filter the shrunken examples
-            (consume t1, _filter_shrunken(shrunken))
+        fun generate(rnd: Randomness): T^ ? =>
+          var tries: USize = 0
+          while tries < 100 do
+            rnd.start_span(SpanFilter)
+            let t: T = _gen.generate(rnd)?
+            (let t1, let matches) = predicate(consume t)
+            if matches then
+              rnd.end_span()?
+              return consume t1
+            end
+            rnd.end_span(true)?
+            tries = tries + 1
           end
-
-        fun shrink(t: T): ValueAndShrink[T] =>
-          """
-          shrink `t` using the generator this one filters upon
-          and call the filter predicate on the shrunken values
-          """
-          (let s, let shrunken: Iterator[T^]) = _gen.shrink(consume t)
-          (consume s, _filter_shrunken(shrunken))
-
-        fun _filter_shrunken(shrunken: Iterator[T^]): Iterator[T^] =>
-          Iter[T^](shrunken)
-            .filter_map[T^]({
-              (t: T): (T^| None) =>
-                match predicate(consume t)
-                | (let matching: T, true) => consume matching
-                end
-            })
+          error
       end)
 
-  fun map[U](fn: {(T): U^} box)
-    : Generator[U]
-  =>
+  fun map[U](fn: {(T): U^} box): Generator[U] =>
     """
-    Apply `fn` to each value of this iterator
-    and yield the results.
-
-    Example:
-
-    ```pony
-    let single_code_point_string_gen =
-      Generators.u32()
-        .map[String]({(u) => String.from_utf32(u) })
-    ```
+    Apply `fn` to each generated value.
     """
     Generator[U](
       object is GenObj[U]
-        fun generate(rnd: Randomness): GenerateResult[U] ? =>
-          (let generated: T, let shrunken: Iterator[T^]) =
-            _gen.generate_and_shrink(rnd)?
-
-          (fn(consume generated), _map_shrunken(shrunken))
-
-        fun shrink(u: U): ValueAndShrink[U] =>
-          """
-          We can only shrink if T is a subtype of U.
-
-          This method should in general not be called on this generator
-          as it is always returning shrinks with the call to `generate`
-          and they should be used for executing the shrink, but in case
-          a strange hierarchy of generators is used, which does not make use of
-          the pre-generated shrink results, we keep this method here.
-          """
-          match \exhaustive\ consume u
-          | let ut: T =>
-            (let uts: T, let shrunken: Iterator[T^]) = _gen.shrink(consume ut)
-            (fn(consume uts), _map_shrunken(shrunken))
-          | let uu: U =>
-            (consume uu, Poperator[U].empty())
-          end
-
-        fun _map_shrunken(shrunken: Iterator[T^]): Iterator[U^] =>
-          Iter[T^](shrunken)
-            .map[U^]({(t) => fn(consume t) })
+        fun generate(rnd: Randomness): U^ ? =>
+          fn(_gen.generate(rnd)?)
       end)
 
   fun flat_map[U](fn: {(T): Generator[U]} box): Generator[U] =>
     """
     For each value of this generator, create a generator that is then combined.
+    Both outer and inner choices are in the same sequence, so shrinking the
+    outer value works automatically.
     """
-    // TODO: enable proper shrinking:
     Generator[U](
       object is GenObj[U]
-        fun generate(rnd: Randomness): GenerateResult[U] ? =>
-          let value: T = _gen.generate_value(rnd)?
-          fn(consume value).generate_and_shrink(rnd)?
+        fun generate(rnd: Randomness): U^ ? =>
+          let outer: T = _gen.generate(rnd)?
+          fn(consume outer).generate(rnd)?
       end)
 
   fun union[U](other: Generator[U]): Generator[(T | U)] =>
     """
-    Create a generator that produces the value of this generator or the other
-    with the same probability, returning a union type of this generator and
-    the other one.
+    Produce the value of this generator or the other with equal probability.
     """
     Generator[(T | U)](
       object is GenObj[(T | U)]
-        fun generate(rnd: Randomness): GenerateResult[(T | U)] ? =>
-          if rnd.bool() then
-            _gen.generate_and_shrink(rnd)?
+        fun generate(rnd: Randomness): (T^ | U^) ? =>
+          if rnd.bool()? then
+            _gen.generate(rnd)?
           else
-            other.generate_and_shrink(rnd)?
+            other.generate(rnd)?
           end
-
-        fun shrink(t: (T | U)): ValueAndShrink[(T | U)] =>
-          match \exhaustive\ consume t
-          | let tt: T => _gen.shrink(consume tt)
-          | let tu: U => other.shrink(consume tu)
-          end
-      end
-    )
+      end)
 
 type WeightedGenerator[T] is (USize, Generator[T] box)
   """
-  A generator with an associated weight, used in Generators.frequency.
+  A generator with an associated weight, used in `Generators.frequency`.
   """
 
 primitive Generators
   """
-  Convenience combinators and factories for common types and kind of Generators.
+  Convenience combinators and factories for common types of Generators.
   """
 
-  fun unit[T](t: T, do_shrink: Bool = false): Generator[box->T] =>
+  fun unit[T](t: T): Generator[box->T] =>
     """
     Generate a reference to the same value over and over again.
-
-    This reference will be of type `box->T` and not just `T`
-    as this generator will need to keep a reference to the given value.
     """
     Generator[box->T](
       object is GenObj[box->T]
         let _t: T = consume t
-        fun generate(rnd: Randomness): GenerateResult[box->T] =>
-          if do_shrink then
-            (_t, Iter[box->T].repeat_value(_t))
-          else
-            _t
-          end
+        fun generate(rnd: Randomness): box->T => _t
       end)
 
   fun none[T: None](): Generator[(T | None)] =>
+    """
+    Always generate `None`.
+    """
     Generators.unit[(T | None)](None)
 
   fun repeatedly[T](f: {(): T^ ?} box): Generator[T] =>
     """
-    Generate values by calling the lambda `f` repeatedly,
-    once for every invocation of `generate`.
+    Generate values by calling the lambda `f` repeatedly.
 
-    `f` needs to return an ephemeral type `T^`, that means
-    in most cases it needs to consume its returned value.
-    Otherwise we would end up with
-    an alias for `T` which is `T!`.
-    (e.g. `String iso` would be returned as `String iso!`,
-    which aliases as a `String tag`).
-
-    Example:
-
-    ```pony
-    Generators.repeatedly[Writer]({(): Writer^ =>
-      let writer = Writer.>write("consume me, please")
-      consume writer
-    })
-    ```
+    Values generated this way produce zero recorded choices and cannot
+    be shrunk. Use a generator that draws from `Randomness` when shrinking
+    matters.
     """
     Generator[T](
       object is GenObj[T]
-        fun generate(rnd: Randomness): GenerateResult[T] ? =>
-          f()?
+        fun generate(rnd: Randomness): T^ ? => f()?
       end)
 
-  fun seq_of[T, S: Seq[T] ref](
+  fun array_of[T](
     gen: Generator[T],
     from: USize = 0,
     to: USize = 100)
-    : Generator[S]
+    : Generator[Array[T]]
   =>
     """
-    Create a `Seq` from the values of the given Generator
-    with size in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
+    Generate an `Array[T]` with size in the range `from` to `to`.
+    Uses boolean-per-element encoding for shrinking: each element is preceded
+    by a boolean deciding whether to include it. Shrinking deletes elements
+    while preserving all others exactly.
     """
     let lo = from.min(to)
     let hi = from.max(to)
 
-    Generator[S](
-      object is GenObj[S]
+    Generator[Array[T]](
+      object is GenObj[Array[T]]
         let _gen: GenObj[T] = gen
-        fun generate(rnd: Randomness): GenerateResult[S] =>
-          let size = rnd.usize(lo, hi)
-
-          let result: S =
-            Iter[T^](_gen.value_iter(rnd))
-              .take(size)
-              .collect[S](S.create(size))
-
-          // create shrink_iter with smaller seqs and elements
-          // generated from _gen.value_iter
-          let shrink_iter =
-            Iter[USize](CountdownIter(size, lo)) // Range(size, lo, -1))
-              // .skip(1)
-              .map_stateful[S^]({
-                (s: USize): S^ =>
-                  Iter[T^](_gen.value_iter(rnd))
-                    .take(s)
-                    .collect[S](S.create(s))
-              })
-          (consume result, shrink_iter)
+        fun generate(rnd: Randomness): Array[T]^ ? =>
+          let result = Array[T](hi)
+          var count: USize = 0
+          while count < hi do
+            rnd.start_span(SpanElement)
+            let cont =
+              if count < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let elem = _gen.generate(rnd)?
+              result.push(consume elem)
+              count = count + 1
+              rnd.end_span()?
+            else
+              rnd.end_span()?
+              break
+            end
+          end
+          result
       end)
 
   fun iso_seq_of[T: Any #send, S: Seq[T] iso](
@@ -417,16 +180,8 @@ primitive Generators
     : Generator[S]
   =>
     """
-    Generate a `Seq[T]` where `T` must be sendable (i.e. it must have a
-    reference capability of either `tag`, `val`, or `iso`).
-
-    The constraint of the elements being sendable stems from the fact that
-    there is no other way to populate the iso seq if the elements might be
-    non-sendable (i.e. ref), as then the seq would leak references via
-    its elements.
-
-    Size is in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate a `Seq[T]` where `T` must be sendable.
+    Uses boolean-per-element encoding.
     """
     let lo = from.min(to)
     let hi = from.max(to)
@@ -434,79 +189,97 @@ primitive Generators
     Generator[S](
       object is GenObj[S]
         let _gen: GenObj[T] = gen
-        fun generate(rnd: Randomness): GenerateResult[S] =>
-          let size = rnd.usize(lo, hi)
-
-          let result: S = recover iso S.create(size) end
-          let iter = _gen.value_iter(rnd)
-          var i = USize(0)
-
-          for elem in iter do
-            if i >= size then break end
-
-            result.push(consume elem)
-            i = i + 1
+        fun generate(rnd: Randomness): S^ ? =>
+          let result: S = recover iso S.create(hi) end
+          var count: USize = 0
+          while count < hi do
+            rnd.start_span(SpanElement)
+            let cont =
+              if count < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let elem = _gen.generate(rnd)?
+              result.push(consume elem)
+              count = count + 1
+              rnd.end_span()?
+            else
+              rnd.end_span()?
+              break
+            end
           end
-          // create shrink_iter with smaller seqs and elements
-          // generated from _gen.value_iter
-          let shrink_iter =
-            Iter[USize](CountdownIter(size, lo)) // Range(size, lo, -1))
-              // .skip(1)
-              .map_stateful[S^]({
-                (s: USize): S^ =>
-                  let res = recover iso S.create(s) end
-                  let s_iter = _gen.value_iter(rnd)
-                  var j = USize(0)
+          consume result
+      end)
 
-                  for s_elem in s_iter do
-                    if j >= s then break end
-                    res.push(consume s_elem)
-                    j = j + 1
-                  end
-                  consume res
-              })
-          (consume result, shrink_iter)
-      end
-    )
-
-  fun array_of[T](
+  fun seq_of[T, S: Seq[T] ref](
     gen: Generator[T],
     from: USize = 0,
     to: USize = 100)
-    : Generator[Array[T]]
+    : Generator[S]
   =>
-    Generators.seq_of[T, Array[T]](gen, from, to)
+    """
+    Create a `Seq` from generated values with size in `from` to `to`.
+    Uses boolean-per-element encoding.
+    """
+    let lo = from.min(to)
+    let hi = from.max(to)
+
+    Generator[S](
+      object is GenObj[S]
+        let _gen: GenObj[T] = gen
+        fun generate(rnd: Randomness): S^ ? =>
+          let result: S = S.create(hi)
+          var count: USize = 0
+          while count < hi do
+            rnd.start_span(SpanElement)
+            let cont =
+              if count < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let elem = _gen.generate(rnd)?
+              result.push(consume elem)
+              count = count + 1
+              rnd.end_span()?
+            else
+              rnd.end_span()?
+              break
+            end
+          end
+          result
+      end)
 
   fun shuffled_array_gen[T](
     gen: Generator[Array[T]])
     : Generator[Array[T]]
   =>
+    """
+    Generate an array and shuffle it.
+    """
     Generator[Array[T]](
       object is GenObj[Array[T]]
         let _gen: GenObj[Array[T]] = gen
-        fun generate(rnd: Randomness): GenerateResult[Array[T]] ? =>
-          (let arr, let source_shrink_iter) = _gen.generate_and_shrink(rnd)?
-            rnd.shuffle[T](arr)
-            let shrink_iter =
-              Iter[Array[T]](source_shrink_iter)
-                .map_stateful[Array[T]^]({
-                  (shrink_arr: Array[T]): Array[T]^ =>
-                      rnd.shuffle[T](shrink_arr)
-                      consume shrink_arr
-                })
-            (consume arr, shrink_iter)
-      end
-    )
+        fun generate(rnd: Randomness): Array[T]^ ? =>
+          let arr = _gen.generate(rnd)?
+          rnd.shuffle[T](arr)?
+          arr
+      end)
 
   fun shuffled_iter[T](array: Array[T]): Generator[Iterator[this->T!]] =>
+    """
+    Shuffle the elements of the array and return an iterator.
+    """
     Generator[Iterator[this->T!]](
       object is GenObj[Iterator[this->T!]]
-        fun generate(rnd: Randomness): GenerateResult[Iterator[this->T!]] =>
+        fun generate(rnd: Randomness): Iterator[this->T!]^ ? =>
           let cloned = array.clone()
-          rnd.shuffle[this->T!](cloned)
+          rnd.shuffle[this->T!](cloned)?
           cloned.values()
-      end
-    )
+      end)
 
   fun list_of[T](
     gen: Generator[T],
@@ -514,6 +287,9 @@ primitive Generators
     to: USize = 100)
     : Generator[List[T]]
   =>
+    """
+    Generate a `List[T]` with size in `from` to `to`.
+    """
     Generators.seq_of[T, List[T]](gen, from, to)
 
   fun set_of[T: (Hashable #read & Equatable[T] #read)](
@@ -523,17 +299,9 @@ primitive Generators
     : Generator[Set[T]]
   =>
     """
-    Create a generator for `Set` filled with values
-    of the given generator `gen`
-    with a number of elements in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    The source generator must be able to produce enough distinct values
-    to reach the requested size. When the source generator is exhausted
-    (100 consecutive insertions without growth), the set is returned
-    at its current size.
+    Generate a `Set[T]` with elements in `from` to `to`.
+    Uses boolean-per-element encoding with a stall guard for duplicate
+    rejection.
     """
     let lo = from.min(to)
     let hi = from.max(to)
@@ -541,39 +309,32 @@ primitive Generators
     Generator[Set[T]](
       object is GenObj[Set[T]]
         let _gen: GenObj[T] = gen
-        fun generate(rnd: Randomness): GenerateResult[Set[T]] ? =>
-          let size = rnd.usize(lo, hi)
-          let result = Set[T].create(size)
-          let values = _gen.value_iter(rnd)
+        fun generate(rnd: Randomness): Set[T]^ ? =>
+          let result = Set[T].create(hi)
           var stall: USize = 0
-          while (result.size() < size) and (stall < 100) do
-            let prev = result.size()
-            result.set(values.next()?)
-            if result.size() == prev then
-              stall = stall + 1
+          while (result.size() < hi) and (stall < 100) do
+            rnd.start_span(SpanElement)
+            let cont =
+              if result.size() < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let prev = result.size()
+              result.set(_gen.generate(rnd)?)
+              if result.size() == prev then
+                stall = stall + 1
+              else
+                stall = 0
+              end
+              rnd.end_span()?
             else
-              stall = 0
+              rnd.end_span()?
+              break
             end
           end
-          let shrink_iter: Iterator[Set[T]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[Set[T]^]({
-                (s: USize): Set[T]^ ? =>
-                  let set = Set[T].create(s)
-                  let vs = _gen.value_iter(rnd)
-                  var stall': USize = 0
-                  while (set.size() < s) and (stall' < 100) do
-                    let prev = set.size()
-                    set.set(vs.next()?)
-                    if set.size() == prev then
-                      stall' = stall' + 1
-                    else
-                      stall' = 0
-                    end
-                  end
-                  set
-                })
-          (consume result, shrink_iter)
+          result
       end)
 
   fun set_is_of[T](
@@ -583,56 +344,39 @@ primitive Generators
     : Generator[SetIs[T]]
   =>
     """
-    Create a generator for `SetIs` filled with values
-    of the given generator `gen`
-    with a number of elements in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    The source generator must be able to produce enough distinct values
-    (by identity) to reach the requested size. When the source generator
-    is exhausted (100 consecutive insertions without growth), the set is
-    returned at its current size.
+    Generate a `SetIs[T]` with elements in `from` to `to`.
     """
     let lo = from.min(to)
     let hi = from.max(to)
 
     Generator[SetIs[T]](
       object is GenObj[SetIs[T]]
-        fun generate(rnd: Randomness): GenerateResult[SetIs[T]] ? =>
-          let size = rnd.usize(lo, hi)
-          let result = SetIs[T].create(size)
-          let values = gen.value_iter(rnd)
+        fun generate(rnd: Randomness): SetIs[T]^ ? =>
+          let result = SetIs[T].create(hi)
           var stall: USize = 0
-          while (result.size() < size) and (stall < 100) do
-            let prev = result.size()
-            result.set(values.next()?)
-            if result.size() == prev then
-              stall = stall + 1
+          while (result.size() < hi) and (stall < 100) do
+            rnd.start_span(SpanElement)
+            let cont =
+              if result.size() < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let prev = result.size()
+              result.set(gen.generate(rnd)?)
+              if result.size() == prev then
+                stall = stall + 1
+              else
+                stall = 0
+              end
+              rnd.end_span()?
             else
-              stall = 0
+              rnd.end_span()?
+              break
             end
           end
-          let shrink_iter: Iterator[SetIs[T]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[SetIs[T]^]({
-                (s: USize): SetIs[T]^ ? =>
-                  let set = SetIs[T].create(s)
-                  let vs = gen.value_iter(rnd)
-                  var stall': USize = 0
-                  while (set.size() < s) and (stall' < 100) do
-                    let prev = set.size()
-                    set.set(vs.next()?)
-                    if set.size() == prev then
-                      stall' = stall' + 1
-                    else
-                      stall' = 0
-                    end
-                  end
-                  set
-                })
-          (consume result, shrink_iter)
+          result
       end)
 
   fun map_of[K: (Hashable #read & Equatable[K] #read), V](
@@ -642,57 +386,40 @@ primitive Generators
     : Generator[Map[K, V]]
   =>
     """
-    Create a generator for `Map` from a generator of key-value tuples
-    with a number of entries in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    The source generator must be able to produce enough distinct keys
-    (based on structural equality) to reach the requested size. When
-    the source generator is exhausted (100 consecutive insertions
-    without growth), the map is returned at its current size.
+    Generate a `Map[K, V]` with entries in `from` to `to`.
     """
     let lo = from.min(to)
     let hi = from.max(to)
 
     Generator[Map[K, V]](
       object is GenObj[Map[K, V]]
-        fun generate(rnd: Randomness): GenerateResult[Map[K, V]] ? =>
-          let size = rnd.usize(lo, hi)
-          let result = Map[K, V].create(size)
-          let values = gen.value_iter(rnd)
+        fun generate(rnd: Randomness): Map[K, V]^ ? =>
+          let result = Map[K, V].create(hi)
           var stall: USize = 0
-          while (result.size() < size) and (stall < 100) do
-            let prev = result.size()
-            (let k, let v) = values.next()?
-            result(consume k) = consume v
-            if result.size() == prev then
-              stall = stall + 1
+          while (result.size() < hi) and (stall < 100) do
+            rnd.start_span(SpanElement)
+            let cont =
+              if result.size() < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let prev = result.size()
+              (let k, let v) = gen.generate(rnd)?
+              result(consume k) = consume v
+              if result.size() == prev then
+                stall = stall + 1
+              else
+                stall = 0
+              end
+              rnd.end_span()?
             else
-              stall = 0
+              rnd.end_span()?
+              break
             end
           end
-          let shrink_iter: Iterator[Map[K, V]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[Map[K, V]^]({
-                (s: USize): Map[K, V]^ ? =>
-                  let map = Map[K, V].create(s)
-                  let vs = gen.value_iter(rnd)
-                  var stall': USize = 0
-                  while (map.size() < s) and (stall' < 100) do
-                    let prev = map.size()
-                    (let k, let v) = vs.next()?
-                    map(consume k) = consume v
-                    if map.size() == prev then
-                      stall' = stall' + 1
-                    else
-                      stall' = 0
-                    end
-                  end
-                  map
-                })
-          (consume result, shrink_iter)
+          result
       end)
 
   fun map_is_of[K, V](
@@ -702,57 +429,40 @@ primitive Generators
     : Generator[MapIs[K, V]]
   =>
     """
-    Create a generator for `MapIs` from a generator of key-value tuples
-    with a number of entries in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    The source generator must be able to produce enough distinct keys
-    (based on identity) to reach the requested size. When the source
-    generator is exhausted (100 consecutive insertions without growth),
-    the map is returned at its current size.
+    Generate a `MapIs[K, V]` with entries in `from` to `to`.
     """
     let lo = from.min(to)
     let hi = from.max(to)
 
     Generator[MapIs[K, V]](
       object is GenObj[MapIs[K, V]]
-        fun generate(rnd: Randomness): GenerateResult[MapIs[K, V]] ? =>
-          let size = rnd.usize(lo, hi)
-          let result = MapIs[K, V].create(size)
-          let values = gen.value_iter(rnd)
+        fun generate(rnd: Randomness): MapIs[K, V]^ ? =>
+          let result = MapIs[K, V].create(hi)
           var stall: USize = 0
-          while (result.size() < size) and (stall < 100) do
-            let prev = result.size()
-            (let k, let v) = values.next()?
-            result(consume k) = consume v
-            if result.size() == prev then
-              stall = stall + 1
+          while (result.size() < hi) and (stall < 100) do
+            rnd.start_span(SpanElement)
+            let cont =
+              if result.size() < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let prev = result.size()
+              (let k, let v) = gen.generate(rnd)?
+              result(consume k) = consume v
+              if result.size() == prev then
+                stall = stall + 1
+              else
+                stall = 0
+              end
+              rnd.end_span()?
             else
-              stall = 0
+              rnd.end_span()?
+              break
             end
           end
-          let shrink_iter: Iterator[MapIs[K, V]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[MapIs[K, V]^]({
-                (s: USize): MapIs[K, V]^ ? =>
-                  let map = MapIs[K, V].create(s)
-                  let vs = gen.value_iter(rnd)
-                  var stall': USize = 0
-                  while (map.size() < s) and (stall' < 100) do
-                    let prev = map.size()
-                    (let k, let v) = vs.next()?
-                    map(consume k) = consume v
-                    if map.size() == prev then
-                      stall' = stall' + 1
-                    else
-                      stall' = 0
-                    end
-                  end
-                  map
-                })
-          (consume result, shrink_iter)
+          result
       end)
 
   fun vec_of[T: Any #share](
@@ -762,12 +472,7 @@ primitive Generators
     : Generator[persistent.Vec[T]]
   =>
     """
-    Create a generator for persistent `Vec` filled with values
-    of the given generator `gen`
-    with size in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
+    Generate a persistent `Vec[T]` with size in `from` to `to`.
     """
     let lo = from.min(to)
     let hi = from.max(to)
@@ -775,21 +480,27 @@ primitive Generators
     Generator[persistent.Vec[T]](
       object is GenObj[persistent.Vec[T]]
         let _gen: GenObj[T] = gen
-        fun generate(rnd: Randomness)
-          : GenerateResult[persistent.Vec[T]]
-        =>
-          let size = rnd.usize(lo, hi)
-          let result: persistent.Vec[T] =
-            persistent.Vec[T].concat(
-              Iter[T^](_gen.value_iter(rnd)).take(size))
-          let shrink_iter: Iterator[persistent.Vec[T]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[persistent.Vec[T]^]({
-                (s: USize): persistent.Vec[T]^ =>
-                  persistent.Vec[T].concat(
-                    Iter[T^](_gen.value_iter(rnd)).take(s))
-              })
-          (consume result, shrink_iter)
+        fun generate(rnd: Randomness): persistent.Vec[T]^ ? =>
+          var result = persistent.Vec[T]
+          var count: USize = 0
+          while count < hi do
+            rnd.start_span(SpanElement)
+            let cont =
+              if count < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              result = result.push(_gen.generate(rnd)?)
+              count = count + 1
+              rnd.end_span()?
+            else
+              rnd.end_span()?
+              break
+            end
+          end
+          result
       end)
 
   fun persistent_list_of[T: Any #share](
@@ -799,12 +510,7 @@ primitive Generators
     : Generator[persistent.List[T]]
   =>
     """
-    Create a generator for persistent `List` filled with values
-    of the given generator `gen`
-    with size in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
+    Generate a persistent `List[T]` with size in `from` to `to`.
     """
     let lo = from.min(to)
     let hi = from.max(to)
@@ -812,21 +518,27 @@ primitive Generators
     Generator[persistent.List[T]](
       object is GenObj[persistent.List[T]]
         let _gen: GenObj[T] = gen
-        fun generate(rnd: Randomness)
-          : GenerateResult[persistent.List[T]]
-        =>
-          let size = rnd.usize(lo, hi)
-          let result: persistent.List[T] =
-            persistent.Lists[T].from(
-              Iter[T^](_gen.value_iter(rnd)).take(size))
-          let shrink_iter: Iterator[persistent.List[T]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[persistent.List[T]^]({
-                (s: USize): persistent.List[T]^ =>
-                  persistent.Lists[T].from(
-                    Iter[T^](_gen.value_iter(rnd)).take(s))
-              })
-          (consume result, shrink_iter)
+        fun generate(rnd: Randomness): persistent.List[T]^ ? =>
+          var result: persistent.List[T] = persistent.Lists[T].empty()
+          var count: USize = 0
+          while count < hi do
+            rnd.start_span(SpanElement)
+            let cont =
+              if count < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              result = result.prepend(_gen.generate(rnd)?)
+              count = count + 1
+              rnd.end_span()?
+            else
+              rnd.end_span()?
+              break
+            end
+          end
+          result.reverse()
       end)
 
   fun persistent_set_of[T: (Hashable val & Equatable[T] val)](
@@ -836,17 +548,7 @@ primitive Generators
     : Generator[persistent.Set[T]]
   =>
     """
-    Create a generator for persistent `Set` filled with values
-    of the given generator `gen`
-    with a number of elements in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    The source generator must be able to produce enough distinct values
-    to reach the requested size. When the source generator is exhausted
-    (100 consecutive insertions without growth), the set is returned
-    at its current size.
+    Generate a persistent `Set[T]` with elements in `from` to `to`.
     """
     let lo = from.min(to)
     let hi = from.max(to)
@@ -854,41 +556,32 @@ primitive Generators
     Generator[persistent.Set[T]](
       object is GenObj[persistent.Set[T]]
         let _gen: GenObj[T] = gen
-        fun generate(rnd: Randomness)
-          : GenerateResult[persistent.Set[T]] ?
-        =>
-          let size = rnd.usize(lo, hi)
+        fun generate(rnd: Randomness): persistent.Set[T]^ ? =>
           var result = persistent.Set[T].create()
-          let values = _gen.value_iter(rnd)
           var stall: USize = 0
-          while (result.size() < size) and (stall < 100) do
-            let prev = result.size()
-            result = result + values.next()?
-            if result.size() == prev then
-              stall = stall + 1
+          while (result.size() < hi) and (stall < 100) do
+            rnd.start_span(SpanElement)
+            let cont =
+              if result.size() < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let prev = result.size()
+              result = result + _gen.generate(rnd)?
+              if result.size() == prev then
+                stall = stall + 1
+              else
+                stall = 0
+              end
+              rnd.end_span()?
             else
-              stall = 0
+              rnd.end_span()?
+              break
             end
           end
-          let shrink_iter: Iterator[persistent.Set[T]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[persistent.Set[T]^]({
-                (s: USize): persistent.Set[T]^ ? =>
-                  var set = persistent.Set[T].create()
-                  let vs = _gen.value_iter(rnd)
-                  var stall': USize = 0
-                  while (set.size() < s) and (stall' < 100) do
-                    let prev = set.size()
-                    set = set + vs.next()?
-                    if set.size() == prev then
-                      stall' = stall' + 1
-                    else
-                      stall' = 0
-                    end
-                  end
-                  set
-              })
-          (consume result, shrink_iter)
+          result
       end)
 
   fun persistent_set_is_of[T: Any #share](
@@ -898,17 +591,7 @@ primitive Generators
     : Generator[persistent.SetIs[T]]
   =>
     """
-    Create a generator for persistent `SetIs` filled with values
-    of the given generator `gen`
-    with a number of elements in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    The source generator must be able to produce enough distinct values
-    (by identity) to reach the requested size. When the source generator
-    is exhausted (100 consecutive insertions without growth), the set is
-    returned at its current size.
+    Generate a persistent `SetIs[T]` with elements in `from` to `to`.
     """
     let lo = from.min(to)
     let hi = from.max(to)
@@ -916,41 +599,32 @@ primitive Generators
     Generator[persistent.SetIs[T]](
       object is GenObj[persistent.SetIs[T]]
         let _gen: GenObj[T] = gen
-        fun generate(rnd: Randomness)
-          : GenerateResult[persistent.SetIs[T]] ?
-        =>
-          let size = rnd.usize(lo, hi)
+        fun generate(rnd: Randomness): persistent.SetIs[T]^ ? =>
           var result = persistent.SetIs[T].create()
-          let values = _gen.value_iter(rnd)
           var stall: USize = 0
-          while (result.size() < size) and (stall < 100) do
-            let prev = result.size()
-            result = result + values.next()?
-            if result.size() == prev then
-              stall = stall + 1
+          while (result.size() < hi) and (stall < 100) do
+            rnd.start_span(SpanElement)
+            let cont =
+              if result.size() < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let prev = result.size()
+              result = result + _gen.generate(rnd)?
+              if result.size() == prev then
+                stall = stall + 1
+              else
+                stall = 0
+              end
+              rnd.end_span()?
             else
-              stall = 0
+              rnd.end_span()?
+              break
             end
           end
-          let shrink_iter: Iterator[persistent.SetIs[T]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[persistent.SetIs[T]^]({
-                (s: USize): persistent.SetIs[T]^ ? =>
-                  var set = persistent.SetIs[T].create()
-                  let vs = _gen.value_iter(rnd)
-                  var stall': USize = 0
-                  while (set.size() < s) and (stall' < 100) do
-                    let prev = set.size()
-                    set = set + vs.next()?
-                    if set.size() == prev then
-                      stall' = stall' + 1
-                    else
-                      stall' = 0
-                    end
-                  end
-                  set
-              })
-          (consume result, shrink_iter)
+          result
       end)
 
   fun persistent_map_of[
@@ -962,59 +636,40 @@ primitive Generators
     : Generator[persistent.Map[K, V]]
   =>
     """
-    Create a generator for persistent `Map` from a generator of key-value
-    tuples with a number of entries in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    The source generator must be able to produce enough distinct keys
-    (based on structural equality) to reach the requested size. When
-    the source generator is exhausted (100 consecutive insertions
-    without growth), the map is returned at its current size.
+    Generate a persistent `Map[K, V]` with entries in `from` to `to`.
     """
     let lo = from.min(to)
     let hi = from.max(to)
 
     Generator[persistent.Map[K, V]](
       object is GenObj[persistent.Map[K, V]]
-        fun generate(rnd: Randomness)
-          : GenerateResult[persistent.Map[K, V]] ?
-        =>
-          let size = rnd.usize(lo, hi)
+        fun generate(rnd: Randomness): persistent.Map[K, V]^ ? =>
           var result = persistent.Map[K, V].create()
-          let values = gen.value_iter(rnd)
           var stall: USize = 0
-          while (result.size() < size) and (stall < 100) do
-            let prev = result.size()
-            (let k, let v) = values.next()?
-            result = result.update(consume k, consume v)
-            if result.size() == prev then
-              stall = stall + 1
+          while (result.size() < hi) and (stall < 100) do
+            rnd.start_span(SpanElement)
+            let cont =
+              if result.size() < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let prev = result.size()
+              (let k, let v) = gen.generate(rnd)?
+              result = result.update(consume k, consume v)
+              if result.size() == prev then
+                stall = stall + 1
+              else
+                stall = 0
+              end
+              rnd.end_span()?
             else
-              stall = 0
+              rnd.end_span()?
+              break
             end
           end
-          let shrink_iter: Iterator[persistent.Map[K, V]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[persistent.Map[K, V]^]({
-                (s: USize): persistent.Map[K, V]^ ? =>
-                  var map = persistent.Map[K, V].create()
-                  let vs = gen.value_iter(rnd)
-                  var stall': USize = 0
-                  while (map.size() < s) and (stall' < 100) do
-                    let prev = map.size()
-                    (let k, let v) = vs.next()?
-                    map = map.update(consume k, consume v)
-                    if map.size() == prev then
-                      stall' = stall' + 1
-                    else
-                      stall' = 0
-                    end
-                  end
-                  map
-              })
-          (consume result, shrink_iter)
+          result
       end)
 
   fun persistent_map_is_of[K: Any #share, V: Any #share](
@@ -1024,135 +679,80 @@ primitive Generators
     : Generator[persistent.MapIs[K, V]]
   =>
     """
-    Create a generator for persistent `MapIs` from a generator of key-value
-    tuples with a number of entries in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    The source generator must be able to produce enough distinct keys
-    (based on identity) to reach the requested size. When the source
-    generator is exhausted (100 consecutive insertions without growth),
-    the map is returned at its current size.
+    Generate a persistent `MapIs[K, V]` with entries in `from` to `to`.
     """
     let lo = from.min(to)
     let hi = from.max(to)
 
     Generator[persistent.MapIs[K, V]](
       object is GenObj[persistent.MapIs[K, V]]
-        fun generate(rnd: Randomness)
-          : GenerateResult[persistent.MapIs[K, V]] ?
-        =>
-          let size = rnd.usize(lo, hi)
+        fun generate(rnd: Randomness): persistent.MapIs[K, V]^ ? =>
           var result = persistent.MapIs[K, V].create()
-          let values = gen.value_iter(rnd)
           var stall: USize = 0
-          while (result.size() < size) and (stall < 100) do
-            let prev = result.size()
-            (let k, let v) = values.next()?
-            result = result.update(consume k, consume v)
-            if result.size() == prev then
-              stall = stall + 1
+          while (result.size() < hi) and (stall < 100) do
+            rnd.start_span(SpanElement)
+            let cont =
+              if result.size() < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              let prev = result.size()
+              (let k, let v) = gen.generate(rnd)?
+              result = result.update(consume k, consume v)
+              if result.size() == prev then
+                stall = stall + 1
+              else
+                stall = 0
+              end
+              rnd.end_span()?
             else
-              stall = 0
+              rnd.end_span()?
+              break
             end
           end
-          let shrink_iter: Iterator[persistent.MapIs[K, V]^] =
-            Iter[USize](CountdownIter(size, lo))
-              .map_stateful[persistent.MapIs[K, V]^]({
-                (s: USize): persistent.MapIs[K, V]^ ? =>
-                  var map = persistent.MapIs[K, V].create()
-                  let vs = gen.value_iter(rnd)
-                  var stall': USize = 0
-                  while (map.size() < s) and (stall' < 100) do
-                    let prev = map.size()
-                    (let k, let v) = vs.next()?
-                    map = map.update(consume k, consume v)
-                    if map.size() == prev then
-                      stall' = stall' + 1
-                    else
-                      stall' = 0
-                    end
-                  end
-                  map
-              })
-          (consume result, shrink_iter)
+          result
       end)
 
-  fun one_of[T](xs: ReadSeq[T], do_shrink: Bool = false): Generator[box->T] =>
+  fun one_of[T](xs: ReadSeq[T]): Generator[box->T] =>
     """
     Generate a random value from the given ReadSeq.
-    This generator will generate nothing if the given xs is empty.
-
-    Generators created with this method do not support shrinking.
-    If `do_shrink` is set to `true`, it will return the same value
-    for each shrink round. Otherwise it will return nothing.
+    Errors if `xs` is empty.
     """
-
     Generator[box->T](
       object is GenObj[box->T]
-        fun generate(rnd: Randomness): GenerateResult[box->T] ? =>
-          let idx = rnd.usize(0, xs.size() - 1)
-          let res = xs(idx)?
-          if do_shrink then
-            (res, Iter[box->T].repeat_value(res))
-          else
-            res
-          end
+        fun generate(rnd: Randomness): box->T ? =>
+          xs(rnd.usize(0, xs.size() - 1)?)?
       end)
 
-  fun one_of_safe[T](
-    xs: ReadSeq[T],
-    do_shrink: Bool = false)
-    : Generator[box->T] ?
-  =>
+  fun one_of_safe[T](xs: ReadSeq[T]): Generator[box->T] ? =>
     """
-    Version of `one_of` that will error if `xs` is empty.
+    Version of `one_of` that errors at construction time if `xs` is empty.
     """
-    Fact(xs.size() > 0, "cannot use one_of_safe on empty ReadSeq")?
-    Generators.one_of[T](xs, do_shrink)
+    if xs.size() == 0 then error end
+    Generators.one_of[T](xs)
 
   fun frequency[T](
     weighted_generators: ReadSeq[WeightedGenerator[T]])
     : Generator[T]
   =>
     """
-    Choose a value of one of the given Generators,
-    while controlling the distribution with the associated weights.
-
-    The weights are of type `USize` and control how likely a value is chosen.
-    The likelihood of a value `v` to be chosen
-    is `weight_v` / `weights_sum`.
-    If all `weighted_generators` have equal size the distribution
-    will be uniform.
-
-    Example of a generator to output odd `U8` values
-    twice as likely as even ones:
-
-    ```pony
-    Generators.frequency[U8]([
-      (1, Generators.u8().filter({(u) => (u, (u % 2) == 0 }))
-      (2, Generators.u8().filter({(u) => (u, (u % 2) != 0 }))
-    ])
-    ```
+    Choose a value from one of the given Generators, weighted by associated
+    weights.
     """
-
-    // nasty hack to avoid handling the theoretical error case where we have
-    // no generator and thus would have to change the type signature
     Generator[T](
       object is GenObj[T]
-        fun generate(rnd: Randomness): GenerateResult[T] ? =>
+        fun generate(rnd: Randomness): T^ ? =>
           let weight_sum: USize =
             Iter[WeightedGenerator[T]](weighted_generators.values())
               .fold[USize](
                 0,
-                // segfaults when types are removed - TODO: investigate
                 {(acc: USize, weighted_gen: WeightedGenerator[T]): USize^ =>
                   weighted_gen._1 + acc
                 })
-          let desired_sum = rnd.usize(0, weight_sum)
+          let desired_sum = rnd.usize(0, weight_sum)?
           var running_sum: USize = 0
-          var chosen: (Generator[T] | None) = None
           for weighted_gen in weighted_generators.values() do
             let new_sum = running_sum + weighted_gen._1
             if
@@ -1160,21 +760,12 @@ primitive Generators
                 ((running_sum < desired_sum) and
                   (desired_sum <= new_sum)))
             then
-              // we just crossed or reached the desired sum
-              chosen = weighted_gen._2
-              break
+              return weighted_gen._2.generate(rnd)?
             else
-              // update running sum
               running_sum = new_sum
             end
           end
-          match \exhaustive\ chosen
-          | let x: Generator[T] box => x.generate(rnd)?
-          | None =>
-            Debug("chosen is None, desired_sum: " + desired_sum.string() +
-              "running_sum: " + running_sum.string())
-            error
-          end
+          error
       end)
 
   fun frequency_safe[T](
@@ -1185,9 +776,7 @@ primitive Generators
     Version of `frequency` that errors if the given `weighted_generators` is
     empty.
     """
-    Fact(
-      weighted_generators.size() > 0,
-      "cannot use frequency_safe on empty ReadSeq[WeightedGenerator]")?
+    if weighted_generators.size() == 0 then error end
     Generators.frequency[T](weighted_generators)
 
   fun zip2[T1, T2](
@@ -1196,25 +785,12 @@ primitive Generators
     : Generator[(T1, T2)]
   =>
     """
-    Zip two generators into a generator of a 2-tuple
-    containing the values generated by both generators.
+    Zip two generators into a generator of a 2-tuple.
     """
     Generator[(T1, T2)](
       object is GenObj[(T1, T2)]
-        fun generate(rnd: Randomness): GenerateResult[(T1, T2)] ? =>
-          (let v1: T1, let shrinks1: Iterator[T1^]) =
-            gen1.generate_and_shrink(rnd)?
-          (let v2: T2, let shrinks2: Iterator[T2^]) =
-            gen2.generate_and_shrink(rnd)?
-          ((consume v1, consume v2), Iter[T1^](shrinks1).zip[T2^](shrinks2))
-
-        fun shrink(t: (T1, T2)): ValueAndShrink[(T1, T2)] =>
-          (let t1, let t2) = consume t
-          (let t11, let t1_shrunken: Iterator[T1^]) = gen1.shrink(consume t1)
-          (let t21, let t2_shrunken: Iterator[T2^]) = gen2.shrink(consume t2)
-
-          let shrunken = Iter[T1^](t1_shrunken).zip[T2^](t2_shrunken)
-          ((consume t11, consume t21), shrunken)
+        fun generate(rnd: Randomness): (T1^, T2^) ? =>
+          (gen1.generate(rnd)?, gen2.generate(rnd)?)
       end)
 
   fun zip3[T1, T2, T3](
@@ -1224,32 +800,13 @@ primitive Generators
     : Generator[(T1, T2, T3)]
   =>
     """
-    Zip three generators into a generator of a 3-tuple
-    containing the values generated by those three generators.
+    Zip three generators into a generator of a 3-tuple.
     """
     Generator[(T1, T2, T3)](
       object is GenObj[(T1, T2, T3)]
-        fun generate(rnd: Randomness): GenerateResult[(T1, T2, T3)] ? =>
-          (let v1: T1, let shrinks1: Iterator[T1^]) =
-            gen1.generate_and_shrink(rnd)?
-          (let v2: T2, let shrinks2: Iterator[T2^]) =
-            gen2.generate_and_shrink(rnd)?
-          (let v3: T3, let shrinks3: Iterator[T3^]) =
-            gen3.generate_and_shrink(rnd)?
-          ((consume v1, consume v2, consume v3),
-              Iter[T1^](shrinks1).zip2[T2^, T3^](shrinks2, shrinks3))
-
-        fun shrink(t: (T1, T2, T3)): ValueAndShrink[(T1, T2, T3)] =>
-          (let t1, let t2, let t3) = consume t
-          (let t11, let t1_shrunken: Iterator[T1^]) = gen1.shrink(consume t1)
-          (let t21, let t2_shrunken: Iterator[T2^]) = gen2.shrink(consume t2)
-          (let t31, let t3_shrunken: Iterator[T3^]) = gen3.shrink(consume t3)
-
-          let shrunken =
-            Iter[T1^](t1_shrunken)
-              .zip2[T2^, T3^](t2_shrunken, t3_shrunken)
-          ((consume t11, consume t21, consume t31), shrunken)
-        end)
+        fun generate(rnd: Randomness): (T1^, T2^, T3^) ? =>
+          (gen1.generate(rnd)?, gen2.generate(rnd)?, gen3.generate(rnd)?)
+      end)
 
   fun zip4[T1, T2, T3, T4](
     gen1: Generator[T1],
@@ -1259,36 +816,14 @@ primitive Generators
     : Generator[(T1, T2, T3, T4)]
   =>
     """
-    Zip four generators into a generator of a 4-tuple
-    containing the values generated by those four generators.
+    Zip four generators into a generator of a 4-tuple.
     """
     Generator[(T1, T2, T3, T4)](
       object is GenObj[(T1, T2, T3, T4)]
-        fun generate(rnd: Randomness): GenerateResult[(T1, T2, T3, T4)] ? =>
-          (let v1: T1, let shrinks1: Iterator[T1^]) =
-            gen1.generate_and_shrink(rnd)?
-          (let v2: T2, let shrinks2: Iterator[T2^]) =
-            gen2.generate_and_shrink(rnd)?
-          (let v3: T3, let shrinks3: Iterator[T3^]) =
-            gen3.generate_and_shrink(rnd)?
-          (let v4: T4, let shrinks4: Iterator[T4^]) =
-            gen4.generate_and_shrink(rnd)?
-          ((consume v1, consume v2, consume v3, consume v4),
-            Iter[T1^](shrinks1)
-              .zip3[T2^, T3^, T4^](
-                shrinks2, shrinks3, shrinks4))
-
-        fun shrink(t: (T1, T2, T3, T4)): ValueAndShrink[(T1, T2, T3, T4)] =>
-          (let t1, let t2, let t3, let t4) = consume t
-          (let t11, let t1_shrunken) = gen1.shrink(consume t1)
-          (let t21, let t2_shrunken) = gen2.shrink(consume t2)
-          (let t31, let t3_shrunken) = gen3.shrink(consume t3)
-          (let t41, let t4_shrunken) = gen4.shrink(consume t4)
-
-          let shrunken = Iter[T1^](t1_shrunken)
-            .zip3[T2^, T3^, T4^](t2_shrunken, t3_shrunken, t4_shrunken)
-          ((consume t11, consume t21, consume t31, consume t41), shrunken)
-        end)
+        fun generate(rnd: Randomness): (T1^, T2^, T3^, T4^) ? =>
+          (gen1.generate(rnd)?, gen2.generate(rnd)?,
+            gen3.generate(rnd)?, gen4.generate(rnd)?)
+      end)
 
   fun map2[T1, T2, T3](
     gen1: Generator[T1],
@@ -1340,76 +875,12 @@ primitive Generators
 
   fun bool(): Generator[Bool] =>
     """
-    Create a generator of bool values.
+    Generate random Bool values.
     """
     Generator[Bool](
       object is GenObj[Bool]
-        fun generate(rnd: Randomness): Bool =>
-          rnd.bool()
-        end)
-
-  fun _int_shrink[T: (Int & Integer[T] val)](
-    t: T^,
-    min: T)
-    : ValueAndShrink[T]
-  =>
-    """
-    """
-    let relation = t.compare(min)
-    let t_copy: T = T.create(t)
-    // Debug(t.string() + " is " + relation.string()
-    // + " than min " + min.string())
-    let sub_iter =
-      object is Iterator[T^]
-        var _cur: T = t_copy
-        var _subtract: F64 = 1.0
-        var _overflow: Bool = false
-
-        fun ref _next_minuend(): T =>
-          // f(x) = x + (2^-5 * x^2)
-          T.from[F64](_subtract = _subtract + (0.03125 * _subtract * _subtract))
-
-        fun ref has_next(): Bool =>
-          match \exhaustive\ relation
-          | Less => (_cur < min) and not _overflow
-          | Equal => false
-          | Greater => (_cur > min) and not _overflow
-          end
-
-        fun ref next(): T^ ? =>
-          match \exhaustive\ relation
-          | Less =>
-            let minuend: T = _next_minuend()
-            let old = _cur
-            _cur = _cur + minuend
-            if old > _cur then
-              _overflow = true
-            end
-            old
-          | Equal => error
-          | Greater =>
-            let minuend: T = _next_minuend()
-            let old = _cur
-            _cur = _cur - minuend
-            if old < _cur then
-              _overflow = true
-            end
-            old
-          end
-      end
-
-    let min_iter =
-      match \exhaustive\ relation
-      | let _: (Less | Greater) => Poperator[T]([min])
-      | Equal => Poperator[T].empty()
-      end
-
-    let shrunken_iter =
-      Iter[T].chain(
-        [ Iter[T^](sub_iter).skip(1)
-          min_iter
-        ].values())
-    (consume t, shrunken_iter)
+        fun generate(rnd: Randomness): Bool ? => rnd.bool()?
+      end)
 
   fun u8(
     from: U8 = U8.min_value(),
@@ -1417,21 +888,14 @@ primitive Generators
     : Generator[U8]
   =>
     """
-    Create a generator for U8 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate U8 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[U8](
       object is GenObj[U8]
-        fun generate(rnd: Randomness): U8^ =>
-          rnd.u8(lo, hi)
-
-        fun shrink(u: U8): ValueAndShrink[U8] =>
-          that._int_shrink[U8](consume u, lo)
-        end)
+        fun generate(rnd: Randomness): U8 ? => rnd.u8(lo, hi)?
+      end)
 
   fun u16(
     from: U16 = U16.min_value(),
@@ -1439,20 +903,13 @@ primitive Generators
     : Generator[U16]
   =>
     """
-    Create a generator for U16 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate U16 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[U16](
       object is GenObj[U16]
-        fun generate(rnd: Randomness): U16^ =>
-          rnd.u16(lo, hi)
-
-        fun shrink(u: U16): ValueAndShrink[U16] =>
-          that._int_shrink[U16](consume u, lo)
+        fun generate(rnd: Randomness): U16 ? => rnd.u16(lo, hi)?
       end)
 
   fun u32(
@@ -1461,20 +918,13 @@ primitive Generators
     : Generator[U32]
   =>
     """
-    Create a generator for U32 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate U32 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[U32](
       object is GenObj[U32]
-        fun generate(rnd: Randomness): U32^ =>
-          rnd.u32(lo, hi)
-
-        fun shrink(u: U32): ValueAndShrink[U32] =>
-          that._int_shrink[U32](consume u, lo)
+        fun generate(rnd: Randomness): U32 ? => rnd.u32(lo, hi)?
       end)
 
   fun u64(
@@ -1483,20 +933,13 @@ primitive Generators
     : Generator[U64]
   =>
     """
-    Create a generator for U64 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate U64 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[U64](
       object is GenObj[U64]
-        fun generate(rnd: Randomness): U64^ =>
-          rnd.u64(lo, hi)
-
-        fun shrink(u: U64): ValueAndShrink[U64] =>
-          that._int_shrink[U64](consume u, lo)
+        fun generate(rnd: Randomness): U64 ? => rnd.u64(lo, hi)?
       end)
 
   fun u128(
@@ -1505,20 +948,13 @@ primitive Generators
     : Generator[U128]
   =>
     """
-    Create a generator for U128 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate U128 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[U128](
       object is GenObj[U128]
-        fun generate(rnd: Randomness): U128^ =>
-          rnd.u128(lo, hi)
-
-        fun shrink(u: U128): ValueAndShrink[U128] =>
-          that._int_shrink[U128](consume u, lo)
+        fun generate(rnd: Randomness): U128 ? => rnd.u128(lo, hi)?
       end)
 
   fun usize(
@@ -1527,20 +963,13 @@ primitive Generators
     : Generator[USize]
   =>
     """
-    Create a generator for USize values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate USize values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[USize](
       object is GenObj[USize]
-        fun generate(rnd: Randomness): GenerateResult[USize] =>
-          rnd.usize(lo, hi)
-
-        fun shrink(u: USize): ValueAndShrink[USize] =>
-          that._int_shrink[USize](consume u, lo)
+        fun generate(rnd: Randomness): USize ? => rnd.usize(lo, hi)?
       end)
 
   fun ulong(
@@ -1549,20 +978,13 @@ primitive Generators
     : Generator[ULong]
   =>
     """
-    Create a generator for ULong values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate ULong values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[ULong](
       object is GenObj[ULong]
-        fun generate(rnd: Randomness): ULong^ =>
-          rnd.ulong(lo, hi)
-
-        fun shrink(u: ULong): ValueAndShrink[ULong] =>
-          that._int_shrink[ULong](consume u, lo)
+        fun generate(rnd: Randomness): ULong ? => rnd.ulong(lo, hi)?
       end)
 
   fun i8(
@@ -1571,20 +993,13 @@ primitive Generators
     : Generator[I8]
   =>
     """
-    Create a generator for I8 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate I8 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[I8](
       object is GenObj[I8]
-        fun generate(rnd: Randomness): I8^ =>
-          rnd.i8(lo, hi)
-
-        fun shrink(i: I8): ValueAndShrink[I8] =>
-          that._int_shrink[I8](consume i, lo)
+        fun generate(rnd: Randomness): I8 ? => rnd.i8(lo, hi)?
       end)
 
   fun i16(
@@ -1593,20 +1008,13 @@ primitive Generators
     : Generator[I16]
   =>
     """
-    Create a generator for I16 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate I16 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[I16](
       object is GenObj[I16]
-        fun generate(rnd: Randomness): I16^ =>
-          rnd.i16(lo, hi)
-
-        fun shrink(i: I16): ValueAndShrink[I16] =>
-          that._int_shrink[I16](consume i, lo)
+        fun generate(rnd: Randomness): I16 ? => rnd.i16(lo, hi)?
       end)
 
   fun i32(
@@ -1615,20 +1023,13 @@ primitive Generators
     : Generator[I32]
   =>
     """
-    Create a generator for I32 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate I32 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[I32](
       object is GenObj[I32]
-        fun generate(rnd: Randomness): I32^ =>
-          rnd.i32(lo, hi)
-
-        fun shrink(i: I32): ValueAndShrink[I32] =>
-          that._int_shrink[I32](consume i, lo)
+        fun generate(rnd: Randomness): I32 ? => rnd.i32(lo, hi)?
       end)
 
   fun i64(
@@ -1637,20 +1038,13 @@ primitive Generators
     : Generator[I64]
   =>
     """
-    Create a generator for I64 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate I64 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[I64](
       object is GenObj[I64]
-        fun generate(rnd: Randomness): I64^ =>
-          rnd.i64(lo, hi)
-
-        fun shrink(i: I64): ValueAndShrink[I64] =>
-          that._int_shrink[I64](consume i, lo)
+        fun generate(rnd: Randomness): I64 ? => rnd.i64(lo, hi)?
       end)
 
   fun i128(
@@ -1659,20 +1053,13 @@ primitive Generators
     : Generator[I128]
   =>
     """
-    Create a generator for I128 values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate I128 values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[I128](
       object is GenObj[I128]
-        fun generate(rnd: Randomness): I128^ =>
-          rnd.i128(lo, hi)
-
-        fun shrink(i: I128): ValueAndShrink[I128] =>
-          that._int_shrink[I128](consume i, lo)
+        fun generate(rnd: Randomness): I128 ? => rnd.i128(lo, hi)?
       end)
 
   fun ilong(
@@ -1681,20 +1068,13 @@ primitive Generators
     : Generator[ILong]
   =>
     """
-    Create a generator for ILong values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate ILong values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[ILong](
       object is GenObj[ILong]
-        fun generate(rnd: Randomness): ILong^ =>
-          rnd.ilong(lo, hi)
-
-        fun shrink(i: ILong): ValueAndShrink[ILong] =>
-          that._int_shrink[ILong](consume i, lo)
+        fun generate(rnd: Randomness): ILong ? => rnd.ilong(lo, hi)?
       end)
 
   fun isize(
@@ -1703,20 +1083,13 @@ primitive Generators
     : Generator[ISize]
   =>
     """
-    Create a generator for ISize values
-    in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
+    Generate ISize values in `[from, to]`. Order does not matter.
     """
     let lo = from.min(to)
     let hi = from.max(to)
-    let that = this
     Generator[ISize](
       object is GenObj[ISize]
-        fun generate(rnd: Randomness): ISize^ =>
-          rnd.isize(lo, hi)
-
-        fun shrink(i: ISize): ValueAndShrink[ISize] =>
-          that._int_shrink[ISize](consume i, lo)
+        fun generate(rnd: Randomness): ISize ? => rnd.isize(lo, hi)?
       end)
 
   fun byte_string(
@@ -1726,48 +1099,35 @@ primitive Generators
     : Generator[String]
   =>
     """
-    Create a generator for strings
-    generated from the bytes returned by the generator `gen`,
-    with length in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
+    Generate a string from bytes with length in `from` to `to`.
+    Uses boolean-per-element encoding.
     """
     let lo = from.min(to)
     let hi = from.max(to)
 
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness): GenerateResult[String] =>
-          let size = rnd.usize(lo, hi)
-          let gen_iter = Iter[U8^](gen.value_iter(rnd))
-            .take(size)
-          let arr: Array[U8] iso = recover Array[U8](size) end
-          for b in gen_iter do
-            arr.push(b)
+        fun generate(rnd: Randomness): String^ ? =>
+          let arr: Array[U8] iso = recover Array[U8](hi) end
+          var count: USize = 0
+          while count < hi do
+            rnd.start_span(SpanElement)
+            let cont =
+              if count < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              arr.push(gen.generate(rnd)?)
+              count = count + 1
+              rnd.end_span()?
+            else
+              rnd.end_span()?
+              break
+            end
           end
           String.from_iso_array(consume arr)
-
-        fun shrink(s: String): ValueAndShrink[String] =>
-          var str: String = s.trim(0, s.size() - 1)
-          let shorten_iter: Iterator[String^] =
-            object is Iterator[String^]
-              fun ref has_next(): Bool => str.size() > lo
-              fun ref next(): String^ =>
-                str = str.trim(0, str.size() - 1)
-            end
-          let lo_iter =
-            if s.size() > lo then
-              Poperator[String]([s.trim(0, lo)])
-            else
-              Poperator[String].empty()
-            end
-          let shrink_iter =
-            Iter[String^].chain(
-              [ shorten_iter
-                lo_iter
-              ].values())
-          (consume s, shrink_iter)
       end)
 
   fun ascii(
@@ -1777,11 +1137,7 @@ primitive Generators
     : Generator[String]
   =>
     """
-    Create a generator for strings within the given `range`,
-    with length in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
+    Generate a string within the given `range` with length in `from` to `to`.
     """
     let range_bytes = range.apply()
     let fallback = U8(0)
@@ -1790,7 +1146,6 @@ primitive Generators
         try
           range_bytes(size)?
         else
-          // should never happen
           fallback
         end
       })
@@ -1802,11 +1157,7 @@ primitive Generators
     : Generator[String]
   =>
     """
-    Create a generator for strings of printable ASCII characters,
-    with length in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
+    Generate strings of printable ASCII characters.
     """
     ascii(from, to, ASCIIPrintable)
 
@@ -1816,11 +1167,7 @@ primitive Generators
     : Generator[String]
   =>
     """
-    Create a generator for strings of numeric ASCII characters,
-    with length in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
+    Generate strings of numeric ASCII characters.
     """
     ascii(from, to, ASCIIDigits)
 
@@ -1830,11 +1177,7 @@ primitive Generators
     : Generator[String]
   =>
     """
-    Create a generator for strings of ASCII letters,
-    with length in the range `from` to `to`.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
+    Generate strings of ASCII letter characters.
     """
     ascii(from, to, ASCIILetters)
 
@@ -1845,69 +1188,40 @@ primitive Generators
     : Generator[String]
   =>
     """
-    Create a generator for strings
-    from a generator of unicode codepoints,
-    with length in the range `from` to `to` codepoints.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    Note that the byte length of the generated string can be up to 4 times
-    the size in code points.
+    Generate a string from unicode codepoints with length in `from` to `to`
+    codepoints.
     """
     let lo = from.min(to)
     let hi = from.max(to)
 
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness): GenerateResult[String] =>
-          let size = rnd.usize(lo, hi)
-          let gen_iter = Iter[U32^](gen.value_iter(rnd))
-            .filter(
-              {(cp) =>
-                // excluding surrogate pairs
-                (cp <= 0xD7FF) or (cp >= 0xE000)
-              })
-            .take(size)
-          let s: String iso = recover String(size) end
-          for code_point in gen_iter do
-            s.push_utf32(code_point)
-          end
-          s
-
-        fun shrink(s: String): ValueAndShrink[String] =>
-          """
-          Strip off codepoints from the end, not just bytes, so we
-          maintain a valid utf8 string.
-          """
-          var shrink_base = s
-          let s_len = s.codepoints()
-          let shrink_iter: Iterator[String^] =
-            if s_len > lo then
-              Iter[String^].repeat_value(consume shrink_base)
-                .map_stateful[String^](
-                  object
-                    var len: USize = s_len - 1
-                    fun ref apply(str: String): String =>
-                      Generators._trim_codepoints(str, len = len - 1)
-                  end
-                ).take(s_len - lo)
-                // take_while is buggy in pony < 0.21.0
-                // .take_while({(t) => t.codepoints() > lo})
+        fun generate(rnd: Randomness): String^ ? =>
+          let s: String iso = recover String(hi) end
+          var count: USize = 0
+          while count < hi do
+            rnd.start_span(SpanElement)
+            let cont =
+              if count < lo then
+                rnd.forced_bool(true)?
+              else
+                rnd.bool()?
+              end
+            if cont then
+              var cp = gen.generate(rnd)?
+              while (cp > 0xD7FF) and (cp < 0xE000) do
+                cp = gen.generate(rnd)?
+              end
+              s.push_utf32(cp)
+              count = count + 1
+              rnd.end_span()?
             else
-              Poperator[String].empty()
+              rnd.end_span()?
+              break
             end
-          (consume s, shrink_iter)
+          end
+          consume s
       end)
-
-  fun _trim_codepoints(s: String, trim_to: USize): String =>
-    recover val
-      Iter[U32](s.runes())
-        .take(trim_to)
-        .fold[String ref](
-          String.create(trim_to),
-          {(acc, cp) => acc .> push_utf32(cp) })
-    end
 
   fun unicode(
     from: USize = 0,
@@ -1915,19 +1229,10 @@ primitive Generators
     : Generator[String]
   =>
     """
-    Create a generator for unicode strings,
-    with length in the range `from` to `to` codepoints.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    Note that the byte length of the generated string can be up to 4 times
-    the size in code points.
+    Generate a random String of Unicode code points.
     """
     let range_1 = u32(0x0, 0xD7FF)
     let range_1_size: USize = 0xD7FF
-    // excluding surrogate pairs
-    // this might be duplicate work but increases efficiency
     let range_2 = u32(0xE000, 0x10FFFF)
     let range_2_size = U32(0x10FFFF - 0xE000).usize()
 
@@ -1944,20 +1249,10 @@ primitive Generators
     : Generator[String]
   =>
     """
-    Create a generator for unicode strings
-    from the basic multilingual plane only,
-    with length in the range `from` to `to` codepoints.
-    The order of `from` and `to` does not matter.
-
-    Defaults are 0 and 100.
-
-    Note that the byte length of the generated string can be up to 4 times
-    the size in code points.
+    Generate a random String of Unicode BMP code points.
     """
     let range_1 = u32(0x0, 0xD7FF)
     let range_1_size: USize = 0xD7FF
-    // excluding surrogate pairs
-    // this might be duplicate work but increases efficiency
     let range_2 = u32(0xE000, 0xFFFF)
     let range_2_size = U32(0xFFFF - 0xE000).usize()
 
@@ -1967,4 +1262,3 @@ primitive Generators
           (range_2_size, range_2)
         ])
     utf32_codepoint_string(code_point_gen, from, to)
-

--- a/packages/pony_check/pony_check.pony
+++ b/packages/pony_check/pony_check.pony
@@ -95,9 +95,9 @@ execute it for a configurable number of samples.
 
 If the property fails using an assertion method of
 [PropertyHelper](pony_check-PropertyHelper.md),
-the failed example will be shrunken by the generator
-to obtain a smaller and more informative, still failing, sample
-for reporting.
+the framework automatically shrinks the failing sample by replaying the
+generator against mutated choice sequences, producing a smaller and more
+informative counterexample for reporting.
 
 """
 use "pony_test"

--- a/packages/pony_check/property4.pony
+++ b/packages/pony_check/property4.pony
@@ -6,7 +6,7 @@ class val PropertyParams is Stringable
 
   * seed: the seed for the source of Randomness
   * num_samples: the number of samples to produce from the property generator
-  * max_shrink_rounds: the maximum rounds of shrinking to perform
+  * max_shrink_reductions: the maximum number of shrink reductions to accept
   * max_generator_retries: the maximum number of retries to do if a generator
     fails to generate a sample
   * timeout: the timeout for the PonyTest runner, in nanoseconds
@@ -15,7 +15,7 @@ class val PropertyParams is Stringable
   """
   let seed: U64
   let num_samples: USize
-  let max_shrink_rounds: USize
+  let max_shrink_reductions: USize
   let max_generator_retries: USize
   let timeout: U64
   let async: Bool
@@ -23,14 +23,14 @@ class val PropertyParams is Stringable
   new val create(
     num_samples': USize = 100,
     seed': U64 = Time.millis(),
-    max_shrink_rounds': USize = 10,
+    max_shrink_reductions': USize = 100,
     max_generator_retries': USize = 5,
     timeout': U64 = 60_000_000_000,
     async': Bool = false)
   =>
     num_samples = num_samples'
     seed = seed'
-    max_shrink_rounds = max_shrink_rounds'
+    max_shrink_reductions = max_shrink_reductions'
     max_generator_retries = max_generator_retries'
     timeout = timeout'
     async = async'
@@ -68,9 +68,9 @@ trait Property1[T]
   samples and each is passed to the
   [property](pony_check-Property1.md#property) method for verification.
 
-  If the property did not verify, the given sample is shrunken if the
-  generator supports shrinking.
-  The smallest shrunken sample will then be reported to the user.
+  If the property did not verify, the framework automatically shrinks the
+  failing sample by replaying the generator against mutated choice sequences.
+  The smallest counterexample found is reported to the user.
 
   A [Property1](pony_check-Property1.md) can be run with
   [Ponytest](pony_test--index.md).

--- a/packages/pony_check/property_result_notify.pony
+++ b/packages/pony_check/property_result_notify.pony
@@ -85,10 +85,8 @@ interface val PropertyResultNotify
 
 actor PropertyRunner[T]
   """
-  Actor executing a Property1 implementation
-  in a way that allows garbage collection between single
-  property executions, because it uses recursive behaviours
-  for looping.
+  Executes a `Property1` using recursive behaviours so the garbage collector
+  can reclaim between samples.
   """
   let _prop1: Property1[T]
   let _params: PropertyParams
@@ -97,22 +95,15 @@ actor PropertyRunner[T]
   let _gen: Generator[T]
   let _logger: PropertyLogger
   let _env: Env
-  // state changed during runtime
   var _current_round: _Round = _Run.create(0)
-    """
-    The number and kind of the round currently executed.
-    Keep track of which runs/shrinks we expect to be notified about.
-    """
   let _expected_actions: Set[String] = Set[String]
-    """
-    List of expected actions for this round.
-    Will be cleared after each round.
-    """
   let _disposables: Array[DisposableActor] = Array[DisposableActor]
-    """
-    Disposable actors that are disposed of after every round.
-    """
-  var _shrinker: Iterator[T^] = _EmptyIterator[T^]
+  var _failing_choices: Array[_Choice val] val =
+    recover val Array[_Choice val] end
+  var _failing_spans: Array[_Span val] val =
+    recover val Array[_Span val] end
+  var _shrink_shrinker: (_Shrinker ref | None) = None
+  var _shrink_candidates: (Iterator[Array[_Choice val] val] | None) = None
   var _sample_repr: String = ""
   var _pass: Bool = true
 
@@ -139,8 +130,6 @@ actor PropertyRunner[T]
     This behaviour is called from the PropertyHelper
     or from the actor itself.
     """
-
-    // verify that this is an expected call
     if this._current_round != round then
       _logger.log(
         "unexpected " +
@@ -152,24 +141,22 @@ actor PropertyRunner[T]
       return
     end
 
-    _pass = success // in case of sync property - signal failure
+    _pass = success
 
     if not success then
-      // found a bad example, try to shrink it
-      if not _shrinker.has_next() then
-        _logger.log("no shrinks available")
+      _failing_choices = _rnd._get_choices()
+      _failing_spans = _rnd._get_spans()
+
+      if _failing_choices.size() == 0 then
+        _logger.log("no choices recorded, cannot shrink")
         _prepare_next_round()
         fail(_sample_repr, 0)
       else
-        // prepare next round
         _prepare_next_round()
-        // set rounds to shrinking
-        this._current_round = _Shrink.create(0) // reset rounds for shrinking
-        // start shrinking process
+        this._current_round = _Shrink.create(0)
         do_shrink(_sample_repr)
       end
     else
-      // property holds, recurse
       _prepare_next_round()
       run()
     end
@@ -181,12 +168,13 @@ actor PropertyRunner[T]
       disposable.dispose()
     end
 
-  fun ref _generate_with_retry(max_retries: USize): ValueAndShrink[T] ? =>
+  fun ref _generate_with_retry(max_retries: USize): T^ ? =>
     var tries: USize = 0
     repeat
       try
-        return _gen.generate_and_shrink(_rnd)?
+        return _gen.generate(_rnd)?
       else
+        _rnd._start_recording()
         tries = tries + 1
       end
     until (tries > max_retries) end
@@ -198,16 +186,17 @@ actor PropertyRunner[T]
     Execute the next property sample.
     """
     if this._current_round.round() >= _params.num_samples then
-      complete() // all samples have been successful
+      complete()
       return
     end
 
-    // prepare property run
-    (var sample, _shrinker) =
+    _rnd._start_recording()
+
+    var sample: T =
       try
         _generate_with_retry(_params.max_generator_retries)?
       else
-        // break out if we were not able to generate a sample
+        _rnd._reset()
         _notify.fail(
           "Unable to generate samples from the given iterator, tried " +
           _params.max_generator_retries.string() + " times." +
@@ -216,8 +205,6 @@ actor PropertyRunner[T]
         return
       end
 
-    // create a string representation before consuming ``sample``
-    // with property
     (sample, _sample_repr) = _Stringify.apply[T](consume sample)
     let run_notify = recover val this~complete_run() end
     let helper =
@@ -227,81 +214,94 @@ actor PropertyRunner[T]
         run_notify,
         this._current_round,
         _params.string())
-    _pass = true // will be set to false by fail calls
+    _pass = true
 
     try
       _prop1.property(consume sample, helper)?
     else
+      _failing_choices = _rnd._get_choices()
+      _failing_spans = _rnd._get_spans()
       _prepare_next_round()
       fail(_sample_repr, 0 where err=true)
       return
     end
-    // dispatch to another behavior
-    // as complete_run might have set _pass already through a call to
-    // complete_run
     _run_finished(this._current_round)
 
   be _run_finished(round: _Round) =>
     if not _params.async and _pass then
-      // otherwise complete_run has already been called
       complete_run(round, true)
     end
 
 // SHRINKING //
-  be complete_shrink(
-    failed_repr: String,
-    last_repr: String,
-    shrink_round: _Round,
-    success: Bool)
-  =>
-    // verify that this is an expected call
-    if this._current_round != shrink_round then
-      _logger.log(
-        "unexpected " +
-          (if success then "complete" else "fail" end) +
-          " msg for " + shrink_round.string() +
-          ". Currently at " +
-          _current_round.string(),
-        true)
-      return
-    end
-
-    _pass = success // in case of sync property - signal failure
-
-    if success then
-      // we have a sample that did not fail and thus can stop shrinking
-      fail(failed_repr, shrink_round.round())
-
-    else
-      // we have a failing shrink sample, recurse
-      _prepare_next_round()
-      do_shrink(last_repr)
-    end
-
   be do_shrink(failed_repr: String) =>
     """
-    Attempt to shrink a failing sample.
+    Shrink a failing sample using choice-sequence replay.
     """
-    // shrink iters can be infinite, so we need to limit
-    // the examples we consider during shrinking
-    let round_num = this._current_round.round()
-    if round_num == _params.max_shrink_rounds then
-      fail(failed_repr, round_num)
+    let shrinker =
+      _Shrinker(
+        _failing_choices,
+        _failing_spans,
+        _params.max_shrink_reductions)
+    _shrink_shrinker = shrinker
+    _shrink_candidates = shrinker.candidates()
+    _try_next_candidate(failed_repr)
+
+  be _try_next_candidate(failed_repr: String) =>
+    let candidates =
+      match _shrink_candidates
+      | let c: Iterator[Array[_Choice val] val] => c
+      else
+        fail(failed_repr, this._current_round.round())
+        return
+      end
+
+    if not candidates.has_next() then
+      fail(failed_repr, this._current_round.round())
       return
     end
 
-    (let shrink, let current_repr) =
+    let candidate =
       try
-        _Stringify.apply[T](_shrinker.next()?)
+        candidates.next()?
       else
-        // no more shrink samples, report previous failed example
-        fail(failed_repr, round_num)
+        fail(failed_repr, this._current_round.round())
         return
       end
-    // callback for asynchronous shrinking or aborting on error case
+
+    _rnd._replay(candidate)
+    var sample: T =
+      try
+        _gen.generate(_rnd)?
+      else
+        _try_next_candidate(failed_repr)
+        return
+      end
+
+    let consumed = _rnd._consumed()
+    let new_choices =
+      if consumed < candidate.size() then
+        recover val
+          let trimmed = Array[_Choice val](consumed)
+          try
+            var i: USize = 0
+            while i < consumed do
+              trimmed.push(candidate(i)?)
+              i = i + 1
+            end
+          end
+          trimmed
+        end
+      else
+        candidate
+      end
+
+    (sample, let current_repr) = _Stringify.apply[T](consume sample)
+    let new_spans = _rnd._get_spans()
+
     let run_notify =
       recover val
-        this~complete_shrink(failed_repr, current_repr)
+        this~_shrink_candidate_result(
+          failed_repr, current_repr, new_choices, new_spans)
       end
     let helper =
       PropertyHelper(
@@ -310,27 +310,67 @@ actor PropertyRunner[T]
         run_notify,
         this._current_round,
         _params.string())
-    _pass = true // will be set to false by fail calls
+    _pass = true
 
     try
-      _prop1.property(consume shrink, helper)?
+      _prop1.property(consume sample, helper)?
     else
+      _accept_shrink_candidate(new_choices, new_spans)
       _prepare_next_round()
-      fail(current_repr, round_num where err=true)
+      _try_next_candidate(current_repr)
       return
     end
-    // dispatch to another behaviour
-    // to ensure _complete_shrink has been called already
-    _shrink_finished(failed_repr, current_repr, this._current_round)
+    _shrink_candidate_finished(
+      failed_repr,
+      current_repr,
+      new_choices,
+      new_spans,
+      this._current_round)
 
-  be _shrink_finished(
+  fun ref _accept_shrink_candidate(
+    new_choices: Array[_Choice val] val,
+    new_spans: Array[_Span val] val)
+  =>
+    match _shrink_shrinker
+    | let s: _Shrinker ref =>
+      s.accept(new_choices, new_spans)
+    end
+    _failing_choices = new_choices
+    _failing_spans = new_spans
+
+  be _shrink_candidate_result(
     failed_repr: String,
     current_repr: String,
-    shrink_round: _Round)
+    new_choices: Array[_Choice val] val,
+    new_spans: Array[_Span val] val,
+    round: _Round,
+    success: Bool)
+  =>
+    if round != this._current_round then return end
+    if success then
+      _prepare_next_round()
+      _try_next_candidate(failed_repr)
+    else
+      _accept_shrink_candidate(new_choices, new_spans)
+      _prepare_next_round()
+      _try_next_candidate(current_repr)
+    end
+
+  be _shrink_candidate_finished(
+    failed_repr: String,
+    current_repr: String,
+    new_choices: Array[_Choice val] val,
+    new_spans: Array[_Span val] val,
+    round: _Round)
   =>
     if not _params.async and _pass then
-      // directly complete the shrink run
-      complete_shrink(failed_repr, current_repr, shrink_round, true)
+      _shrink_candidate_result(
+        failed_repr,
+        current_repr,
+        new_choices,
+        new_spans,
+        round,
+        true)
     end
 
 // interface towards PropertyHelper
@@ -390,8 +430,6 @@ actor PropertyRunner[T]
     try
       _expected_actions.extract(name)?
 
-      // call back into the helper to invoke the current run_notify
-      // that we don't have access to otherwise
       if not success then
         ph.complete(false)
       elseif _expected_actions.size() == 0 then
@@ -405,10 +443,6 @@ actor PropertyRunner[T]
     end
 
   be dispose_when_done(disposable: DisposableActor, round: _Round) =>
-    """
-    Let us not have older rounds interfere with newer ones,
-    thus dispose directly.
-    """
     if round != this._current_round then
       _logger.log("Unexpected dispose_when_done for " + round.string() +
         ". Currently at " + this._current_round.string(), true)
@@ -477,10 +511,6 @@ actor PropertyRunner[T]
         " shrinks)"
     )
 
-class _EmptyIterator[T]
-  fun ref has_next(): Bool => false
-  fun ref next(): T^ ? => error
-
 primitive _Stringify
   fun apply[T](t: T): (T^, String) =>
     """
@@ -511,4 +541,3 @@ primitive _Stringify
         "<identity:" + digest.string() + ">"
       end
     (consume t, consume s)
-

--- a/packages/pony_check/randomness.pony
+++ b/packages/pony_check/randomness.pony
@@ -1,258 +1,408 @@
 use "random"
 
+type _RandomnessMode is (_ModePlain | _ModeRecording | _ModeReplaying)
+
+primitive _ModePlain
+primitive _ModeRecording
+primitive _ModeReplaying
+
 class ref Randomness
   """
-  Source of randomness, providing methods for generating uniformly distributed
-  values of the primitive numeric types.
+  All draw methods are partial: they error during replay when the recorded
+  choice sequence is exhausted or when a type/range mismatch is detected.
+  In plain mode (user-constructed Randomness), draws never error.
 
-  The integer methods (`u8` through `isize`) generate values in the closed
-  interval [min, max]. Both bounds are included, so every value of the type can
-  be produced.
-
-  The floating-point methods (`f32` and `f64`) scale a value from the underlying
-  generator's `real()` (uniformly distributed in [0, 1)) onto the requested
-  range. `min` is always reachable and results are never below `min`, but `max`
-  is only an approximate upper bound: floating-point rounding means `max` may or
-  may not be produced, and an `f32` result can land marginally above `max`. Do
-  not rely on `max` being included or excluded.
+  Integer methods generate values in the closed interval [min, max].
+  Floating-point methods scale onto [min, max]; `min` is always reachable,
+  `max` is an approximate upper bound due to floating-point rounding.
   """
   let _random: Random
+  var _mode: _RandomnessMode = _ModePlain
+  var _choices: Array[_Choice val] iso = recover iso Array[_Choice val] end
+  var _spans: Array[_Span val] iso = recover iso Array[_Span val] end
+  var _replay_seq: Array[_Choice val] val = recover val Array[_Choice val] end
+  var _replay_idx: USize = 0
+  var _replay_exhausted_flag: Bool = false
+  var _span_stack: Array[USize] ref = Array[USize]
+  var _span_labels: Array[SpanLabel] ref = Array[SpanLabel]
 
   new ref create(seed1: U64 = 42, seed2: U64 = 0) =>
     _random = Rand(seed1, seed2)
 
-  fun ref u8(min: U8 = U8.min_value(), max: U8 = U8.max_value()): U8 =>
+  // --- Public draw methods ---
+  fun ref u8(min: U8 = U8.min_value(), max: U8 = U8.max_value()): U8 ? =>
     """
-    Generate a U8 in closed interval [min, max]
-    (default: [min_value, max_value]).
+    Generate a U8 in closed interval [min, max].
+    """
+    _draw_int(min.i128(), max.i128(), min.i128())?.u8()
 
-    Behavior is undefined if `min` > `max`.
+  fun ref u16(min: U16 = U16.min_value(), max: U16 = U16.max_value()): U16 ? =>
     """
-    if (min == U8.min_value()) and (max == U8.max_value()) then
-      _random.u8()
-    else
-      min + _random.int((max - min).u64() + 1).u8()
-    end
+    Generate a U16 in closed interval [min, max].
+    """
+    _draw_int(min.i128(), max.i128(), min.i128())?.u16()
 
-  fun ref u16(min: U16 = U16.min_value(), max: U16 = U16.max_value()): U16 =>
+  fun ref u32(min: U32 = U32.min_value(), max: U32 = U32.max_value()): U32 ? =>
     """
-    Generate a U16 in closed interval [min, max]
-    (default: [min_value, max_value]).
+    Generate a U32 in closed interval [min, max].
+    """
+    _draw_int(min.i128(), max.i128(), min.i128())?.u32()
 
-    Behavior is undefined if `min` > `max`.
+  fun ref u64(min: U64 = U64.min_value(), max: U64 = U64.max_value()): U64 ? =>
     """
-    if (min == U16.min_value()) and (max == U16.max_value()) then
-      _random.u16()
-    else
-      min + _random.int((max - min).u64() + 1).u16()
-    end
-
-  fun ref u32(min: U32 = U32.min_value(), max: U32 = U32.max_value()): U32 =>
+    Generate a U64 in closed interval [min, max].
     """
-    Generate a U32 in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
-    """
-    if (min == U32.min_value()) and (max == U32.max_value()) then
-      _random.u32()
-    else
-      min + _random.int((max - min).u64() + 1).u32()
-    end
-
-  fun ref u64(min: U64 = U64.min_value(), max: U64 = U64.max_value()): U64 =>
-    """
-    Generate a U64 in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
-    """
-    if (min == U64.min_value()) and (max == U64.max_value()) then
-      _random.u64()
-    elseif min > U32.max_value().u64() then
-      (u32((min >> 32).u32(), (max >> 32).u32()).u64() << 32) or
-        _random.u32().u64()
-    elseif max > U32.max_value().u64() then
-      let high = (u32((min >> 32).u32(), (max >> 32).u32()).u64() << 32).u64()
-      let low =
-        if high > 0 then
-          _random.u32().u64()
-        else
-          u32(min.u32(), U32.max_value()).u64()
-        end
-      high or low
-    else
-      // range within U32 range
-      u32(min.u32(), max.u32()).u64()
-    end
+    _draw_int(min.i128(), max.i128(), min.i128())?.u64()
 
   fun ref u128(
     min: U128 = U128.min_value(),
     max: U128 = U128.max_value())
-    : U128
+    : U128 ?
   =>
     """
-    Generate a U128 in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
+    Generate a U128 in closed interval [min, max].
     """
-    if (min == U128.min_value()) and (max == U128.max_value()) then
-      _random.u128()
-    elseif min > U64.max_value().u128() then
-      // both above U64 range - chose random low 64 bits
-      (u64((min >> 64).u64(), (max >> 64).u64()).u128() << 64) or u64().u128()
-    elseif max > U64.max_value().u128() then
-      // min below U64 max value
-      let high = (u64((min >> 64).u64(), (max >> 64).u64()).u128() << 64)
-      let low =
-        if high > 0 then
-          // number will be bigger than U64 max anyway, so chose a
-          // random lower u64
-          u64().u128()
-        else
-          // number <= U64 max, so chose lower u64 while considering
-          // requested range min
-          u64(min.u64(), U64.max_value()).u128()
-        end
-      high or low
-    else
-      // range within u64 range
-      u64(min.u64(), max.u64()).u128()
-    end
+    _draw_u128(min, max, min)?
 
   fun ref ulong(
     min: ULong = ULong.min_value(),
     max: ULong = ULong.max_value())
-    : ULong
+    : ULong ?
   =>
     """
-    Generate a ULong in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
+    Generate a ULong in closed interval [min, max].
     """
-    u64(min.u64(), max.u64()).ulong()
+    _draw_int(min.i128(), max.i128(), min.i128())?.ulong()
 
   fun ref usize(
     min: USize = USize.min_value(),
     max: USize = USize.max_value())
-    : USize
+    : USize ?
   =>
     """
-    Generate a USize in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
+    Generate a USize in closed interval [min, max].
     """
-    u64(min.u64(), max.u64()).usize()
+    _draw_int(min.i128(), max.i128(), min.i128())?.usize()
 
-  fun ref i8(min: I8 = I8.min_value(), max: I8 = I8.max_value()): I8 =>
+  fun ref i8(min: I8 = I8.min_value(), max: I8 = I8.max_value()): I8 ? =>
     """
-    Generate a I8 in closed interval [min, max]
-    (default: [min_value, max_value]).
+    Generate an I8 in closed interval [min, max].
+    """
+    _draw_int(min.i128(), max.i128(), 0)?.i8()
 
-    Behavior is undefined if `min` > `max`.
+  fun ref i16(min: I16 = I16.min_value(), max: I16 = I16.max_value()): I16 ? =>
     """
-    min + u8(0, (max - min).u8()).i8()
+    Generate an I16 in closed interval [min, max].
+    """
+    _draw_int(min.i128(), max.i128(), 0)?.i16()
 
-  fun ref i16(min: I16 = I16.min_value(), max: I16 = I16.max_value()): I16 =>
+  fun ref i32(min: I32 = I32.min_value(), max: I32 = I32.max_value()): I32 ? =>
     """
-    Generate a I16 in closed interval [min, max]
-    (default: [min_value, max_value]).
+    Generate an I32 in closed interval [min, max].
+    """
+    _draw_int(min.i128(), max.i128(), 0)?.i32()
 
-    Behavior is undefined if `min` > `max`.
+  fun ref i64(min: I64 = I64.min_value(), max: I64 = I64.max_value()): I64 ? =>
     """
-    min + u16(0, (max - min).u16()).i16()
-
-  fun ref i32(min: I32 = I32.min_value(), max: I32 = I32.max_value()): I32 =>
+    Generate an I64 in closed interval [min, max].
     """
-    Generate a I32 in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
-    """
-    min + u32(0, (max - min).u32()).i32()
-
-  fun ref i64(min: I64 = I64.min_value(), max: I64 = I64.max_value()): I64 =>
-    """
-    Generate a I64 in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
-    """
-    min + u64(0, (max - min).u64()).i64()
+    _draw_int(min.i128(), max.i128(), 0)?.i64()
 
   fun ref i128(
     min: I128 = I128.min_value(),
     max: I128 = I128.max_value())
-    : I128
+    : I128 ?
   =>
     """
-    Generate a I128 in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
+    Generate an I128 in closed interval [min, max].
     """
-    min + u128(0, (max - min).u128()).i128()
+    _draw_int(min, max, 0)?
 
   fun ref ilong(
     min: ILong = ILong.min_value(),
     max: ILong = ILong.max_value())
-    : ILong
+    : ILong ?
   =>
     """
-    Generate a ILong in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
+    Generate an ILong in closed interval [min, max].
     """
-    min + ulong(0, (max - min).ulong()).ilong()
+    _draw_int(min.i128(), max.i128(), 0)?.ilong()
 
   fun ref isize(
     min: ISize = ISize.min_value(),
     max: ISize = ISize.max_value())
-    : ISize
+    : ISize ?
   =>
     """
-    Generate a ISize in closed interval [min, max]
-    (default: [min_value, max_value]).
-
-    Behavior is undefined if `min` > `max`.
+    Generate an ISize in closed interval [min, max].
     """
-    min + usize(0, (max - min).usize()).isize()
+    _draw_int(min.i128(), max.i128(), 0)?.isize()
 
-  fun ref f32(min: F32 = 0.0, max: F32 = 1.0): F32 =>
+  fun ref f32(min: F32 = 0.0, max: F32 = 1.0): F32 ? =>
     """
-    Generate an F32 in the range from `min` to `max` (default: 0.0 to 1.0).
-
-    `min` is always reachable. On the default range the result is the closed
-    interval [0.0, 1.0]: `real()`'s largest value rounds up to 1.0 when
-    converted to F32, so `max` is produced when that top value is drawn. See
-    `Randomness` for how `max` behaves on other ranges.
+    Generate an F32 in the range from `min` to `max`.
     """
-    (_random.real().f32() * (max - min)) + min
+    _draw_float(min.f64(), max.f64())?.f32()
 
-  fun ref f64(min: F64 = 0.0, max: F64 = 1.0): F64 =>
+  fun ref f64(min: F64 = 0.0, max: F64 = 1.0): F64 ? =>
     """
-    Generate an F64 in the range from `min` to `max` (default: 0.0 to 1.0).
-
-    `min` is always reachable. On the default range the result is the half-open
-    interval [0.0, 1.0); `max` (1.0) is never produced. See `Randomness` for how
-    `max` behaves on other ranges.
+    Generate an F64 in the range from `min` to `max`.
     """
-    (_random.real() * (max - min)) + min
+    _draw_float(min, max)?
 
-  fun ref bool(): Bool =>
+  fun ref bool(): Bool ? =>
     """
     Generate a random Bool value.
     """
-    (_random.next() % 2) == 0
+    match \exhaustive\ _mode
+    | _ModePlain =>
+      let v = (_random.next() % 2) == 0
+      v
+    | _ModeRecording =>
+      let v = (_random.next() % 2) == 0
+      _choices.push(_BoolChoice(v))
+      v
+    | _ModeReplaying =>
+      if _replay_idx >= _replay_seq.size() then
+        _replay_exhausted_flag = true
+        error
+      end
+      match _replay_seq(_replay_idx)?
+      | let bc: _BoolChoice =>
+        _replay_idx = _replay_idx + 1
+        bc.value
+      else
+        error
+      end
+    end
 
-  fun ref shuffle[T](array: Array[T] ref) =>
+  fun ref forced_bool(value: Bool): Bool ? =>
     """
-    Shuffle the elements of the array into a random order, mutating the array.
+    Record a predetermined Bool. The shrinker will not attempt to
+    change this choice. Use when the outcome is fixed by the
+    generator's structure (e.g., elements below a collection minimum).
     """
-    _random.shuffle[T](array)
+    match \exhaustive\ _mode
+    | _ModePlain =>
+      value
+    | _ModeRecording =>
+      _choices.push(_BoolChoice(value, true))
+      value
+    | _ModeReplaying =>
+      if _replay_idx >= _replay_seq.size() then
+        _replay_exhausted_flag = true
+        error
+      end
+      match _replay_seq(_replay_idx)?
+      | let bc: _BoolChoice =>
+        _replay_idx = _replay_idx + 1
+        value
+      else
+        error
+      end
+    end
 
+  fun ref shuffle[T](array: Array[T] ref) ? =>
+    """
+    Shuffle the array in place using Fisher-Yates, recording one integer
+    choice per element as the swap index.
+    """
+    let n = array.size()
+    if n <= 1 then return end
+    start_span(SpanShuffle)
+    var i = n - 1
+    while i > 0 do
+      let j = usize(0, i)?
+      try
+        array.swap_elements(i, j)?
+      else
+        end_span()?
+        error
+      end
+      i = i - 1
+    end
+    end_span()?
 
+  // --- Public span tracking ---
+  fun ref start_span(label: SpanLabel) =>
+    """
+    Mark the beginning of a structural span in the choice sequence.
+    Spans let the shrinker understand generator structure — for example,
+    which choices belong to a single collection element.
+    """
+    let pos =
+      match \exhaustive\ _mode
+      | _ModePlain => _choices.size()
+      | _ModeRecording => _choices.size()
+      | _ModeReplaying => _replay_idx
+      end
+    _span_stack.push(pos)
+    _span_labels.push(label)
+
+  fun ref end_span(discard: Bool = false) ? =>
+    """
+    Close the most recently opened span. If `discard` is true, the span
+    is marked as discarded (e.g., a filter rejection).
+
+    Errors if no span is open (mismatched start_span/end_span calls).
+    """
+    let start = _span_stack.pop()?
+    let label = _span_labels.pop()?
+    let end_pos =
+      match \exhaustive\ _mode
+      | _ModePlain => _choices.size()
+      | _ModeRecording => _choices.size()
+      | _ModeReplaying => _replay_idx
+      end
+    _spans.push(_Span(start, end_pos, label, discard))
+
+  // --- Package-private mode control ---
+  fun ref _start_recording() =>
+    _mode = _ModeRecording
+    _choices = recover iso Array[_Choice val] end
+    _spans = recover iso Array[_Span val] end
+    _span_stack = Array[USize]
+    _span_labels = Array[SpanLabel]
+
+  fun ref _replay(choices: Array[_Choice val] val) =>
+    _mode = _ModeReplaying
+    _replay_seq = choices
+    _replay_idx = 0
+    _replay_exhausted_flag = false
+    _choices = recover iso Array[_Choice val] end
+    _spans = recover iso Array[_Span val] end
+    _span_stack = Array[USize]
+    _span_labels = Array[SpanLabel]
+
+  fun ref _reset() =>
+    _mode = _ModePlain
+    _choices = recover iso Array[_Choice val] end
+    _spans = recover iso Array[_Span val] end
+    _span_stack = Array[USize]
+    _span_labels = Array[SpanLabel]
+    _replay_seq = recover val Array[_Choice val] end
+    _replay_idx = 0
+    _replay_exhausted_flag = false
+
+  fun ref _get_choices(): Array[_Choice val] val =>
+    _choices =
+      recover iso Array[_Choice val] end
+
+  fun ref _get_spans(): Array[_Span val] val =>
+    _spans =
+      recover iso Array[_Span val] end
+
+  fun _consumed(): USize =>
+    _replay_idx
+
+  // --- Internal draw helpers ---
+  fun ref _draw_int(min: I128, max: I128, shrink_towards: I128): I128 ? =>
+    match \exhaustive\ _mode
+    | _ModePlain =>
+      _raw_int(min, max)
+    | _ModeRecording =>
+      let v = _raw_int(min, max)
+      let towards = shrink_towards.max(min).min(max)
+      _choices.push(_IntChoice(v, min, max, towards))
+      v
+    | _ModeReplaying =>
+      if _replay_idx >= _replay_seq.size() then
+        _replay_exhausted_flag = true
+        error
+      end
+      match _replay_seq(_replay_idx)?
+      | let ic: _IntChoice =>
+        _replay_idx = _replay_idx + 1
+        ic.value.max(min).min(max)
+      else
+        error
+      end
+    end
+
+  fun ref _draw_float(min: F64, max: F64): F64 ? =>
+    match \exhaustive\ _mode
+    | _ModePlain =>
+      (_random.real() * (max - min)) + min
+    | _ModeRecording =>
+      let v = (_random.real() * (max - min)) + min
+      _choices.push(_FloatChoice(v, min, max))
+      v
+    | _ModeReplaying =>
+      if _replay_idx >= _replay_seq.size() then
+        _replay_exhausted_flag = true
+        error
+      end
+      match _replay_seq(_replay_idx)?
+      | let fc: _FloatChoice =>
+        _replay_idx = _replay_idx + 1
+        fc.value.max(min).min(max)
+      else
+        error
+      end
+    end
+
+  fun ref _draw_u128(min: U128, max: U128, shrink_towards: U128): U128 ? =>
+    match \exhaustive\ _mode
+    | _ModePlain =>
+      _raw_u128(min, max)
+    | _ModeRecording =>
+      let v = _raw_u128(min, max)
+      let towards = shrink_towards.max(min).min(max)
+      _choices.push(_U128Choice(v, min, max, towards))
+      v
+    | _ModeReplaying =>
+      if _replay_idx >= _replay_seq.size() then
+        _replay_exhausted_flag = true
+        error
+      end
+      match _replay_seq(_replay_idx)?
+      | let uc: _U128Choice =>
+        _replay_idx = _replay_idx + 1
+        uc.value.max(min).min(max)
+      else
+        error
+      end
+    end
+
+  fun ref _raw_u128(min: U128, max: U128): U128 =>
+    if min == max then return min end
+    let range: U128 = max - min
+    if range <= U64.max_value().u128() then
+      if range == U64.max_value().u128() then
+        min + _random.u64().u128()
+      else
+        min + _random.int(range.u64() + 1).u128()
+      end
+    else
+      let high = _random.u64()
+      let low = _random.u64()
+      let raw = (high.u128() << 64) or low.u128()
+      if range == U128.max_value() then
+        min + raw
+      else
+        min + (raw %% (range + 1))
+      end
+    end
+
+  fun ref _raw_int(min: I128, max: I128): I128 =>
+    """
+    Generate a random I128 in [min, max] using the underlying PRNG.
+    """
+    if min == max then return min end
+    let range: U128 = (max - min).u128()
+    if range <= U64.max_value().u128() then
+      if range == U64.max_value().u128() then
+        min + _random.u64().i128()
+      else
+        min + _random.int(range.u64() + 1).i128()
+      end
+    else
+      let high = _random.u64()
+      let low = _random.u64()
+      let raw = (high.u128() << 64) or low.u128()
+      if range == U128.max_value() then
+        min + raw.i128()
+      else
+        min + (raw %% (range + 1)).i128()
+      end
+    end

--- a/test/full-program-tests/regression-4838/main.pony
+++ b/test/full-program-tests/regression-4838/main.pony
@@ -10,9 +10,9 @@ use @pony_exitcode[None](code: I32)
 // method to not be marked as reachable, leaving a hole in the vtable and
 // producing a segfault at runtime.
 //
-// The bug manifests when Generator.map's internal _map_shrunken method
-// passes a lambda to Iter.map, creating a chain of nested object literals.
-// Iterating the resulting shrink iterator triggers the segfault because the
+// The bug manifests when Generator.map's internal object literal wraps
+// a lambda passed by the caller, creating a chain of nested object literals.
+// Calling generate on the mapped generator triggers the segfault because the
 // lambda's apply method has no vtable entry.
 
 actor Main
@@ -22,16 +22,10 @@ actor Main
     end
     let rnd = Randomness
     try
-      // generate_and_shrink returns the mapped value and a shrink iterator.
-      // The shrink iterator is produced by _map_shrunken, which uses the
-      // nested lambda pattern that triggers the bug.
-      (let value: U32, let shrunken: Iterator[U32^]) =
-        gen.generate_and_shrink(rnd)?
-      // Iterating the shrink iterator calls the nested lambda's apply.
+      // generate calls through the mapped generator's object literal,
+      // which invokes the lambda — the nested pattern that triggers the bug.
       // Without the fix, this segfaults due to the missing vtable entry.
-      while shrunken.has_next() do
-        shrunken.next()?
-      end
+      let value: U32 = gen.generate(rnd)?
       @pony_exitcode(0)
     else
       @pony_exitcode(1)

--- a/tools/pony-lint/test/_test_glob_match.pony
+++ b/tools/pony-lint/test/_test_glob_match.pony
@@ -142,14 +142,12 @@ class \nodoc\ _TestGlobMatchLiteralSelfMatchProperty is Property1[String]
   fun gen(): Generator[String] =>
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness): GenerateResult[String] =>
-          // Generate strings without * or /
-          let len = rnd.u8(0, 20).usize()
+        fun generate(rnd: Randomness): String^ ? =>
+          let len = rnd.u8(0, 20)?.usize()
           let s = recover iso String(len) end
           var i: USize = 0
           while i < len do
-            // ASCII printable chars excluding * and /
-            var ch = rnd.u8(33, 126)
+            var ch = rnd.u8(33, 126)?
             if ch == '*' then ch = 'a' end
             if ch == '/' then ch = 'b' end
             s.push(ch)
@@ -172,17 +170,16 @@ class \nodoc\ _TestGlobMatchStarNoCrossSlashProperty is Property1[String]
   fun gen(): Generator[String] =>
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness): GenerateResult[String] =>
-          let len = rnd.u8(0, 15).usize()
+        fun generate(rnd: Randomness): String^ ? =>
+          let len = rnd.u8(0, 15)?.usize()
           let s = recover iso String(len) end
           var i: USize = 0
           while i < len do
-            // Mix of alphanumeric, /, and other chars
-            let mode = rnd.u8(0, 3)
+            let mode = rnd.u8(0, 3)?
             if mode == 0 then
               s.push('/')
             else
-              s.push('a' + rnd.u8(0, 25))
+              s.push('a' + rnd.u8(0, 25)?)
             end
             i = i + 1
           end
@@ -206,16 +203,16 @@ class \nodoc\ _TestGlobMatchDoubleStarMatchesAllProperty is Property1[String]
   fun gen(): Generator[String] =>
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness): GenerateResult[String] =>
-          let len = rnd.u8(0, 30).usize()
+        fun generate(rnd: Randomness): String^ ? =>
+          let len = rnd.u8(0, 30)?.usize()
           let s = recover iso String(len) end
           var i: USize = 0
           while i < len do
-            let mode = rnd.u8(0, 3)
+            let mode = rnd.u8(0, 3)?
             if mode == 0 then
               s.push('/')
             else
-              s.push('a' + rnd.u8(0, 25))
+              s.push('a' + rnd.u8(0, 25)?)
             end
             i = i + 1
           end

--- a/tools/pony-lint/test/_test_naming.pony
+++ b/tools/pony-lint/test/_test_naming.pony
@@ -151,21 +151,19 @@ class \nodoc\ _TestCamelCaseValidProperty is Property1[String]
   fun gen(): Generator[String] =>
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness)
-          : GenerateResult[String]
-        =>
-          let len = rnd.u8(1, 10).usize()
+        fun generate(rnd: Randomness): String^ ? =>
+          let len = rnd.u8(1, 10)?.usize()
           let s = recover iso String(len + 2) end
           // Optional leading underscore (~25%)
-          if rnd.bool() and rnd.bool() then
+          if rnd.bool()? and rnd.bool()? then
             s.push('_')
           end
           // First significant char: uppercase
-          s.push('A' + rnd.u8(0, 25))
+          s.push('A' + rnd.u8(0, 25)?)
           // Remaining: alphanumeric only
           var i: USize = 1
           while i < len do
-            let ch = rnd.u8(0, 61)
+            let ch = rnd.u8(0, 61)?
             if ch < 26 then
               s.push('A' + ch)
             elseif ch < 52 then
@@ -193,10 +191,8 @@ class \nodoc\ _TestCamelCaseInvalidProperty is Property1[String]
   fun gen(): Generator[String] =>
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness)
-          : GenerateResult[String]
-        =>
-          let mode = rnd.u8(0, 4)
+        fun generate(rnd: Randomness): String^ ? =>
+          let mode = rnd.u8(0, 4)?
           let s = recover iso String(12) end
           if mode == 0 then
             // Empty string
@@ -206,23 +202,23 @@ class \nodoc\ _TestCamelCaseInvalidProperty is Property1[String]
             s.push('_')
           elseif mode == 2 then
             // Starts with lowercase
-            if rnd.bool() then s.push('_') end
-            s.push('a' + rnd.u8(0, 25))
-            var extra = rnd.u8(0, 5).usize()
+            if rnd.bool()? then s.push('_') end
+            s.push('a' + rnd.u8(0, 25)?)
+            var extra = rnd.u8(0, 5)?.usize()
             while extra > 0 do
-              s.push('a' + rnd.u8(0, 25))
+              s.push('a' + rnd.u8(0, 25)?)
               extra = extra - 1
             end
           elseif mode == 3 then
             // Underscore in body
-            s.push('A' + rnd.u8(0, 25))
-            s.push('a' + rnd.u8(0, 25))
+            s.push('A' + rnd.u8(0, 25)?)
+            s.push('a' + rnd.u8(0, 25)?)
             s.push('_')
-            s.push('A' + rnd.u8(0, 25))
+            s.push('A' + rnd.u8(0, 25)?)
           else
             // Starts with digit
-            s.push('0' + rnd.u8(0, 9))
-            s.push('a' + rnd.u8(0, 25))
+            s.push('0' + rnd.u8(0, 9)?)
+            s.push('a' + rnd.u8(0, 25)?)
           end
           consume s
       end)
@@ -242,21 +238,19 @@ class \nodoc\ _TestSnakeCaseValidProperty is Property1[String]
   fun gen(): Generator[String] =>
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness)
-          : GenerateResult[String]
-        =>
-          let len = rnd.u8(1, 10).usize()
+        fun generate(rnd: Randomness): String^ ? =>
+          let len = rnd.u8(1, 10)?.usize()
           let s = recover iso String(len + 2) end
           // Optional leading underscore (~25%)
-          if rnd.bool() and rnd.bool() then
+          if rnd.bool()? and rnd.bool()? then
             s.push('_')
           end
           // First significant char: lowercase
-          s.push('a' + rnd.u8(0, 25))
+          s.push('a' + rnd.u8(0, 25)?)
           // Remaining: lowercase, digits, underscores
           var i: USize = 1
           while i < len do
-            let ch = rnd.u8(0, 36)
+            let ch = rnd.u8(0, 36)?
             if ch < 26 then
               s.push('a' + ch)
             elseif ch < 36 then
@@ -284,10 +278,8 @@ class \nodoc\ _TestSnakeCaseInvalidProperty is Property1[String]
   fun gen(): Generator[String] =>
     Generator[String](
       object is GenObj[String]
-        fun generate(rnd: Randomness)
-          : GenerateResult[String]
-        =>
-          let mode = rnd.u8(0, 3)
+        fun generate(rnd: Randomness): String^ ? =>
+          let mode = rnd.u8(0, 3)?
           let s = recover iso String(12) end
           if mode == 0 then
             // Empty string
@@ -297,19 +289,19 @@ class \nodoc\ _TestSnakeCaseInvalidProperty is Property1[String]
             s.push('_')
           elseif mode == 2 then
             // Starts with uppercase
-            if rnd.bool() then s.push('_') end
-            s.push('A' + rnd.u8(0, 25))
-            var extra = rnd.u8(0, 5).usize()
+            if rnd.bool()? then s.push('_') end
+            s.push('A' + rnd.u8(0, 25)?)
+            var extra = rnd.u8(0, 5)?.usize()
             while extra > 0 do
-              s.push('a' + rnd.u8(0, 25))
+              s.push('a' + rnd.u8(0, 25)?)
               extra = extra - 1
             end
           else
             // Uppercase in body
-            s.push('a' + rnd.u8(0, 25))
-            s.push('a' + rnd.u8(0, 25))
-            s.push('A' + rnd.u8(0, 25))
-            s.push('a' + rnd.u8(0, 25))
+            s.push('a' + rnd.u8(0, 25)?)
+            s.push('a' + rnd.u8(0, 25)?)
+            s.push('A' + rnd.u8(0, 25)?)
+            s.push('a' + rnd.u8(0, 25)?)
           end
           consume s
       end)


### PR DESCRIPTION
PonyCheck's type-based shrinking is replaced with choice-sequence recording and replay, modeled on Hypothesis. Instead of each generator producing both a value and a shrink iterator, the framework records every random draw made during generation. When a property fails, it replays the generator against mutated choice sequences to find smaller failing inputs. Five passes over the recorded sequence: delete structural spans, binary-search each choice toward its shrink target, redistribute weight between adjacent integers, truncate trailing choices, sort adjacent spans. Passes run in a convergence loop — after all five complete, if any made progress, they restart from the beginning.

Custom generators get simpler. The old API required `generate` to return a `GenerateResult[T]` bundling a value with a shrink iterator — roughly 30 lines for a custom class generator. Now `generate` returns `T^` and the framework handles shrinking. About 5 lines for the same generator.

Breaking API changes: `generate` returns `T^` instead of `GenerateResult[T]`. All `Randomness` draw methods are now partial (`?`). `Randomness.end_span` is now partial — errors on mismatched start/end calls. Removed: `generate_and_shrink`, `generate_value`, `value_iter`, `shrink`, `iter`, `value_and_shrink_iter`, `GenerateResult`, `ValueAndShrink`, the `do_shrink` parameter on `one_of`. All consumers in stdlib (iregex, json) and examples are updated.

Design: #5993
