### PR TITLE
Fix pidfd_open on glibc < 2.30

### DIFF
--- a/src/libponyrt/lang/process.c
+++ b/src/libponyrt/lang/process.c
@@ -18,20 +18,16 @@ PONY_API int32_t ponyint_wnohang() {
 #include <unistd.h>
 #include <sys/syscall.h>
 
-// Open a pidfd for a process. A pidfd goes readable when the process exits and
-// registers with epoll like any other fd, giving exit detection that does not
-// depend on the child's pipes closing. Returns the fd, or -1 with errno set;
-// errno ENOSYS means the kernel is older than 5.3 and does not have the
-// syscall. We call the syscall directly rather than glibc's pidfd_open wrapper,
-// which only exists in glibc 2.36+; SYS_pidfd_open comes from the kernel
-// headers. If the build-time headers predate the syscall number, we report it
-// as unsupported.
+// glibc < 2.30 does not map __NR_pidfd_open to SYS_pidfd_open in
+// <bits/syscall.h>, even when the kernel headers define the __NR_ number.
+#if !defined(SYS_pidfd_open) && defined(__NR_pidfd_open)
+#  define SYS_pidfd_open __NR_pidfd_open
+#endif
+
 PONY_API int32_t ponyint_pidfd_open(int32_t pid) {
 #ifdef SYS_pidfd_open
   return (int32_t)syscall(SYS_pidfd_open, (pid_t)pid, 0u);
 #else
-  // Build-time headers predate SYS_pidfd_open. Report it as unsupported; pid is
-  // unused on this path.
   (void)pid;
   errno = ENOSYS;
   return -1;


### PR DESCRIPTION
glibc's `bits/syscall.h` maps `__NR_*` kernel constants to `SYS_*` at glibc build time, not when kernel headers are later updated. A system running glibc 2.28 (e.g. Raspbian Buster) can have `__NR_pidfd_open` from updated `linux-libc-dev` headers but no `SYS_pidfd_open` in the frozen `bits/syscall.h`. The existing `#ifdef SYS_pidfd_open` guard always fell through to `ENOSYS` on these systems, even though the kernel supports the syscall.

This adds a fallback that defines `SYS_pidfd_open` from `__NR_pidfd_open` when the former is absent. Standard practice — glibc itself documents that `__NR_*` and `SYS_*` have the same values.

Found during 32-bit Raspberry Pi test run.
