### PR TITLE
Add SHA-256 and Merkle tree content hashing to pony-dep

### DIFF
--- a/tools/pony-dep/content_hash.pony
+++ b/tools/pony-dep/content_hash.pony
@@ -1,0 +1,124 @@
+use "collections"
+use "files"
+
+class _LeafEntry is Comparable[_LeafEntry]
+  let path: String val
+  let hash: Array[U8] val
+
+  new create(path': String val, hash': Array[U8] val) =>
+    path = path'
+    hash = hash'
+
+  fun eq(that: _LeafEntry box): Bool => path == that.path
+  fun lt(that: _LeafEntry box): Bool => path < that.path
+
+primitive ContentHash
+  """
+  Computes a Merkle root hash over files in a directory tree. Walks the
+  directory recursively, hashing each file's content on the spot and
+  keeping only the 32-byte leaf hash — file content is not held in
+  memory across files.
+
+  Leaf hashes are sorted by relative path as raw bytes (lexicographic).
+  Each leaf is SHA-256(path_bytes || 0x00 || content_bytes), binding
+  the path into the hash to prevent swapped-content collisions. Interior
+  nodes are SHA-256(left || right). When a level has an odd number of
+  nodes, the last node promotes to the next level without pairing.
+
+  Symlinks are skipped. Errors if a file cannot be read.
+
+  Returns 32 zero bytes for an empty directory tree.
+  """
+  fun apply(root: FilePath): Array[U8] val ? =>
+    """
+    Returns the 32-byte Merkle root hash of all files under `root`.
+    """
+    let leaves = Array[_LeafEntry]
+    _walk(root, root.path, leaves)?
+    Sort[Array[_LeafEntry], _LeafEntry](leaves)
+
+    if leaves.size() == 0 then
+      return recover val Array[U8].init(U8(0), 32) end
+    end
+
+    var level = Array[Array[U8] val](leaves.size())
+    for entry in leaves.values() do
+      level.push(entry.hash)
+    end
+
+    while level.size() > 1 do
+      let next = Array[Array[U8] val]((level.size() + 1) / 2)
+      var j: USize = 0
+      while (j + 1) < level.size() do
+        try
+          let left = level(j)?
+          let right = level(j + 1)?
+          let pair =
+            recover val
+              Array[U8](64)
+                .> append(left)
+                .> append(right)
+            end
+          next.push(Sha256(pair))
+        else
+          _Unreachable()
+        end
+        j = j + 2
+      end
+      if (level.size() % 2) == 1 then
+        try next.push(level(level.size() - 1)?) else _Unreachable() end
+      end
+      level = next
+    end
+
+    try level(0)? else _Unreachable(); recover val Array[U8] end end
+
+  fun _walk(
+    dir: FilePath,
+    root_path: String,
+    leaves: Array[_LeafEntry])
+    ?
+  =>
+    with d = Directory(dir)? do
+      let sorted = Sort[Array[String], String](d.entries()?)
+      for entry_name in sorted.values() do
+        let child = dir.join(entry_name)?
+        let info = FileInfo(child)?
+        if info.symlink then
+          None
+        elseif info.file then
+          let rel =
+            try
+              Path.rel(root_path, child.path)?
+            else
+              _Unreachable()
+              ""
+            end
+          let rel_path: String val =
+            ifdef windows then
+              rel.clone() .> replace("\\", "/")
+            else
+              rel
+            end
+          let content: Array[U8] val =
+            match OpenFile(child)
+            | let f: File =>
+              let data = f.read(f.size())
+              f.dispose()
+              consume data
+            else
+              error
+            end
+          let leaf_input =
+            recover val
+              Array[U8](rel_path.size() + 1 + content.size())
+                .> append(rel_path)
+                .> push(0x00)
+                .> append(content)
+            end
+          leaves.push(_LeafEntry(rel_path, Sha256(leaf_input)))
+        elseif info.directory then
+          _walk(child, root_path, leaves)?
+        end
+      end
+    end

--- a/tools/pony-dep/sha256.pony
+++ b/tools/pony-dep/sha256.pony
@@ -1,0 +1,175 @@
+primitive Sha256
+  """
+  SHA-256 cryptographic hash (FIPS 180-4). Computes a 32-byte digest
+  from an arbitrary byte sequence.
+  """
+  fun apply(data: ReadSeq[U8] val): Array[U8] val =>
+    """
+    Returns the 32-byte SHA-256 digest of `data`.
+    """
+    var h0: U32 = 0x6a09e667
+    var h1: U32 = 0xbb67ae85
+    var h2: U32 = 0x3c6ef372
+    var h3: U32 = 0xa54ff53a
+    var h4: U32 = 0x510e527f
+    var h5: U32 = 0x9b05688c
+    var h6: U32 = 0x1f83d9ab
+    var h7: U32 = 0x5be0cd19
+
+    let msg_len = data.size()
+    let bit_len: U64 = msg_len.u64() * 8
+
+    // FIPS 180-4 Section 5.1.1
+    let padded_len = ((msg_len + 9) + 63) and not USize(63)
+    let padded: Array[U8] val =
+      recover val
+        let p = Array[U8](padded_len)
+        var i: USize = 0
+        while i < msg_len do
+          try p.push(data(i)?) else _Unreachable() end
+          i = i + 1
+        end
+        p.push(0x80)
+        var z: USize = padded_len - msg_len - 9
+        while z > 0 do
+          p.push(0)
+          z = z - 1
+        end
+        p.push((bit_len >> 56).u8())
+        p.push((bit_len >> 48).u8())
+        p.push((bit_len >> 40).u8())
+        p.push((bit_len >> 32).u8())
+        p.push((bit_len >> 24).u8())
+        p.push((bit_len >> 16).u8())
+        p.push((bit_len >> 8).u8())
+        p.push(bit_len.u8())
+        p
+      end
+
+    let k = _round_constants()
+    let w = Array[U32](64)
+
+    var block: USize = 0
+    while block < padded_len do
+      w.clear()
+      var t: USize = 0
+      while t < 16 do
+        let i = block + (t * 4)
+        try
+          w.push(
+            (padded(i)?.u32() << 24) or
+              (padded(i + 1)?.u32() << 16) or
+              (padded(i + 2)?.u32() << 8) or
+              padded(i + 3)?.u32())
+        else
+          _Unreachable()
+        end
+        t = t + 1
+      end
+      while t < 64 do
+        try
+          w.push(
+            _lsigma1(w(t - 2)?) + w(t - 7)? +
+              _lsigma0(w(t - 15)?) + w(t - 16)?)
+        else
+          _Unreachable()
+        end
+        t = t + 1
+      end
+
+      var a: U32 = h0; var b: U32 = h1
+      var c: U32 = h2; var d: U32 = h3
+      var e: U32 = h4; var f: U32 = h5
+      var g: U32 = h6; var h: U32 = h7
+
+      t = 0
+      while t < 64 do
+        try
+          let t1 = h + _usigma1(e) + _ch(e, f, g) + k(t)? + w(t)?
+          let t2 = _usigma0(a) + _maj(a, b, c)
+          h = g; g = f; f = e; e = d + t1
+          d = c; c = b; b = a; a = t1 + t2
+        else
+          _Unreachable()
+        end
+        t = t + 1
+      end
+
+      h0 = h0 + a; h1 = h1 + b; h2 = h2 + c; h3 = h3 + d
+      h4 = h4 + e; h5 = h5 + f; h6 = h6 + g; h7 = h7 + h
+
+      block = block + 64
+    end
+
+    recover val
+      let out = Array[U8](32)
+      _be32(out, h0); _be32(out, h1); _be32(out, h2); _be32(out, h3)
+      _be32(out, h4); _be32(out, h5); _be32(out, h6); _be32(out, h7)
+      out
+    end
+
+  fun hex(digest: ReadSeq[U8] val): String val =>
+    """
+    Hex-encodes a byte sequence as lowercase hexadecimal.
+    """
+    let hex_chars: String val = "0123456789abcdef"
+    recover val
+      let s = String(digest.size() * 2)
+      var i: USize = 0
+      while i < digest.size() do
+        try
+          let byte = digest(i)?
+          s.push(hex_chars((byte >> 4).usize())?)
+          s.push(hex_chars((byte and 0x0f).usize())?)
+        else
+          _Unreachable()
+        end
+        i = i + 1
+      end
+      s
+    end
+
+  fun _ch(x: U32, y: U32, z: U32): U32 =>
+    (x and y) xor ((not x) and z)
+
+  fun _maj(x: U32, y: U32, z: U32): U32 =>
+    (x and y) xor (x and z) xor (y and z)
+
+  fun _usigma0(x: U32): U32 =>
+    x.rotr(2) xor x.rotr(13) xor x.rotr(22)
+
+  fun _usigma1(x: U32): U32 =>
+    x.rotr(6) xor x.rotr(11) xor x.rotr(25)
+
+  fun _lsigma0(x: U32): U32 =>
+    x.rotr(7) xor x.rotr(18) xor (x >> 3)
+
+  fun _lsigma1(x: U32): U32 =>
+    x.rotr(17) xor x.rotr(19) xor (x >> 10)
+
+  fun _be32(out: Array[U8], v: U32) =>
+    out.push((v >> 24).u8())
+    out.push((v >> 16).u8())
+    out.push((v >> 8).u8())
+    out.push(v.u8())
+
+  fun _round_constants(): Array[U32] val =>
+    // FIPS 180-4 Section 4.2.2
+    [ as U32:
+      0x428a2f98; 0x71374491; 0xb5c0fbcf; 0xe9b5dba5
+      0x3956c25b; 0x59f111f1; 0x923f82a4; 0xab1c5ed5
+      0xd807aa98; 0x12835b01; 0x243185be; 0x550c7dc3
+      0x72be5d74; 0x80deb1fe; 0x9bdc06a7; 0xc19bf174
+      0xe49b69c1; 0xefbe4786; 0x0fc19dc6; 0x240ca1cc
+      0x2de92c6f; 0x4a7484aa; 0x5cb0a9dc; 0x76f988da
+      0x983e5152; 0xa831c66d; 0xb00327c8; 0xbf597fc7
+      0xc6e00bf3; 0xd5a79147; 0x06ca6351; 0x14292967
+      0x27b70a85; 0x2e1b2138; 0x4d2c6dfc; 0x53380d13
+      0x650a7354; 0x766a0abb; 0x81c2c92e; 0x92722c85
+      0xa2bfe8a1; 0xa81a664b; 0xc24b8b70; 0xc76c51a3
+      0xd192e819; 0xd6990624; 0xf40e3585; 0x106aa070
+      0x19a4c116; 0x1e376c08; 0x2748774c; 0x34b0bcb5
+      0x391c0cb3; 0x4ed8aa4a; 0x5b9cca4f; 0x682e6ff3
+      0x748f82ee; 0x78a5636f; 0x84c87814; 0x8cc70208
+      0x90befffa; 0xa4506ceb; 0xbef9a3f7; 0xc67178f2
+    ]

--- a/tools/pony-dep/test/_test_content_hash.pony
+++ b/tools/pony-dep/test/_test_content_hash.pony
@@ -1,0 +1,263 @@
+use "files"
+use "pony_test"
+use dep = ".."
+
+class \nodoc\ _TestContentHashSingleFile is UnitTest
+  fun name(): String => "ContentHash/single file"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let dir = Directory(tmp.path)?
+    let f = dir.create_file("hello.pony")?
+    f.write("actor")
+    f.dispose()
+
+    let root = dep.ContentHash(tmp.path)?
+    h.assert_eq[USize](root.size(), 32)
+
+    let expected = _ContentHashHelper._leaf("hello.pony", "actor")
+    h.assert_eq[String](dep.Sha256.hex(root), dep.Sha256.hex(expected))
+    tmp.dispose()
+
+class \nodoc\ _TestContentHashTwoFiles is UnitTest
+  fun name(): String => "ContentHash/two files"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let dir = Directory(tmp.path)?
+    let f1 = dir.create_file("b.pony")?
+    f1.write("2")
+    f1.dispose()
+    let f2 = dir.create_file("a.pony")?
+    f2.write("1")
+    f2.dispose()
+
+    let root = dep.ContentHash(tmp.path)?
+
+    let leaf_a = _ContentHashHelper._leaf("a.pony", "1")
+    let leaf_b = _ContentHashHelper._leaf("b.pony", "2")
+    let expected = _ContentHashHelper._pair(leaf_a, leaf_b)
+    h.assert_eq[String](dep.Sha256.hex(root), dep.Sha256.hex(expected))
+    tmp.dispose()
+
+class \nodoc\ _TestContentHashThreeFiles is UnitTest
+  fun name(): String => "ContentHash/three files (odd promotion)"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let dir = Directory(tmp.path)?
+    let f1 = dir.create_file("c.pony")?
+    f1.write("3")
+    f1.dispose()
+    let f2 = dir.create_file("a.pony")?
+    f2.write("1")
+    f2.dispose()
+    let f3 = dir.create_file("b.pony")?
+    f3.write("2")
+    f3.dispose()
+
+    let root = dep.ContentHash(tmp.path)?
+
+    let leaf_a = _ContentHashHelper._leaf("a.pony", "1")
+    let leaf_b = _ContentHashHelper._leaf("b.pony", "2")
+    let leaf_c = _ContentHashHelper._leaf("c.pony", "3")
+
+    let hash_ab = _ContentHashHelper._pair(leaf_a, leaf_b)
+    let expected = _ContentHashHelper._pair(hash_ab, leaf_c)
+    h.assert_eq[String](dep.Sha256.hex(root), dep.Sha256.hex(expected))
+    tmp.dispose()
+
+class \nodoc\ _TestContentHashFourFiles is UnitTest
+  fun name(): String => "ContentHash/four files (balanced)"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let dir = Directory(tmp.path)?
+    let f1 = dir.create_file("d.pony")?
+    f1.write("4")
+    f1.dispose()
+    let f2 = dir.create_file("b.pony")?
+    f2.write("2")
+    f2.dispose()
+    let f3 = dir.create_file("c.pony")?
+    f3.write("3")
+    f3.dispose()
+    let f4 = dir.create_file("a.pony")?
+    f4.write("1")
+    f4.dispose()
+
+    let root = dep.ContentHash(tmp.path)?
+
+    let leaf_a = _ContentHashHelper._leaf("a.pony", "1")
+    let leaf_b = _ContentHashHelper._leaf("b.pony", "2")
+    let leaf_c = _ContentHashHelper._leaf("c.pony", "3")
+    let leaf_d = _ContentHashHelper._leaf("d.pony", "4")
+
+    let hash_ab = _ContentHashHelper._pair(leaf_a, leaf_b)
+    let hash_cd = _ContentHashHelper._pair(leaf_c, leaf_d)
+    let expected = _ContentHashHelper._pair(hash_ab, hash_cd)
+    h.assert_eq[String](dep.Sha256.hex(root), dep.Sha256.hex(expected))
+    tmp.dispose()
+
+class \nodoc\ _TestContentHashFiveFiles is UnitTest
+  fun name(): String => "ContentHash/five files (multi-level promotion)"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let dir = Directory(tmp.path)?
+    let f1 = dir.create_file("e.pony")?
+    f1.write("5")
+    f1.dispose()
+    let f2 = dir.create_file("c.pony")?
+    f2.write("3")
+    f2.dispose()
+    let f3 = dir.create_file("a.pony")?
+    f3.write("1")
+    f3.dispose()
+    let f4 = dir.create_file("d.pony")?
+    f4.write("4")
+    f4.dispose()
+    let f5 = dir.create_file("b.pony")?
+    f5.write("2")
+    f5.dispose()
+
+    let root = dep.ContentHash(tmp.path)?
+
+    let leaf_a = _ContentHashHelper._leaf("a.pony", "1")
+    let leaf_b = _ContentHashHelper._leaf("b.pony", "2")
+    let leaf_c = _ContentHashHelper._leaf("c.pony", "3")
+    let leaf_d = _ContentHashHelper._leaf("d.pony", "4")
+    let leaf_e = _ContentHashHelper._leaf("e.pony", "5")
+
+    // Level 0: [a, b, c, d, e] -> pair(a,b), pair(c,d), promote(e)
+    let hash_ab = _ContentHashHelper._pair(leaf_a, leaf_b)
+    let hash_cd = _ContentHashHelper._pair(leaf_c, leaf_d)
+    // Level 1: [ab, cd, e] -> pair(ab,cd), promote(e)
+    let hash_abcd = _ContentHashHelper._pair(hash_ab, hash_cd)
+    // Level 2: [abcd, e] -> pair(abcd, e)
+    let expected = _ContentHashHelper._pair(hash_abcd, leaf_e)
+    h.assert_eq[String](dep.Sha256.hex(root), dep.Sha256.hex(expected))
+    tmp.dispose()
+
+class \nodoc\ _TestContentHashPathBinding is UnitTest
+  fun name(): String => "ContentHash/path binding prevents swap"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp1 = _TestHelper.tmp_dir(h)?
+    let dir1 = Directory(tmp1.path)?
+    let f1a = dir1.create_file("a.pony")?
+    f1a.write("X")
+    f1a.dispose()
+    let f1b = dir1.create_file("b.pony")?
+    f1b.write("Y")
+    f1b.dispose()
+
+    let tmp2 = _TestHelper.tmp_dir(h)?
+    let dir2 = Directory(tmp2.path)?
+    let f2a = dir2.create_file("a.pony")?
+    f2a.write("Y")
+    f2a.dispose()
+    let f2b = dir2.create_file("b.pony")?
+    f2b.write("X")
+    f2b.dispose()
+
+    h.assert_ne[String](
+      dep.Sha256.hex(dep.ContentHash(tmp1.path)?),
+      dep.Sha256.hex(dep.ContentHash(tmp2.path)?))
+    tmp1.dispose()
+    tmp2.dispose()
+
+class \nodoc\ _TestContentHashEmpty is UnitTest
+  fun name(): String => "ContentHash/empty directory"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = dep.ContentHash(tmp.path)?
+    h.assert_eq[USize](root.size(), 32)
+    var all_zero = true
+    var i: USize = 0
+    while i < root.size() do
+      try
+        if root(i)? != 0 then all_zero = false end
+      end
+      i = i + 1
+    end
+    h.assert_true(all_zero)
+    tmp.dispose()
+
+class \nodoc\ _TestContentHashEmptyContent is UnitTest
+  fun name(): String => "ContentHash/empty file content"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let dir = Directory(tmp.path)?
+    let f = dir.create_file("empty.pony")?
+    f.dispose()
+
+    let root = dep.ContentHash(tmp.path)?
+
+    let expected = _ContentHashHelper._leaf("empty.pony", "")
+    h.assert_eq[String](dep.Sha256.hex(root), dep.Sha256.hex(expected))
+    tmp.dispose()
+
+class \nodoc\ _TestContentHashNestedDirs is UnitTest
+  fun name(): String => "ContentHash/nested directories"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let dir = Directory(tmp.path)?
+    dir.mkdir("src")
+    let f1 = dir.create_file("src/main.pony")?
+    f1.write("actor Main")
+    f1.dispose()
+    let f2 = dir.create_file("README.md")?
+    f2.write("hello")
+    f2.dispose()
+
+    let root = dep.ContentHash(tmp.path)?
+
+    let leaf_readme = _ContentHashHelper._leaf("README.md", "hello")
+    let leaf_main =
+      _ContentHashHelper._leaf("src/main.pony", "actor Main")
+    let expected = _ContentHashHelper._pair(leaf_readme, leaf_main)
+    h.assert_eq[String](dep.Sha256.hex(root), dep.Sha256.hex(expected))
+    tmp.dispose()
+
+class \nodoc\ _TestContentHashSkipsSymlinks is UnitTest
+  fun name(): String => "ContentHash/skips symlinks"
+
+  fun apply(h: TestHelper) ? =>
+    ifdef not windows then
+      let tmp = _TestHelper.tmp_dir(h)?
+      let dir = Directory(tmp.path)?
+      let f = dir.create_file("real.pony")?
+      f.write("content")
+      f.dispose()
+
+      let source = tmp.path.join("real.pony")?
+      dir.symlink(source, "link.pony")
+
+      let root = dep.ContentHash(tmp.path)?
+
+      let expected = _ContentHashHelper._leaf("real.pony", "content")
+      h.assert_eq[String](dep.Sha256.hex(root), dep.Sha256.hex(expected))
+      tmp.dispose()
+    end
+
+primitive \nodoc\ _ContentHashHelper
+  fun _leaf(path: String val, content: String val): Array[U8] val =>
+    dep.Sha256(
+      recover val
+        Array[U8](path.size() + 1 + content.size())
+          .> append(path)
+          .> push(0x00)
+          .> append(content)
+      end)
+
+  fun _pair(left: Array[U8] val, right: Array[U8] val): Array[U8] val =>
+    dep.Sha256(
+      recover val
+        Array[U8](64)
+          .> append(left)
+          .> append(right)
+      end)

--- a/tools/pony-dep/test/_test_sha256.pony
+++ b/tools/pony-dep/test/_test_sha256.pony
@@ -1,0 +1,53 @@
+use "pony_test"
+use dep = ".."
+
+class \nodoc\ _TestSha256Empty is UnitTest
+  fun name(): String => "Sha256/empty string"
+
+  fun apply(h: TestHelper) =>
+    let digest = dep.Sha256(recover val Array[U8] end)
+    h.assert_eq[String](dep.Sha256.hex(digest),
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+
+class \nodoc\ _TestSha256Abc is UnitTest
+  fun name(): String => "Sha256/abc"
+
+  fun apply(h: TestHelper) =>
+    let digest = dep.Sha256("abc")
+    h.assert_eq[String](dep.Sha256.hex(digest),
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+
+class \nodoc\ _TestSha256TwoBlocks is UnitTest
+  fun name(): String => "Sha256/448-bit message"
+
+  fun apply(h: TestHelper) =>
+    let digest = dep.Sha256(
+      "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
+    h.assert_eq[String](dep.Sha256.hex(digest),
+      "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1")
+
+class \nodoc\ _TestSha256OneBlock is UnitTest
+  fun name(): String => "Sha256/55-byte message (one-block boundary)"
+
+  fun apply(h: TestHelper) =>
+    let digest = dep.Sha256(
+      "abcdefghijklmnopqrstuvwxyz12345678901234567890123456789")
+    h.assert_eq[String](dep.Sha256.hex(digest),
+      "2406ff49cbd6a01835dccc4d448265a1f57122b2bd0bc71926dfe9d9f5012a5f")
+
+class \nodoc\ _TestSha256LongMessage is UnitTest
+  fun name(): String => "Sha256/896-bit message"
+
+  fun apply(h: TestHelper) =>
+    let digest = dep.Sha256(
+      "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+      + "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")
+    h.assert_eq[String](dep.Sha256.hex(digest),
+      "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1")
+
+class \nodoc\ _TestSha256Hex is UnitTest
+  fun name(): String => "Sha256/hex encoding"
+
+  fun apply(h: TestHelper) =>
+    let bytes: Array[U8] val = [0x00; 0xFF; 0x0A; 0xBC]
+    h.assert_eq[String](dep.Sha256.hex(bytes), "00ff0abc")

--- a/tools/pony-dep/test/main.pony
+++ b/tools/pony-dep/test/main.pony
@@ -30,6 +30,26 @@ actor \nodoc\ Main is TestList
     test(_TestArchiveEncoderRootDirectory)
     test(_TestArchiveEncoderUnreadableFile)
 
+    // Sha256 tests
+    test(_TestSha256Empty)
+    test(_TestSha256Abc)
+    test(_TestSha256TwoBlocks)
+    test(_TestSha256OneBlock)
+    test(_TestSha256LongMessage)
+    test(_TestSha256Hex)
+
+    // ContentHash tests
+    test(_TestContentHashSingleFile)
+    test(_TestContentHashTwoFiles)
+    test(_TestContentHashThreeFiles)
+    test(_TestContentHashFourFiles)
+    test(_TestContentHashFiveFiles)
+    test(_TestContentHashPathBinding)
+    test(_TestContentHashEmpty)
+    test(_TestContentHashEmptyContent)
+    test(_TestContentHashNestedDirs)
+    test(_TestContentHashSkipsSymlinks)
+
     // ArchiveDecoder tests
     test(_TestArchiveDecoderRoundTrip)
     test(_TestArchiveDecoderRoundTripNested)


### PR DESCRIPTION
Pure Pony SHA-256 (FIPS 180-4) and a Merkle tree that hashes files in a directory tree, implementing the design from #5999.

`ContentHash` takes a directory path, walks it recursively, reads each file, computes its leaf hash, and drops the content — only 32-byte hashes are held across files. Leaf nodes are `SHA-256(path_bytes || 0x00 || content_bytes)`, binding the relative path into the hash so swapping content between two files always changes the root. Interior nodes are `SHA-256(left || right)`. Entries are sorted by path as raw bytes, and odd nodes promote without pairing (no duplication) to avoid second-preimage attacks. Symlinks are skipped.

The CLI commands that use this to verify dependencies will come in a follow-up.

Design: #5999
