### PR TITLE
Add pack subcommand to pony-dep

### DIFF
--- a/tools/pony-dep/archive_encoder.pony
+++ b/tools/pony-dep/archive_encoder.pony
@@ -24,6 +24,29 @@ class ArchiveEncoder
     _root = root
     _writer.u8(1)
 
+  fun ref add_file_entry(name: String, content: Array[U8] val) ? =>
+    """
+    Writes a file entry with the given relative path and content.
+    """
+    if name.size() > U32.max_value().usize() then error end
+    if content.size() > U32.max_value().usize() then error end
+    _writer.u8(1)
+    _writer.u32_le(name.size().u32())
+    _writer.write(name)
+    _writer.u32_le(content.size().u32())
+    _writer.write(content)
+
+  fun ref add_dir_entry(name: String) ? =>
+    """
+    Writes a directory entry. Entries named `"."` or empty are skipped.
+    """
+    if (name.size() > 0) and (name != ".") then
+      if name.size() > U32.max_value().usize() then error end
+      _writer.u8(2)
+      _writer.u32_le(name.size().u32())
+      _writer.write(name)
+    end
+
   fun ref add(from: FilePath) ? =>
     """
     Descends recursively into directories. Symlinks are skipped. Errors on
@@ -68,8 +91,6 @@ class ArchiveEncoder
 
   fun ref _add_file(entry: FilePath) ? =>
     let name = _relative_path(entry.path)
-    if name.size() > U32.max_value().usize() then error end
-
     let content: Array[U8] val =
       match OpenFile(entry)
       | let file: File =>
@@ -79,22 +100,11 @@ class ArchiveEncoder
       else
         error
       end
-
-    if content.size() > U32.max_value().usize() then error end
-    _writer.u8(1)
-    _writer.u32_le(name.size().u32())
-    _writer.write(name)
-    _writer.u32_le(content.size().u32())
-    _writer.write(content)
+    add_file_entry(name, content)?
 
   fun ref _add_directory(dir: FilePath) ? =>
     let name = _relative_path(dir.path)
-    if (name.size() > 0) and (name != ".") then
-      if name.size() > U32.max_value().usize() then error end
-      _writer.u8(2)
-      _writer.u32_le(name.size().u32())
-      _writer.write(name)
-    end
+    add_dir_entry(name)?
 
     with d = Directory(dir)? do
       let sorted = Sort[Array[String], String](d.entries()?)

--- a/tools/pony-dep/content_hash.pony
+++ b/tools/pony-dep/content_hash.pony
@@ -35,6 +35,23 @@ primitive ContentHash
     """
     let leaves = Array[_LeafEntry]
     _walk(root, root.path, leaves)?
+    _from_leaves(leaves)
+
+  fun leaf_hash(rel_path: String val, content: Array[U8] val): Array[U8] val
+  =>
+    """
+    Computes the leaf hash for a single file: SHA-256(path || 0x00 || content).
+    """
+    let input =
+      recover val
+        Array[U8](rel_path.size() + 1 + content.size())
+          .> append(rel_path)
+          .> push(0x00)
+          .> append(content)
+      end
+    Sha256(input)
+
+  fun _from_leaves(leaves: Array[_LeafEntry]): Array[U8] val =>
     Sort[Array[_LeafEntry], _LeafEntry](leaves)
 
     if leaves.size() == 0 then
@@ -109,14 +126,7 @@ primitive ContentHash
             else
               error
             end
-          let leaf_input =
-            recover val
-              Array[U8](rel_path.size() + 1 + content.size())
-                .> append(rel_path)
-                .> push(0x00)
-                .> append(content)
-            end
-          leaves.push(_LeafEntry(rel_path, Sha256(leaf_input)))
+          leaves.push(_LeafEntry(rel_path, leaf_hash(rel_path, content)))
         elseif info.directory then
           _walk(child, root_path, leaves)?
         end

--- a/tools/pony-dep/main.pony
+++ b/tools/pony-dep/main.pony
@@ -1,4 +1,5 @@
 use "cli"
+use "files"
 
 actor Main
   """
@@ -20,7 +21,15 @@ actor Main
           [
             CommandSpec.leaf(
               "pack",
-              "Create an archive from a project's source")?
+              "Create an archive from a project's source",
+              [
+                OptionSpec.bool(
+                  "hash", "Print content hash to stdout", 'H', false)
+              ],
+              [
+                ArgSpec.string("directory")
+                ArgSpec.string("output")
+              ])?
             CommandSpec.leaf(
               "fetch",
               "Download and extract a package archive from a URL")?
@@ -52,8 +61,30 @@ actor Main
         return
       end
 
+    let auth = FileAuth(env.root)
+
     match cmd.spec().name()
-    | "pack" => _not_implemented(env, "pack")
+    | "pack" =>
+      let dir = cmd.arg("directory").string()
+      let out = cmd.arg("output").string()
+      match \exhaustive\ Pack(
+        auth, dir, out where hash = cmd.option("hash").bool())
+      | let s: String val => env.out.print(s)
+      | None => None
+      | PackSourceNotFound =>
+        env.err.print("error: cannot stat '" + dir + "'")
+        env.exitcode(1)
+      | PackSourceNotDirectory =>
+        env.err.print("error: '" + dir + "' is not a directory")
+        env.exitcode(1)
+      | PackOutputInsideSource =>
+        env.err.print(
+          "error: output path cannot be inside the source directory")
+        env.exitcode(1)
+      | PackFailed =>
+        env.err.print("error: pack failed for '" + dir + "'")
+        env.exitcode(1)
+      end
     | "fetch" => _not_implemented(env, "fetch")
     | "add" => _not_implemented(env, "add")
     | "remove" => _not_implemented(env, "remove")

--- a/tools/pony-dep/pack.pony
+++ b/tools/pony-dep/pack.pony
@@ -1,0 +1,138 @@
+use "collections"
+use "files"
+
+primitive PackSourceNotFound
+  """
+  The source path does not exist or cannot be stat'd.
+  """
+
+primitive PackSourceNotDirectory
+  """
+  The source path exists but is not a directory.
+  """
+
+primitive PackOutputInsideSource
+  """
+  The output path falls inside the source directory.
+  """
+
+primitive PackFailed
+  """
+  An internal error occurred during packing.
+  """
+
+type PackError is
+  ( PackSourceNotFound
+  | PackSourceNotDirectory
+  | PackOutputInsideSource
+  | PackFailed )
+
+primitive Pack
+  """
+  Creates a `.par` archive from a source directory. Returns the content hash
+  when requested. Walks the source tree once, feeding each file to both the
+  archive encoder and the content hasher.
+  """
+  fun apply(
+    auth: FileAuth,
+    source_path: String,
+    output_path: String,
+    hash: Bool)
+    : (String val | None | PackError)
+  =>
+    """
+    Packs the directory at `source_path` into a `.par` archive at
+    `output_path`. Returns the hex-encoded content hash when `hash` is true.
+    """
+    let source =
+      try
+        let s = FilePath(auth, source_path)
+        let info = FileInfo(s)?
+        if not info.directory then
+          return PackSourceNotDirectory
+        end
+        s
+      else
+        return PackSourceNotFound
+      end
+
+    let abs_source = Path.abs(source_path)
+    let abs_out = Path.abs(output_path)
+    let prefix: String val = abs_source + Path.sep()
+    if abs_out.at(prefix) or (abs_out == abs_source) then
+      return PackOutputInsideSource
+    end
+
+    try
+      let encoder = ArchiveEncoder(source)?
+      let leaves: (Array[_LeafEntry] | None) =
+        if hash then Array[_LeafEntry] else None end
+
+      _walk(source, source.path, encoder, leaves)?
+
+      let output = FilePath(auth, output_path)
+      encoder.write(output)?
+
+      match leaves
+      | let l: Array[_LeafEntry] =>
+        let root_hash = ContentHash._from_leaves(l)
+        let s: String val = "sha256:" + Sha256.hex(root_hash)
+        s
+      else
+        None
+      end
+    else
+      PackFailed
+    end
+
+  fun _walk(
+    dir: FilePath,
+    root_path: String,
+    encoder: ArchiveEncoder ref,
+    leaves: (Array[_LeafEntry] | None)) ?
+  =>
+    let name = _relative_path(root_path, dir.path)
+    encoder.add_dir_entry(name)?
+
+    with d = Directory(dir)? do
+      let sorted = Sort[Array[String], String](d.entries()?)
+      for entry_name in sorted.values() do
+        let child = dir.join(entry_name)?
+        let child_info = FileInfo(child)?
+        if child_info.symlink then
+          None
+        elseif child_info.file then
+          let rel = _relative_path(root_path, child.path)
+          let content: Array[U8] val =
+            match OpenFile(child)
+            | let f: File =>
+              let data = f.read(f.size())
+              f.dispose()
+              consume data
+            else
+              error
+            end
+          encoder.add_file_entry(rel, content)?
+          match leaves
+          | let l: Array[_LeafEntry] =>
+            l.push(_LeafEntry(rel, ContentHash.leaf_hash(rel, content)))
+          end
+        elseif child_info.directory then
+          _walk(child, root_path, encoder, leaves)?
+        end
+      end
+    end
+
+  fun _relative_path(root_path: String, path: String): String =>
+    let rel =
+      try
+        Path.rel(root_path, path)?
+      else
+        _Unreachable()
+        ""
+      end
+    ifdef windows then
+      rel.clone() .> replace("\\", "/")
+    else
+      rel
+    end

--- a/tools/pony-dep/test/_test_pack.pony
+++ b/tools/pony-dep/test/_test_pack.pony
@@ -1,0 +1,184 @@
+use "files"
+use "pony_test"
+use dep = ".."
+
+class \nodoc\ _TestPackRoundTrip is UnitTest
+  """
+  Pack a directory, decode the archive, and verify the contents match.
+  """
+  fun name(): String => "Pack/round trip"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    let dir = Directory(root)?
+
+    let f1 = dir.create_file("main.pony")?
+    f1.print("actor Main")
+    f1.dispose()
+    dir.mkdir("sub")
+    let f2 = dir.create_file("sub/helper.pony")?
+    f2.print("class Helper")
+    f2.dispose()
+
+    let out_tmp = _TestHelper.tmp_dir(h)?
+    let archive_path = out_tmp.path.join("out.par")?
+    let auth = FileAuth(h.env.root)
+    match dep.Pack(auth, root.path, archive_path.path where hash = false)
+    | let e: dep.PackError => h.fail("pack failed"); return
+    end
+
+    let out_dir = root.join("out")?
+    out_dir.mkdir()
+    let out = Directory(out_dir)?
+    dep.ArchiveDecoder(archive_path, out)?
+
+    let main_file =
+      match OpenFile(out_dir.join("main.pony")?)
+      | let f: File =>
+        let data = f.read(f.size())
+        f.dispose()
+        String.from_iso_array(consume data)
+      else
+        h.fail("missing main.pony")
+        return
+      end
+    h.assert_true(main_file.contains("actor Main"))
+
+    let helper_file =
+      match OpenFile(out_dir.join("sub/helper.pony")?)
+      | let f: File =>
+        let data = f.read(f.size())
+        f.dispose()
+        String.from_iso_array(consume data)
+      else
+        h.fail("missing sub/helper.pony")
+        return
+      end
+    h.assert_true(helper_file.contains("class Helper"))
+
+    tmp.dispose()
+    out_tmp.dispose()
+
+class \nodoc\ _TestPackHash is UnitTest
+  """
+  Pack with hash=true returns the content hash, matching an independent
+  ContentHash computation on the same source.
+  """
+  fun name(): String => "Pack/hash output"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let f = Directory(root)?.create_file("hello.pony")?
+    f.print("actor Main")
+    f.dispose()
+
+    let out_tmp = _TestHelper.tmp_dir(h)?
+    let archive_path = out_tmp.path.join("out.par")?
+    let auth = FileAuth(h.env.root)
+    let result = dep.Pack(auth, root.path, archive_path.path
+      where hash = true)
+
+    match result
+    | let s: String val =>
+      let expected = dep.ContentHash(root)?
+      let expected_str: String val = "sha256:" + dep.Sha256.hex(expected)
+      h.assert_true(s == expected_str)
+    | let e: dep.PackError =>
+      h.fail("pack failed")
+    else
+      h.fail("expected hash string")
+    end
+
+    tmp.dispose()
+    out_tmp.dispose()
+
+class \nodoc\ _TestPackEmptyDirectory is UnitTest
+  """
+  Pack an empty directory — produces a valid archive with only the version
+  byte.
+  """
+  fun name(): String => "Pack/empty directory"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let out_tmp = _TestHelper.tmp_dir(h)?
+    let archive_path = out_tmp.path.join("out.par")?
+    let auth = FileAuth(h.env.root)
+    match dep.Pack(auth, root.path, archive_path.path where hash = false)
+    | let e: dep.PackError => h.fail("pack failed"); return
+    end
+
+    let reader = _TestHelper.read_archive(archive_path)?
+    h.assert_eq[U8](reader.u8()?, 1)
+    h.assert_eq[USize](reader.size(), 0)
+    tmp.dispose()
+    out_tmp.dispose()
+
+class \nodoc\ _TestPackSourceNotFound is UnitTest
+  """
+  Pack returns PackSourceNotFound for a nonexistent source path.
+  """
+  fun name(): String => "Pack/source not found"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let out_tmp = _TestHelper.tmp_dir(h)?
+    let auth = FileAuth(h.env.root)
+    let source = tmp.path.join("nonexistent")?.path
+    let output = out_tmp.path.join("out.par")?.path
+    match dep.Pack(auth, source, output where hash = false)
+    | dep.PackSourceNotFound => None
+    else
+      h.fail("expected PackSourceNotFound")
+    end
+    tmp.dispose()
+    out_tmp.dispose()
+
+class \nodoc\ _TestPackSourceIsFile is UnitTest
+  """
+  Pack returns PackSourceNotDirectory when the source is a regular file.
+  """
+  fun name(): String => "Pack/source is a file"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let f = Directory(root)?.create_file("not-a-dir.txt")?
+    f.print("hello")
+    f.dispose()
+
+    let out_tmp = _TestHelper.tmp_dir(h)?
+    let auth = FileAuth(h.env.root)
+    let source = root.join("not-a-dir.txt")?.path
+    let output = out_tmp.path.join("out.par")?.path
+    match dep.Pack(auth, source, output where hash = false)
+    | dep.PackSourceNotDirectory => None
+    else
+      h.fail("expected PackSourceNotDirectory")
+    end
+    tmp.dispose()
+    out_tmp.dispose()
+
+class \nodoc\ _TestPackOutputInsideSource is UnitTest
+  """
+  Pack rejects an output path inside the source directory.
+  """
+  fun name(): String => "Pack/output inside source"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    let auth = FileAuth(h.env.root)
+    let output = root.join("out.par")?.path
+    match dep.Pack(auth, root.path, output where hash = false)
+    | dep.PackOutputInsideSource => None
+    else
+      h.fail("expected PackOutputInsideSource")
+    end
+    tmp.dispose()

--- a/tools/pony-dep/test/main.pony
+++ b/tools/pony-dep/test/main.pony
@@ -63,6 +63,14 @@ actor \nodoc\ Main is TestList
     test(_TestArchiveDecoderRejectsUnknownType)
     test(_TestArchiveDecoderRejectsAbsolutePath)
 
+    // Pack tests
+    test(_TestPackRoundTrip)
+    test(_TestPackHash)
+    test(_TestPackEmptyDirectory)
+    test(_TestPackSourceNotFound)
+    test(_TestPackSourceIsFile)
+    test(_TestPackOutputInsideSource)
+
     // ConfigParser tests
     test(_TestConfigParserMinimalValid)
     test(_TestConfigParserSingleDep)


### PR DESCRIPTION
Implements the `pack` subcommand for `pony-dep` as specified in #6003.

`pony-dep pack <directory> <output>` creates a `.par` archive from a source directory. The `--hash` / `-H` flag prints the content hash to stdout for use in a `pony.deps` entry.

Pack walks the source tree once, feeding each file to both the archive encoder and the content hasher. This avoids the TOCTOU window a two-walk design would have. The output path is rejected if it falls inside the source tree.

Pack returns a result type (`String val | None | PackError`) rather than calling `env.exitcode` — the CLI layer in `main.pony` handles error presentation and exit codes.

Adds `add_file_entry` and `add_dir_entry` to `ArchiveEncoder`, and `leaf_hash` and `_from_leaves` to `ContentHash`, so Pack can drive a single walk while reusing the encoding and hashing logic. Existing `add` and `apply` entry points are unchanged.

Six tests cover the round trip, hash output, empty directory, missing source, non-directory source, and output-inside-source cases.

Design: #6003
