### PR TITLE
Add per-PR net package tests against all 5 SSL backends

### DIFF
--- a/.ci-dockerfiles/ubuntu26.04-builder-with-libressl-3.9.2/Dockerfile
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-libressl-3.9.2/Dockerfile
@@ -1,0 +1,24 @@
+ARG FROM_TAG=20260908
+FROM ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:${FROM_TAG}
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+USER root
+
+RUN apt-get update \
+ && apt-get remove -y libssl-dev \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG LIBRESSL_VERSION=3.9.2
+RUN curl -fsSL "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRESSL_VERSION}.tar.gz" \
+      -o /tmp/libressl.tar.gz \
+ && tar -xzf /tmp/libressl.tar.gz -C /tmp \
+ && cd /tmp/libressl-${LIBRESSL_VERSION} \
+ && ./configure --prefix=/usr/local --disable-shared --enable-static \
+ && make -j"$(nproc)" \
+ && make install \
+ && rm -rf /tmp/libressl*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/ubuntu26.04-builder-with-libressl-3.9.2/build-and-push.bash
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-libressl-3.9.2/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-libressl-3.9.2"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="ssl-libressl392-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.ci-dockerfiles/ubuntu26.04-builder-with-libressl-4.2.1/Dockerfile
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-libressl-4.2.1/Dockerfile
@@ -1,0 +1,24 @@
+ARG FROM_TAG=20260908
+FROM ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:${FROM_TAG}
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+USER root
+
+RUN apt-get update \
+ && apt-get remove -y libssl-dev \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG LIBRESSL_VERSION=4.2.1
+RUN curl -fsSL "https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-${LIBRESSL_VERSION}.tar.gz" \
+      -o /tmp/libressl.tar.gz \
+ && tar -xzf /tmp/libressl.tar.gz -C /tmp \
+ && cd /tmp/libressl-${LIBRESSL_VERSION} \
+ && ./configure --prefix=/usr/local --disable-shared --enable-static \
+ && make -j"$(nproc)" \
+ && make install \
+ && rm -rf /tmp/libressl*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/ubuntu26.04-builder-with-libressl-4.2.1/build-and-push.bash
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-libressl-4.2.1/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-libressl-4.2.1"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="ssl-libressl421-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-1.1.1w/Dockerfile
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-1.1.1w/Dockerfile
@@ -1,0 +1,24 @@
+ARG FROM_TAG=20260908
+FROM ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:${FROM_TAG}
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+USER root
+
+RUN apt-get update \
+ && apt-get remove -y libssl-dev \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG OPENSSL_VERSION=1.1.1w
+RUN curl -fsSL "https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-${OPENSSL_VERSION}.tar.gz" \
+      -o /tmp/openssl.tar.gz \
+ && tar -xzf /tmp/openssl.tar.gz -C /tmp \
+ && cd /tmp/openssl-${OPENSSL_VERSION} \
+ && ./config --prefix=/usr/local no-shared \
+ && make -j"$(nproc)" \
+ && make install_sw \
+ && rm -rf /tmp/openssl*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-1.1.1w/build-and-push.bash
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-1.1.1w/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-openssl-1.1.1w"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="ssl-openssl111w-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-3.6.2/Dockerfile
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-3.6.2/Dockerfile
@@ -1,0 +1,24 @@
+ARG FROM_TAG=20260908
+FROM ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:${FROM_TAG}
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+USER root
+
+RUN apt-get update \
+ && apt-get remove -y libssl-dev \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG OPENSSL_VERSION=3.6.2
+RUN curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" \
+      -o /tmp/openssl.tar.gz \
+ && tar -xzf /tmp/openssl.tar.gz -C /tmp \
+ && cd /tmp/openssl-${OPENSSL_VERSION} \
+ && ./config --prefix=/usr/local no-shared \
+ && make -j"$(nproc)" \
+ && make install_sw \
+ && rm -rf /tmp/openssl*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-3.6.2/build-and-push.bash
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-3.6.2/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-openssl-3.6.2"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="ssl-openssl362-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-4.0.0/Dockerfile
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-4.0.0/Dockerfile
@@ -1,0 +1,24 @@
+ARG FROM_TAG=20260908
+FROM ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:${FROM_TAG}
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
+
+USER root
+
+RUN apt-get update \
+ && apt-get remove -y libssl-dev \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG OPENSSL_VERSION=4.0.0
+RUN curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" \
+      -o /tmp/openssl.tar.gz \
+ && tar -xzf /tmp/openssl.tar.gz -C /tmp \
+ && cd /tmp/openssl-${OPENSSL_VERSION} \
+ && ./config --prefix=/usr/local no-shared \
+ && make -j"$(nproc)" \
+ && make install_sw \
+ && rm -rf /tmp/openssl*
+
+USER pony
+WORKDIR /home/pony

--- a/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-4.0.0/build-and-push.bash
+++ b/.ci-dockerfiles/ubuntu26.04-builder-with-openssl-4.0.0/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-openssl-4.0.0"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="ssl-openssl400-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.github/workflows/build-builder-image.yml
+++ b/.github/workflows/build-builder-image.yml
@@ -13,10 +13,16 @@ on:
           - arm64-unknown-linux-ubuntu24.04-builder
           - cross-riscv64
           - ubuntu26.04-builder
+          - ubuntu26.04-builder-with-libressl-3.9.2
+          - ubuntu26.04-builder-with-libressl-4.2.1
+          - ubuntu26.04-builder-with-openssl-1.1.1w
+          - ubuntu26.04-builder-with-openssl-3.6.2
+          - ubuntu26.04-builder-with-openssl-4.0.0
           - x86-64-unknown-linux-fedora44-builder
           - x86-64-unknown-linux-ubuntu24.04-builder
 
 permissions:
+  contents: write
   packages: write
 
 jobs:
@@ -139,6 +145,131 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-dockerfiles/ubuntu26.04-builder/build-and-push.bash
+      - name: Trigger SSL builder cascade
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api repos/${{ github.repository }}/dispatches -f event_type=ubuntu26_04-builder-pushed
+
+  ubuntu26_04-builder-with-libressl-3_9_2:
+    if: ${{ github.event.inputs.builder-name == 'ubuntu26.04-builder-with-libressl-3.9.2' }}
+    runs-on: ubuntu-latest
+
+    name: ubuntu26.04-builder-with-libressl-3.9.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+          cache-binary: false
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/ubuntu26.04-builder-with-libressl-3.9.2/build-and-push.bash
+
+  ubuntu26_04-builder-with-libressl-4_2_1:
+    if: ${{ github.event.inputs.builder-name == 'ubuntu26.04-builder-with-libressl-4.2.1' }}
+    runs-on: ubuntu-latest
+
+    name: ubuntu26.04-builder-with-libressl-4.2.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+          cache-binary: false
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/ubuntu26.04-builder-with-libressl-4.2.1/build-and-push.bash
+
+  ubuntu26_04-builder-with-openssl-1_1_1w:
+    if: ${{ github.event.inputs.builder-name == 'ubuntu26.04-builder-with-openssl-1.1.1w' }}
+    runs-on: ubuntu-latest
+
+    name: ubuntu26.04-builder-with-openssl-1.1.1w
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+          cache-binary: false
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/ubuntu26.04-builder-with-openssl-1.1.1w/build-and-push.bash
+
+  ubuntu26_04-builder-with-openssl-3_6_2:
+    if: ${{ github.event.inputs.builder-name == 'ubuntu26.04-builder-with-openssl-3.6.2' }}
+    runs-on: ubuntu-latest
+
+    name: ubuntu26.04-builder-with-openssl-3.6.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+          cache-binary: false
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/ubuntu26.04-builder-with-openssl-3.6.2/build-and-push.bash
+
+  ubuntu26_04-builder-with-openssl-4_0_0:
+    if: ${{ github.event.inputs.builder-name == 'ubuntu26.04-builder-with-openssl-4.0.0' }}
+    runs-on: ubuntu-latest
+
+    name: ubuntu26.04-builder-with-openssl-4.0.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+          cache-binary: false
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/ubuntu26.04-builder-with-openssl-4.0.0/build-and-push.bash
 
   x86-64-unknown-linux-fedora44-builder:
     if: ${{ github.event.inputs.builder-name == 'x86-64-unknown-linux-fedora44-builder' }}

--- a/.github/workflows/net-ssl-tests.yml
+++ b/.github/workflows/net-ssl-tests.yml
@@ -1,0 +1,90 @@
+name: Net SSL Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'packages/net/**'
+      - '.github/workflows/net-ssl-tests.yml'
+
+concurrency:
+  group: net-ssl-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  build:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    name: Build ponyc
+    container:
+      image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260908
+      options: --user pony
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Build libs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIBS_IMAGE: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260908
+          LIBS_TAG: ${{ hashFiles('lib/CMakePresets.json', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/build-libs.cmake', 'lib/llvm/patches/*') }}
+          LIBS_BRANCH_CACHE: ${{ github.event.pull_request.head.repo.full_name == github.repository && '--branch-cache' || '' }}
+        run: python3 .ci-scripts/libs-cache/pr_libs_cache.py $LIBS_BRANCH_CACHE --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- cmake -DJOBS=4 -P lib/build-libs.cmake
+      - name: Build
+        run: |
+          cmake --preset debug -DPONY_INSTALL_SYMLINKS=OFF
+          cmake --build --preset debug
+      - name: Install
+        run: cmake --install build/build_debug --prefix install
+      - name: Upload installed ponyc
+        uses: actions/upload-artifact@v4
+        with:
+          name: ponyc-installed
+          path: install/
+          retention-days: 1
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    name: 'net: ${{ matrix.ssl-name }}'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ssl-name: libressl-3.9.2
+            ssl-flag: '-Dlibressl'
+            image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-libressl-3.9.2:20260911
+          - ssl-name: libressl-4.2.1
+            ssl-flag: '-Dlibressl'
+            image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-libressl-4.2.1:20260911
+          - ssl-name: openssl-1.1.1w
+            ssl-flag: '-Dopenssl_1.1.x'
+            image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-openssl-1.1.1w:20260911
+          - ssl-name: openssl-3.6.2
+            ssl-flag: '-Dopenssl_3.0.x'
+            image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-openssl-3.6.2:20260911
+          - ssl-name: openssl-4.0.0
+            ssl-flag: '-Dopenssl_4.0.x'
+            image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder-with-openssl-4.0.0:20260911
+    container:
+      image: ${{ matrix.image }}
+      options: --user pony
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Download ponyc
+        uses: actions/download-artifact@v4
+        with:
+          name: ponyc-installed
+          path: ponyc-installed/
+      - name: Make ponyc executable
+        run: chmod +x ponyc-installed/lib/pony/*/bin/ponyc
+      - name: Compile net tests
+        run: |
+          PONYC="$(find ponyc-installed/lib/pony -name ponyc -type f)"
+          "$PONYC" -d ${{ matrix.ssl-flag }} -b net-tests --checktree --pic --strip packages/net/
+      - name: Run net tests
+        run: ./net-tests --sequential

--- a/.github/workflows/rebuild-ssl-builder-images.yml
+++ b/.github/workflows/rebuild-ssl-builder-images.yml
@@ -1,0 +1,55 @@
+name: Rebuild SSL Builder Images
+
+on:
+  repository_dispatch:
+    types: [ubuntu26_04-builder-pushed]
+
+  registry_package:
+    types: [published]
+
+  workflow_dispatch:
+
+concurrency:
+  group: rebuild-ssl-builder-images
+  cancel-in-progress: true
+
+permissions:
+  packages: write
+
+jobs:
+  rebuild:
+    # registry_package fires for every GHCR push in the repo. Only run when the
+    # base builder was published — exact name match prevents the SSL images
+    # themselves from re-triggering this workflow in an infinite loop.
+    if: >-
+      github.event_name != 'registry_package' ||
+      github.event.registry_package.name == 'ponyc-ci-ubuntu26.04-builder'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ssl:
+          - libressl-3.9.2
+          - libressl-4.2.1
+          - openssl-1.1.1w
+          - openssl-3.6.2
+          - openssl-4.0.0
+    name: ${{ matrix.ssl }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        # v3.10.0
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+          cache-binary: false
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/ubuntu26.04-builder-with-${{ matrix.ssl }}/build-and-push.bash


### PR DESCRIPTION
Five Docker images, each based on the glibc CI builder with one SSL library built from source at /usr/local (static, system libssl-dev removed):

| Image suffix | Library | Pony `-D` flag |
|---|---|---|
| `libressl-3.9.2` | LibreSSL 3.9.2 | `-Dlibressl` |
| `libressl-4.2.1` | LibreSSL 4.2.1 | `-Dlibressl` |
| `openssl-1.1.1w` | OpenSSL 1.1.1w | `-Dopenssl_1.1.x` |
| `openssl-3.6.2` | OpenSSL 3.6.2 | `-Dopenssl_3.0.x` |
| `openssl-4.0.0` | OpenSSL 4.0.0 | `-Dopenssl_4.0.x` |

Three workflows:

- **`net-ssl-tests.yml`** — triggers on PRs touching `packages/net/`. One build job (ponyc debug, installed with symlinks off), then 5 matrix test jobs each compiling and running `packages/net/` with the right `-D` flag in the matching SSL container.
- **`rebuild-ssl-builder-images.yml`** — cascades when the base `ubuntu26.04-builder` is rebuilt. Three triggers: `repository_dispatch` from `build-builder-image.yml`, `registry_package` (best-effort for local pushes), `workflow_dispatch`.
- **`build-builder-image.yml`** — gains the 5 SSL builders in its dispatch choice list and a cascade trigger step on the `ubuntu26.04-builder` job.

Image tags are `20260908` (placeholder matching the current base builder). After merging, images need to be built and pushed, then tags updated to match.

Closes #6019.
