### PR TITLE
Fix PoolArena test address space exhaustion on ILP32

### DIFF
--- a/test/libponyrt/mem/pool.cc
+++ b/test/libponyrt/mem/pool.cc
@@ -235,7 +235,13 @@ private:
 template<typename F>
 void on_fresh_thread(F f)
 {
-  std::thread t(f);
+  std::thread t([&f]{
+    f();
+#ifdef POOL_USE_ARENA
+    ponyint_pool_return_idle();
+    ponyint_pool_thread_cleanup();
+#endif
+  });
   t.join();
 }
 


### PR DESCRIPTION
`on_fresh_thread()` in the PoolArena tests spawns a thread, runs the test body, and joins — but never calls `ponyint_pool_thread_cleanup()`. Each thread's arena slots and their backing regions are never released. After 37 PoolArena tests on ILP32, the 32-bit address space is too fragmented to mmap a new 64 MiB region, and `LargeRetainAdmission` crashes with ENOMEM.

The fix calls `ponyint_pool_return_idle()` and `ponyint_pool_thread_cleanup()` after the test body, guarded by `#ifdef POOL_USE_ARENA` so it's a no-op on other pool backends.

Found during 32-bit Raspberry Pi test run.
