### PR TITLE
Add .par archive codec to pony-dep

### DIFF
--- a/tools/pony-dep/_unreachable.pony
+++ b/tools/pony-dep/_unreachable.pony
@@ -1,0 +1,20 @@
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[U8]]()
+use @exit[None](code: I32)
+
+primitive _Unreachable
+  """
+  Crashes the program when a code path that should be unreachable is reached.
+
+  Use in `else` blocks of `try` expressions where bounds are guarded by prior
+  checks and the error path is logically impossible.
+  """
+  fun apply(loc: SourceLoc = __loc): None =>
+    let url = "https://github.com/ponylang/ponyc/issues"
+    let fmt = "Unreachable at %s:%zu\nPlease report: " + url + "\n"
+    @fprintf(
+      @pony_os_stderr(),
+      fmt.cstring(),
+      loc.file().cstring(),
+      loc.line())
+    @exit(1)

--- a/tools/pony-dep/archive_decoder.pony
+++ b/tools/pony-dep/archive_decoder.pony
@@ -1,0 +1,67 @@
+use "buffered"
+use "files"
+
+primitive ArchiveDecoder
+  """
+  Decodes a Pony archive (.par) into a target directory.
+
+  Rejects invalid paths, unknown version bytes, and unknown entry types.
+  Fails hard on invalid paths rather than skipping them.
+  """
+  fun apply(archive: FilePath, to: Directory) ? =>
+    let reader: Reader = Reader
+
+    match OpenFile(archive)
+    | let f: File =>
+      reader.append(f.read(f.size()))
+      f.dispose()
+
+      let version = reader.u8()?
+      if version != 1 then
+        error
+      end
+
+      while reader.size() > 0 do
+        let entry_type = reader.u8()?
+        match entry_type
+        | 1 =>
+          let path_size = reader.u32_le()?.usize()
+          let path_block = reader.block(path_size)?
+          let path = String.from_array(consume path_block)
+
+          if not PathValidator(path) then
+            error
+          end
+
+          let content_size = reader.u32_le()?.usize()
+          let content = reader.block(content_size)?
+
+          let file = to.create_file(path)?
+          if not file.set_length(0) then
+            file.dispose()
+            error
+          end
+          if not file.write(consume content) then
+            file.dispose()
+            error
+          end
+          file.dispose()
+        | 2 =>
+          let path_size = reader.u32_le()?.usize()
+          let path_block = reader.block(path_size)?
+          let path = String.from_array(consume path_block)
+
+          if not PathValidator(path) then
+            error
+          end
+
+          if not to.mkdir(path) then
+            error
+          end
+        else
+          error
+        end
+      end
+    else
+      error
+    end

--- a/tools/pony-dep/archive_encoder.pony
+++ b/tools/pony-dep/archive_encoder.pony
@@ -1,0 +1,126 @@
+use "buffered"
+use "collections"
+use "files"
+
+class ArchiveEncoder
+  """
+  Encodes files and directories into a Pony archive (.par).
+
+  All paths are stored relative to the root directory passed at
+  construction. Directory contents are sorted lexicographically at each
+  level for deterministic output. Symlinks are skipped. Errors on
+  unreadable files.
+  """
+  let _root: FilePath
+  embed _writer: Writer = Writer
+
+  new create(root: FilePath) ? =>
+    """
+    Errors if `root` lacks FileStat capability.
+    """
+    if not root.caps(FileStat) then
+      error
+    end
+    _root = root
+    _writer.u8(1)
+
+  fun ref add(from: FilePath) ? =>
+    """
+    Descends recursively into directories. Symlinks are skipped. Errors on
+    unreadable files.
+    """
+    if not from.caps(FileStat) then
+      error
+    end
+
+    let info = FileInfo(from)?
+    if info.symlink then
+      return
+    end
+
+    if info.file then
+      _add_file(from)?
+    elseif info.directory then
+      _add_directory(from)?
+    end
+
+  fun ref write(to: FilePath) ? =>
+    """
+    Replaces any existing file at `to`. Errors if the file cannot be
+    created. The encoder must not be reused after calling this.
+    """
+    match CreateFile(to)
+    | let archive: File =>
+      if not archive.set_length(0) then
+        archive.dispose()
+        error
+      end
+      for chunk in _writer.done().values() do
+        if not archive.write(chunk) then
+          archive.dispose()
+          error
+        end
+      end
+      archive.dispose()
+    else
+      error
+    end
+
+  fun ref _add_file(entry: FilePath) ? =>
+    let name = _relative_path(entry.path)
+    if name.size() > U32.max_value().usize() then error end
+
+    let content: Array[U8] val =
+      match OpenFile(entry)
+      | let file: File =>
+        let data = file.read(file.size())
+        file.dispose()
+        consume data
+      else
+        error
+      end
+
+    if content.size() > U32.max_value().usize() then error end
+    _writer.u8(1)
+    _writer.u32_le(name.size().u32())
+    _writer.write(name)
+    _writer.u32_le(content.size().u32())
+    _writer.write(content)
+
+  fun ref _add_directory(dir: FilePath) ? =>
+    let name = _relative_path(dir.path)
+    if (name.size() > 0) and (name != ".") then
+      if name.size() > U32.max_value().usize() then error end
+      _writer.u8(2)
+      _writer.u32_le(name.size().u32())
+      _writer.write(name)
+    end
+
+    with d = Directory(dir)? do
+      let sorted = Sort[Array[String], String](d.entries()?)
+      for entry_name in sorted.values() do
+        let child = dir.join(entry_name)?
+        let info = FileInfo(child)?
+        if info.symlink then
+          None
+        elseif info.file then
+          _add_file(child)?
+        elseif info.directory then
+          _add_directory(child)?
+        end
+      end
+    end
+
+  fun _relative_path(path: String): String =>
+    let rel =
+      try
+        Path.rel(_root.path, path)?
+      else
+        _Unreachable()
+        ""
+      end
+    ifdef windows then
+      rel.clone().>replace("\\", "/")
+    else
+      rel
+    end

--- a/tools/pony-dep/path_validator.pony
+++ b/tools/pony-dep/path_validator.pony
@@ -1,0 +1,45 @@
+primitive PathValidator
+  """
+  Validates archive entry paths. Rejects paths that could escape the target
+  directory, contain backslashes or NUL bytes, or have empty or dot segments.
+  """
+  fun apply(path: String): Bool =>
+    if path.size() == 0 then
+      return false
+    end
+
+    try
+      if path(0)? == '/' then
+        return false
+      end
+
+      var i: USize = 0
+      while i < path.size() do
+        let c = path(i)?
+        if c == '\\' then
+          return false
+        end
+        if c == 0 then
+          return false
+        end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+      return false
+    end
+
+    let segments = path.split_by("/")
+    for segment in (consume segments).values() do
+      if segment == ".." then
+        return false
+      end
+      if segment == "." then
+        return false
+      end
+      if segment.size() == 0 then
+        return false
+      end
+    end
+
+    true

--- a/tools/pony-dep/test/_test_archive_decoder.pony
+++ b/tools/pony-dep/test/_test_archive_decoder.pony
@@ -1,0 +1,304 @@
+use "buffered"
+use "files"
+use "pony_test"
+use dep = ".."
+
+class \nodoc\ _TestArchiveDecoderRoundTrip is UnitTest
+  fun name(): String => "ArchiveDecoder/round-trip single file"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    let dir = Directory(root)?
+
+    let f = dir.create_file("hello.pony")?
+    f.print("actor Main")
+    f.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("hello.pony")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+    dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+
+    let extracted = File.open(out_path.join("hello.pony")?)
+    let content: String val = extracted.read_string(extracted.size())
+    extracted.dispose()
+    h.assert_eq[String val](content, "actor Main\n")
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderRoundTripNested is UnitTest
+  fun name(): String => "ArchiveDecoder/round-trip nested directories"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    let dir = Directory(root)?
+
+    dir.mkdir("pkg")
+    dir.mkdir("pkg/sub")
+    let f1 = dir.create_file("pkg/top.pony")?
+    f1.print("primitive Top")
+    f1.dispose()
+    let f2 = dir.create_file("pkg/sub/deep.pony")?
+    f2.print("primitive Deep")
+    f2.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("pkg")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+    dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+
+    let top = File.open(out_path.join("pkg/top.pony")?)
+    let top_content: String val = top.read_string(top.size())
+    top.dispose()
+    h.assert_eq[String val](top_content, "primitive Top\n")
+
+    let deep = File.open(out_path.join("pkg/sub/deep.pony")?)
+    let deep_content: String val = deep.read_string(deep.size())
+    deep.dispose()
+    h.assert_eq[String val](deep_content, "primitive Deep\n")
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderEmptyDirectory is UnitTest
+  fun name(): String => "ArchiveDecoder/round-trip empty directory"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    Directory(root)?.mkdir("empty")
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("empty")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+    dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+
+    let info = FileInfo(out_path.join("empty")?)?
+    h.assert_true(info.directory)
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderRoundTripEmptyFile is UnitTest
+  fun name(): String => "ArchiveDecoder/round-trip empty file"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let f = Directory(root)?.create_file("empty.pony")?
+    f.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("empty.pony")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+    dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+
+    let extracted = File.open(out_path.join("empty.pony")?)
+    h.assert_eq[USize](extracted.size(), 0)
+    extracted.dispose()
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderRejectsTruncatedArchive is UnitTest
+  fun name(): String => "ArchiveDecoder/rejects truncated archive"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let writer = Writer
+    writer.u8(1)
+    writer.u8(1)
+    let path: String = "hello.pony"
+    writer.u32_le(path.size().u32())
+    writer.write(path)
+    writer.u32_le(U32(100))
+    writer.write("short")
+
+    let archive_path = root.join("bad.par")?
+    _WriteRawArchive(archive_path, consume writer)?
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+
+    h.assert_error({() ? =>
+      dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+    })
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderErrorsOnMkdirFailure is UnitTest
+  fun name(): String => "ArchiveDecoder/errors on mkdir failure"
+
+  fun apply(h: TestHelper) ? =>
+    ifdef not windows then
+      let tmp = _TestHelper.tmp_dir(h)?
+      let root = tmp.path
+
+      let writer = Writer
+      writer.u8(1)
+      writer.u8(2)
+      let dir_path: String = "subdir"
+      writer.u32_le(dir_path.size().u32())
+      writer.write(dir_path)
+
+      let archive_path = root.join("test.par")?
+      _WriteRawArchive(archive_path, consume writer)?
+
+      let out_path = root.join("output")?
+      out_path.mkdir()
+      @chmod(out_path.path.cstring(), U32(0x124))
+
+      h.assert_error({() ? =>
+        dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+      })
+
+      @chmod(out_path.path.cstring(), U32(0x1C0))
+      tmp.dispose()
+    end
+
+class \nodoc\ _TestArchiveDecoderErrorsOnMissingArchive is UnitTest
+  fun name(): String => "ArchiveDecoder/errors on missing archive"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let archive_path = root.join("nonexistent.par")?
+    let out_path = root.join("output")?
+    out_path.mkdir()
+
+    h.assert_error({() ? =>
+      dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+    })
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderRejectsPathTraversal is UnitTest
+  fun name(): String => "ArchiveDecoder/rejects path traversal"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let writer = Writer
+    writer.u8(1)
+    writer.u8(2)
+    let dir_path: String = "sub"
+    writer.u32_le(dir_path.size().u32())
+    writer.write(dir_path)
+    writer.u8(1)
+    let bad_path: String = "sub/../escape.pony"
+    writer.u32_le(bad_path.size().u32())
+    writer.write(bad_path)
+    writer.u32_le(U32(4))
+    writer.write("evil")
+
+    let archive_path = root.join("bad.par")?
+    _WriteRawArchive(archive_path, consume writer)?
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+
+    h.assert_error({() ? =>
+      dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+    })
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderRejectsUnknownVersion is UnitTest
+  fun name(): String => "ArchiveDecoder/rejects unknown version"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let writer = Writer
+    writer.u8(99)
+
+    let archive_path = root.join("bad.par")?
+    _WriteRawArchive(archive_path, consume writer)?
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+
+    h.assert_error({() ? =>
+      dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+    })
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderRejectsUnknownType is UnitTest
+  fun name(): String => "ArchiveDecoder/rejects unknown entry type"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let writer = Writer
+    writer.u8(1)
+    writer.u8(99)
+    let path: String = "foo.pony"
+    writer.u32_le(path.size().u32())
+    writer.write(path)
+
+    let archive_path = root.join("bad.par")?
+    _WriteRawArchive(archive_path, consume writer)?
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+
+    h.assert_error({() ? =>
+      dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+    })
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderRejectsAbsolutePath is UnitTest
+  fun name(): String => "ArchiveDecoder/rejects absolute path"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let writer = Writer
+    writer.u8(1)
+    writer.u8(2)
+    let bad_path: String = "/etc"
+    writer.u32_le(bad_path.size().u32())
+    writer.write(bad_path)
+
+    let archive_path = root.join("bad.par")?
+    _WriteRawArchive(archive_path, consume writer)?
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+
+    h.assert_error({() ? =>
+      dep.ArchiveDecoder(archive_path, Directory(out_path)?)?
+    })
+    tmp.dispose()
+
+primitive \nodoc\ _WriteRawArchive
+  fun apply(path: FilePath, writer: Writer iso) ? =>
+    match CreateFile(path)
+    | let f: File =>
+      for chunk in (consume writer).done().values() do
+        f.write(chunk)
+      end
+      f.dispose()
+    else
+      error
+    end

--- a/tools/pony-dep/test/_test_archive_encoder.pony
+++ b/tools/pony-dep/test/_test_archive_encoder.pony
@@ -1,0 +1,290 @@
+use "files"
+use "pony_test"
+use dep = ".."
+
+class \nodoc\ _TestArchiveEncoderSingleFile is UnitTest
+  fun name(): String => "ArchiveEncoder/single file"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let f = Directory(root)?.create_file("hello.pony")?
+    f.print("actor Main")
+    f.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("hello.pony")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let reader = _TestHelper.read_archive(archive_path)?
+    h.assert_eq[U8](reader.u8()?, 1)
+
+    h.assert_eq[U8](reader.u8()?, 1)
+    let path_size = reader.u32_le()?.usize()
+    let path = String.from_array(reader.block(path_size)?)
+    h.assert_eq[String](path, "hello.pony")
+
+    let content_size = reader.u32_le()?.usize()
+    let content = String.from_array(reader.block(content_size)?)
+    h.assert_true(content.contains("actor Main"))
+
+    h.assert_eq[USize](reader.size(), 0)
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveEncoderDirectory is UnitTest
+  fun name(): String => "ArchiveEncoder/directory with files"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    let dir = Directory(root)?
+
+    dir.mkdir("src")
+    let f1 = dir.create_file("src/main.pony")?
+    f1.print("actor Main")
+    f1.dispose()
+    let f2 = dir.create_file("src/helper.pony")?
+    f2.print("class Helper")
+    f2.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("src")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let reader = _TestHelper.read_archive(archive_path)?
+    h.assert_eq[U8](reader.u8()?, 1)
+
+    // directory entry for "src"
+    h.assert_eq[U8](reader.u8()?, 2)
+    var ps = reader.u32_le()?.usize()
+    var p = String.from_array(reader.block(ps)?)
+    h.assert_eq[String](p, "src")
+
+    h.assert_eq[U8](reader.u8()?, 1)
+    ps = reader.u32_le()?.usize()
+    p = String.from_array(reader.block(ps)?)
+    h.assert_eq[String](p, "src/helper.pony")
+    var cs = reader.u32_le()?.usize()
+    reader.skip(cs)?
+
+    h.assert_eq[U8](reader.u8()?, 1)
+    ps = reader.u32_le()?.usize()
+    p = String.from_array(reader.block(ps)?)
+    h.assert_eq[String](p, "src/main.pony")
+    cs = reader.u32_le()?.usize()
+    reader.skip(cs)?
+
+    h.assert_eq[USize](reader.size(), 0)
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveEncoderNestedDirectories is UnitTest
+  fun name(): String => "ArchiveEncoder/nested directories"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    let dir = Directory(root)?
+
+    dir.mkdir("pkg")
+    dir.mkdir("pkg/sub")
+    let f = dir.create_file("pkg/sub/deep.pony")?
+    f.print("primitive Deep")
+    f.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("pkg")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let reader = _TestHelper.read_archive(archive_path)?
+    h.assert_eq[U8](reader.u8()?, 1)
+
+    // directory: pkg
+    h.assert_eq[U8](reader.u8()?, 2)
+    var ps = reader.u32_le()?.usize()
+    var p = String.from_array(reader.block(ps)?)
+    h.assert_eq[String](p, "pkg")
+
+    // directory: pkg/sub
+    h.assert_eq[U8](reader.u8()?, 2)
+    ps = reader.u32_le()?.usize()
+    p = String.from_array(reader.block(ps)?)
+    h.assert_eq[String](p, "pkg/sub")
+
+    // file: pkg/sub/deep.pony
+    h.assert_eq[U8](reader.u8()?, 1)
+    ps = reader.u32_le()?.usize()
+    p = String.from_array(reader.block(ps)?)
+    h.assert_eq[String](p, "pkg/sub/deep.pony")
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveEncoderEmptyDirectory is UnitTest
+  fun name(): String => "ArchiveEncoder/empty directory"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    Directory(root)?.mkdir("empty")
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("empty")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let reader = _TestHelper.read_archive(archive_path)?
+    h.assert_eq[U8](reader.u8()?, 1)
+
+    // directory entry for "empty", nothing else
+    h.assert_eq[U8](reader.u8()?, 2)
+    let ps = reader.u32_le()?.usize()
+    let p = String.from_array(reader.block(ps)?)
+    h.assert_eq[String](p, "empty")
+
+    h.assert_eq[USize](reader.size(), 0)
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveEncoderSkipsSymlinks is UnitTest
+  fun name(): String => "ArchiveEncoder/skips symlinks"
+
+  fun apply(h: TestHelper) ? =>
+    ifdef not windows then
+      let tmp = _TestHelper.tmp_dir(h)?
+      let root = tmp.path
+      let dir = Directory(root)?
+
+      let f = dir.create_file("real.pony")?
+      f.print("primitive Real")
+      f.dispose()
+
+      @symlink(
+        "real.pony".cstring(),
+        root.join("linked.pony")?.path.cstring())
+
+      let encoder = dep.ArchiveEncoder(root)?
+      encoder.add(root.join("real.pony")?)?
+      encoder.add(root.join("linked.pony")?)?
+
+      let archive_path = root.join("test.par")?
+      encoder.write(archive_path)?
+
+      let reader = _TestHelper.read_archive(archive_path)?
+      h.assert_eq[U8](reader.u8()?, 1)
+
+      // only real.pony, no linked.pony
+      h.assert_eq[U8](reader.u8()?, 1)
+      let ps = reader.u32_le()?.usize()
+      let p = String.from_array(reader.block(ps)?)
+      h.assert_eq[String](p, "real.pony")
+      let cs = reader.u32_le()?.usize()
+      reader.skip(cs)?
+
+      h.assert_eq[USize](reader.size(), 0)
+      tmp.dispose()
+    end
+
+class \nodoc\ _TestArchiveEncoderDeterministicOrder is UnitTest
+  fun name(): String => "ArchiveEncoder/deterministic ordering"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    let dir = Directory(root)?
+
+    dir.mkdir("pkg")
+    let f3 = dir.create_file("pkg/zebra.pony")?
+    f3.print("primitive Zebra")
+    f3.dispose()
+    let f1 = dir.create_file("pkg/alpha.pony")?
+    f1.print("primitive Alpha")
+    f1.dispose()
+    let f2 = dir.create_file("pkg/middle.pony")?
+    f2.print("primitive Middle")
+    f2.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("pkg")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let reader = _TestHelper.read_archive(archive_path)?
+    h.assert_eq[U8](reader.u8()?, 1)
+
+    // directory
+    h.assert_eq[U8](reader.u8()?, 2)
+    var ps = reader.u32_le()?.usize()
+    reader.skip(ps)?
+
+    // files in alphabetical order
+    let expected = ["alpha.pony"; "middle.pony"; "zebra.pony"]
+    for name' in expected.values() do
+      h.assert_eq[U8](reader.u8()?, 1)
+      ps = reader.u32_le()?.usize()
+      let p = String.from_array(reader.block(ps)?)
+      h.assert_eq[String](p, "pkg/" + name')
+      let cs = reader.u32_le()?.usize()
+      reader.skip(cs)?
+    end
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveEncoderRootDirectory is UnitTest
+  fun name(): String => "ArchiveEncoder/root directory skips dot entry"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let f = Directory(root)?.create_file("main.pony")?
+    f.print("actor Main")
+    f.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let reader = _TestHelper.read_archive(archive_path)?
+    h.assert_eq[U8](reader.u8()?, 1)
+
+    h.assert_eq[U8](reader.u8()?, 1)
+    let ps = reader.u32_le()?.usize()
+    let p = String.from_array(reader.block(ps)?)
+    h.assert_eq[String](p, "main.pony")
+    let cs = reader.u32_le()?.usize()
+    reader.skip(cs)?
+
+    h.assert_eq[USize](reader.size(), 0)
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveEncoderUnreadableFile is UnitTest
+  fun name(): String => "ArchiveEncoder/errors on unreadable file"
+
+  fun apply(h: TestHelper) ? =>
+    ifdef not windows then
+      let tmp = _TestHelper.tmp_dir(h)?
+      let root = tmp.path
+      let dir = Directory(root)?
+
+      let f = dir.create_file("nope.pony")?
+      f.print("secret")
+      f.dispose()
+
+      let file_path = root.join("nope.pony")?
+      @chmod(file_path.path.cstring(), U32(0))
+
+      h.assert_error({() ? =>
+        let encoder = dep.ArchiveEncoder(root)?
+        encoder.add(file_path)?
+      })
+
+      @chmod(file_path.path.cstring(), U32(0x180))
+      tmp.dispose()
+    end

--- a/tools/pony-dep/test/_test_helper.pony
+++ b/tools/pony-dep/test/_test_helper.pony
@@ -1,0 +1,37 @@
+use "buffered"
+use "files"
+use "pony_test"
+use "time"
+
+use @symlink[I32](target: Pointer[U8] tag, linkpath: Pointer[U8] tag)
+use @chmod[I32](path: Pointer[U8] tag, mode: U32)
+
+primitive \nodoc\ _TestHelper
+  fun read_archive(path: FilePath): Reader ? =>
+    let reader = Reader
+    match OpenFile(path)
+    | let f: File =>
+      reader.append(f.read(f.size()))
+      f.dispose()
+      reader
+    else
+      error
+    end
+
+  fun tmp_dir(h: TestHelper): _TmpDirHolder ? =>
+    let auth = FileAuth(h.env.root)
+    let dir_path = FilePath(auth,
+      "pony-dep-test-" + Time.nanos().string())
+    if not dir_path.mkdir() then
+      error
+    end
+    _TmpDirHolder(dir_path)
+
+class \nodoc\ _TmpDirHolder
+  let path: FilePath
+
+  new create(path': FilePath) =>
+    path = path'
+
+  fun dispose() =>
+    path.remove()

--- a/tools/pony-dep/test/_test_path_validator.pony
+++ b/tools/pony-dep/test/_test_path_validator.pony
@@ -1,0 +1,74 @@
+use "pony_test"
+use dep = ".."
+
+class \nodoc\ _TestPathValidatorSimplePath is UnitTest
+  fun name(): String => "PathValidator/simple path"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(dep.PathValidator("foo.pony"))
+
+class \nodoc\ _TestPathValidatorNestedPath is UnitTest
+  fun name(): String => "PathValidator/nested path"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(dep.PathValidator("src/foo/bar.pony"))
+
+class \nodoc\ _TestPathValidatorEmptyPath is UnitTest
+  fun name(): String => "PathValidator/empty path"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(dep.PathValidator(""))
+
+class \nodoc\ _TestPathValidatorAbsolutePath is UnitTest
+  fun name(): String => "PathValidator/absolute path"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(dep.PathValidator("/etc/passwd"))
+
+class \nodoc\ _TestPathValidatorDotDot is UnitTest
+  fun name(): String => "PathValidator/dot-dot component"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(dep.PathValidator("../escape"))
+    h.assert_false(dep.PathValidator("foo/../bar"))
+    h.assert_false(dep.PathValidator("foo/.."))
+
+class \nodoc\ _TestPathValidatorDot is UnitTest
+  fun name(): String => "PathValidator/dot component"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(dep.PathValidator("./foo"))
+    h.assert_false(dep.PathValidator("foo/./bar"))
+    h.assert_false(dep.PathValidator("."))
+
+class \nodoc\ _TestPathValidatorBackslash is UnitTest
+  fun name(): String => "PathValidator/backslash"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(dep.PathValidator("foo\\bar"))
+    h.assert_false(dep.PathValidator("src\\foo.pony"))
+
+class \nodoc\ _TestPathValidatorNulByte is UnitTest
+  fun name(): String => "PathValidator/NUL byte"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(dep.PathValidator("foo\x00bar"))
+
+class \nodoc\ _TestPathValidatorConsecutiveSlashes is UnitTest
+  fun name(): String => "PathValidator/consecutive slashes"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(dep.PathValidator("foo//bar"))
+
+class \nodoc\ _TestPathValidatorTrailingSlash is UnitTest
+  fun name(): String => "PathValidator/trailing slash"
+
+  fun apply(h: TestHelper) =>
+    h.assert_false(dep.PathValidator("foo/bar/"))
+
+class \nodoc\ _TestPathValidatorDotDotSubstring is UnitTest
+  fun name(): String => "PathValidator/dot-dot as substring"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(dep.PathValidator("foo..bar"))
+    h.assert_true(dep.PathValidator("..foo"))

--- a/tools/pony-dep/test/main.pony
+++ b/tools/pony-dep/test/main.pony
@@ -1,8 +1,43 @@
 use "pony_test"
+use dep = ".."
 
 actor \nodoc\ Main is TestList
   new create(env: Env) => PonyTest(env, this)
   new make() => None
 
   fun tag tests(test: PonyTest) =>
-    None
+    // PathValidator tests
+    test(_TestPathValidatorSimplePath)
+    test(_TestPathValidatorNestedPath)
+    test(_TestPathValidatorEmptyPath)
+    test(_TestPathValidatorAbsolutePath)
+    test(_TestPathValidatorDotDot)
+    test(_TestPathValidatorDot)
+    test(_TestPathValidatorBackslash)
+    test(_TestPathValidatorNulByte)
+    test(_TestPathValidatorConsecutiveSlashes)
+    test(_TestPathValidatorTrailingSlash)
+    test(_TestPathValidatorDotDotSubstring)
+
+    // ArchiveEncoder tests
+    test(_TestArchiveEncoderSingleFile)
+    test(_TestArchiveEncoderDirectory)
+    test(_TestArchiveEncoderNestedDirectories)
+    test(_TestArchiveEncoderEmptyDirectory)
+    test(_TestArchiveEncoderSkipsSymlinks)
+    test(_TestArchiveEncoderDeterministicOrder)
+    test(_TestArchiveEncoderRootDirectory)
+    test(_TestArchiveEncoderUnreadableFile)
+
+    // ArchiveDecoder tests
+    test(_TestArchiveDecoderRoundTrip)
+    test(_TestArchiveDecoderRoundTripNested)
+    test(_TestArchiveDecoderEmptyDirectory)
+    test(_TestArchiveDecoderRoundTripEmptyFile)
+    test(_TestArchiveDecoderRejectsTruncatedArchive)
+    test(_TestArchiveDecoderErrorsOnMkdirFailure)
+    test(_TestArchiveDecoderErrorsOnMissingArchive)
+    test(_TestArchiveDecoderRejectsPathTraversal)
+    test(_TestArchiveDecoderRejectsUnknownVersion)
+    test(_TestArchiveDecoderRejectsUnknownType)
+    test(_TestArchiveDecoderRejectsAbsolutePath)


### PR DESCRIPTION
Adds the `.par` (Pony ARchive) codec to pony-dep — encoder, decoder, path validator, and 30 tests. This is just the codec; no upload, download, or subcommand wiring.

The `.par` format is a simple container for packaging Pony source trees: a version byte followed by a stream of typed entries (files and directories) with no compression, no checksums, and no metadata. Content integrity is handled by a hash computed after extraction, outside the codec. The format evolved from corral's `.car` format.

The encoder walks a directory tree depth-first with lexicographic sorting at each level for deterministic output, skipping symlinks and erroring on unreadable files. The decoder validates every entry path through `PathValidator` before touching the filesystem.

Parked items from code review for future consideration:

- **P1 — Magic numbers**: Entry type bytes (`1` = file, `2` = directory) and the version byte (`1`) are inline literals in both encoder and decoder. Named constants would make the wire format self-documenting and guarantee encoder/decoder agreement at compile time.
- **P2 — Windows drive-letter paths**: `PathValidator` doesn't reject `C:foo` — defense-in-depth only, since `Directory.create_file`/`mkdir` enforce containment via `FilePath.from`.
- **P3 — `write()` reuse enforcement**: `ArchiveEncoder.write()` drains the internal buffer via `Writer.done()`. A second call produces a broken archive. The docstring warns against reuse but no runtime guard exists.
- **P4 — Structured errors**: Both encoder and decoder use bare `error` for all failure modes. The caller can't distinguish malformed archives from I/O failures from path traversal. Whether to add typed errors before the subcommand layer is wired up is a design question.

Design: #5991
