### PR TITLE
Add PR-time compile check for tcp-swarm and udp-swarm Pony workloads

### DIFF
--- a/.ci-scripts/pr_changed_suites.py
+++ b/.ci-scripts/pr_changed_suites.py
@@ -10,11 +10,11 @@ each suite to stdout in `$GITHUB_OUTPUT` (`name=value`) format.
 The rules are the three suites' original `paths:` blocks, transcribed as plain
 prefix/suffix/exact tests -- no glob engine -- plus two deliberate departures
 from those blocks. First, `test/rt-stress/` and `test/rt-systematic/` are
-excluded from every suite -- with one exception: the generative stress engine's
-`.pony` source (`test/rt-stress/generative/**/*.pony`) triggers the `ponyc`
-suite so a compile check catches syntax errors, type errors, and stdlib API
-drift at PR time. The remaining test workloads' Pony
-is compiled and run only by scheduled workflows (`stress-test-*` and
+excluded from every suite -- with one exception: the stress workloads' `.pony`
+source (`test/rt-stress/{generative,tcp-swarm,udp-swarm}/**/*.pony`) triggers
+the `ponyc` suite so a compile check catches syntax errors, type errors, and
+stdlib API drift at PR time. The remaining test workloads' Pony is compiled and
+run only by scheduled workflows (`stress-test-*` and
 `ponyc-weekly-checks.yml`). The stress harness's Python orchestration is linted
 by `lint-python.yml` and tested by `test-rt-stress.yml` when it changes;
 `test/rt-systematic/` carries no Python (its orchestrator lives under
@@ -54,8 +54,10 @@ WORKFLOW_FILE = '.github/workflows/pr.yml'
 
 
 def excluded(path):
-    if (path.startswith('test/rt-stress/generative/')
-            and path.endswith('.pony')):
+    if path.endswith('.pony') and (
+            path.startswith('test/rt-stress/generative/')
+            or path.startswith('test/rt-stress/tcp-swarm/')
+            or path.startswith('test/rt-stress/udp-swarm/')):
         return False
     return (path.endswith('.md') or path.endswith('.yml')
             or path.startswith('.dockerfiles/')

--- a/.ci-scripts/pr_changed_suites_test.py
+++ b/.ci-scripts/pr_changed_suites_test.py
@@ -49,14 +49,19 @@ SINGLE_PATH_TABLE = [
     ('lib/CMakePresets.json', (True, False, True)),
     ('cmakefoo/build.cmake', (True, False, True)),
     ('cmake/notes.md', (False, False, False)),
-    # The generative stress engine's .pony source triggers the ponyc suite
-    # (not excluded like the rest of test/rt-stress/). Python, other workloads'
-    # Pony, and rt-systematic stay excluded.
+    # generative, tcp-swarm, and udp-swarm .pony source triggers the ponyc
+    # suite (not excluded like the rest of test/rt-stress/). Python and
+    # rt-systematic stay excluded.
     ('test/rt-stress/generative/main.pony', (True, False, True)),
     ('test/rt-stress/generative/orchestrate_normal_test.py', (False, False,
                                                               False)),
     ('test/rt-stress/generative/stress_common.py', (False, False, False)),
-    ('test/rt-stress/tcp-swarm/main.pony', (False, False, False)),
+    ('test/rt-stress/tcp-swarm/tcp_swarm.pony', (True, False, True)),
+    ('test/rt-stress/tcp-swarm/orchestrate_tcp.py', (False, False, False)),
+    ('test/rt-stress/udp-swarm/udp_flood.pony', (True, False, True)),
+    ('test/rt-stress/udp-swarm/udp_swarm.pony', (True, False, True)),
+    ('test/rt-stress/udp-swarm/orchestrate_udp.py', (False, False, False)),
+    ('test/rt-stress/suspend-drain/suspend_drain.pony', (False, False, False)),
     ('test/rt-systematic/order-signature/main.pony', (False, False, False)),
     # ...but the still-built test/ subdirs (compiled by test-ci-core) stay IN,
     # and a sibling like test/rt-stress-foo/ stays IN -- guard rows so an

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,8 +9,8 @@ on:
     # runs. `ponyc` is a subset of `tools`, so the union is `tools` plus
     # `pony_compiler` plus this workflow file. The re-includes below add back
     # the pony_compiler paths (which have no doc/yaml exclusion), this file,
-    # and the generative stress engine's Pony source (compiled in the ponyc
-    # suite to catch breaks at PR time).
+    # and the stress workloads' Pony source (compiled in the ponyc suite to
+    # catch breaks at PR time).
     paths:
       - '**'
       - '!**/*.md'
@@ -23,11 +23,13 @@ on:
       # (stress-test-*, ponyc-weekly-checks). The stress harness's Python is
       # linted by lint-python.yml and tested by test-rt-stress.yml;
       # rt-systematic has no Python. Excluded here AND in
-      # pr_changed_suites.py, except the generative engine's .pony source
+      # pr_changed_suites.py, except the stress workloads' .pony source
       # (re-included below; compiled in the ponyc suite).
       - '!test/rt-stress/**'
       - '!test/rt-systematic/**'
       - 'test/rt-stress/generative/**/*.pony'
+      - 'test/rt-stress/tcp-swarm/**/*.pony'
+      - 'test/rt-stress/udp-swarm/**/*.pony'
       - 'src/libponyc/**'
       - 'tools/lib/ponylang/pony_compiler/**'
       - '.github/workflows/pr.yml'
@@ -168,6 +170,20 @@ jobs:
           ctest --preset x86-64-debug -L ci-core
       - name: Compile generative stress engine
         run: PONYPATH=packages build/debug/ponyc -d --pic -b generative -o build/debug test/rt-stress/generative/
+      - name: Detect SSL version
+        run: |
+          ver=$(openssl version)
+          case "$ver" in
+            LibreSSL*) flag="-Dlibressl" ;;
+            *" 4."*)   flag="-Dopenssl_4.0.x" ;;
+            *" 3."*)   flag="-Dopenssl_3.0.x" ;;
+            *)         flag="-Dopenssl_1.1.x" ;;
+          esac
+          echo "PONY_SSL_FLAG=$flag" >> "$GITHUB_ENV"
+      - name: Compile tcp-swarm stress engine
+        run: PONYPATH=packages build/debug/ponyc -d ${{ env.PONY_SSL_FLAG }} --pic -b tcp-swarm -o build/debug test/rt-stress/tcp-swarm/
+      - name: Compile udp-swarm stress engine
+        run: PONYPATH=packages build/debug/ponyc -d ${{ env.PONY_SSL_FLAG }} --pic -b udp-swarm -o build/debug test/rt-stress/udp-swarm/
       - name: Build Release Runtime
         run: |
           cmake --preset x86-64-release


### PR DESCRIPTION
The generative stress engine already gets a compile check in the PR workflow, but the tcp-swarm and udp-swarm Pony source had no CI signal until the nightly stress runs. A stdlib change (like the recent net → lori swap) can break their compilation silently.

Re-includes their `.pony` files in the `pr.yml` paths filter and the `pr_changed_suites.py` classifier so changes to those files trigger the ponyc suite, and adds compile steps alongside the existing generative step in the Linux ponyc job.

Closes #6017
