### PR TITLE
Implement fetch-and-place for pony-dep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,10 @@ if(NOT PONY_CROSS_LIBPONYRT)
         if(PONY_SSL_FLAG)
             message(STATUS "SSL for stdlib net: ${PONY_SSL_FLAG} (${OPENSSL_VERSION})")
         endif()
+        # Directory containing the SSL/crypto static libraries. Tool binaries
+        # that use the net package (pony-dep) pass this as --path so ponyc's
+        # linker can find ssl.lib/crypto.lib (or libssl.a/libcrypto.a).
+        get_filename_component(PONY_SSL_LIB_DIR "${OPENSSL_SSL_LIBRARY}" DIRECTORY)
     else()
         message(FATAL_ERROR "OpenSSL not found; the net package requires OpenSSL 1.1.x/3.0.x/4.0.x or LibreSSL (install the dev package for your distro — see BUILD.md)")
     endif()
@@ -811,6 +815,7 @@ else()
     add_pony_binary(pony-dep-tests
         NAME pony-dep-tests
         SOURCE ${CMAKE_SOURCE_DIR}/tools/pony-dep/test
+        PATHS ${PONY_SSL_LIB_DIR}
         WATCH ${CMAKE_SOURCE_DIR}/tools/pony-dep)
 
     # On-demand aggregate: build every self-hosted tool test in one target. Run

--- a/cmake/PonyBinary.cmake
+++ b/cmake/PonyBinary.cmake
@@ -38,8 +38,8 @@ function(add_pony_binary _target)
     add_custom_command(OUTPUT ${_exe}
         COMMAND_EXPAND_LISTS
         COMMAND echo "Building ${_pb_NAME}..."
-        COMMAND $<TARGET_FILE:ponyc> ${PONY_CPU_FLAG} ${_path_args}
-            ${PONYC_SELFHOSTED_TOOL_PATH_ARGS}
+        COMMAND $<TARGET_FILE:ponyc> ${PONY_CPU_FLAG} ${PONY_SSL_FLAG}
+            ${_path_args} ${PONYC_SELFHOSTED_TOOL_PATH_ARGS}
             -b ${_pb_NAME} -o ${_out} ${_pb_SOURCE}
         DEPENDS
             ${_watch_srcs}

--- a/packages/net/ssl_context.pony
+++ b/packages/net/ssl_context.pony
@@ -41,6 +41,7 @@ use @SSL_CTX_load_verify_locations[I32](
   ctx: Pointer[_SSLContext] tag,
   ca_file: Pointer[U8] tag,
   ca_path: Pointer[U8] tag)
+use @SSL_CTX_set_default_verify_paths[I32](ctx: Pointer[_SSLContext] tag)
 use @X509_STORE_new[Pointer[_X509Store] tag]()
 use @CertOpenSystemStoreA[Pointer[_CertStore] tag](
   prov: Pointer[None],
@@ -295,6 +296,15 @@ class val SSLContext
         @CertCloseStore(h_store, U32(0))
       end
     end
+
+  fun ref set_default_verify_paths() ? =>
+    """
+    Load the default certificate authority locations that OpenSSL was
+    configured with at build time. Raises an error if the context has been
+    disposed or if OpenSSL could not load the default locations.
+    """
+    if _ctx.is_null() then error end
+    if @SSL_CTX_set_default_verify_paths(_ctx) != 1 then error end
 
   fun ref set_ciphers(ciphers: String) ? =>
     """

--- a/tools/pony-dep/CMakeLists.txt
+++ b/tools/pony-dep/CMakeLists.txt
@@ -7,5 +7,5 @@ configure_file(version.pony.in ${CMAKE_CURRENT_SOURCE_DIR}/version.pony @ONLY)
 add_pony_binary(tools.pony-dep ALL
     NAME pony-dep
     SOURCE ${CMAKE_CURRENT_SOURCE_DIR}
-    PATHS ${CMAKE_CURRENT_SOURCE_DIR}
+    PATHS ${CMAKE_CURRENT_SOURCE_DIR} ${PONY_SSL_LIB_DIR}
     WATCH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tools/pony-dep/_fetch_handler.pony
+++ b/tools/pony-dep/_fetch_handler.pony
@@ -1,0 +1,16 @@
+actor _FetchHandler is FetchNotify
+  """
+  CLI result handler for the fetch subcommand. Translates fetch outcomes
+  into stderr messages and exit codes.
+  """
+  let _env: Env
+
+  new create(env: Env) =>
+    _env = env
+
+  be fetch_failed(err: FetchError) =>
+    _env.err.print("error: " + err.message)
+    _env.exitcode(1)
+
+  be fetch_succeeded() =>
+    None

--- a/tools/pony-dep/archive_decoder.pony
+++ b/tools/pony-dep/archive_decoder.pony
@@ -9,59 +9,65 @@ primitive ArchiveDecoder
   Fails hard on invalid paths rather than skipping them.
   """
   fun apply(archive: FilePath, to: Directory) ? =>
-    let reader: Reader = Reader
-
     match OpenFile(archive)
     | let f: File =>
-      reader.append(f.read(f.size()))
+      let data: Array[U8] val = f.read(f.size())
       f.dispose()
-
-      let version = reader.u8()?
-      if version != 1 then
-        error
-      end
-
-      while reader.size() > 0 do
-        let entry_type = reader.u8()?
-        match entry_type
-        | 1 =>
-          let path_size = reader.u32_le()?.usize()
-          let path_block = reader.block(path_size)?
-          let path = String.from_array(consume path_block)
-
-          if not PathValidator(path) then
-            error
-          end
-
-          let content_size = reader.u32_le()?.usize()
-          let content = reader.block(content_size)?
-
-          let file = to.create_file(path)?
-          if not file.set_length(0) then
-            file.dispose()
-            error
-          end
-          if not file.write(consume content) then
-            file.dispose()
-            error
-          end
-          file.dispose()
-        | 2 =>
-          let path_size = reader.u32_le()?.usize()
-          let path_block = reader.block(path_size)?
-          let path = String.from_array(consume path_block)
-
-          if not PathValidator(path) then
-            error
-          end
-
-          if not to.mkdir(path) then
-            error
-          end
-        else
-          error
-        end
-      end
+      from_bytes(data, to)?
     else
       error
+    end
+
+  fun from_bytes(data: Array[U8] val, to: Directory) ? =>
+    """
+    Decode archive bytes and extract entries into the target directory.
+    """
+    let reader: Reader = Reader
+    reader.append(data)
+
+    let version = reader.u8()?
+    if version != 1 then
+      error
+    end
+
+    while reader.size() > 0 do
+      let entry_type = reader.u8()?
+      match entry_type
+      | 1 =>
+        let path_size = reader.u32_le()?.usize()
+        let path_block = reader.block(path_size)?
+        let path = String.from_array(consume path_block)
+
+        if not PathValidator(path) then
+          error
+        end
+
+        let content_size = reader.u32_le()?.usize()
+        let content = reader.block(content_size)?
+
+        let file = to.create_file(path)?
+        if not file.set_length(0) then
+          file.dispose()
+          error
+        end
+        if not file.write(consume content) then
+          file.dispose()
+          error
+        end
+        file.dispose()
+      | 2 =>
+        let path_size = reader.u32_le()?.usize()
+        let path_block = reader.block(path_size)?
+        let path = String.from_array(consume path_block)
+
+        if not PathValidator(path) then
+          error
+        end
+
+        if not to.mkdir(path) then
+          error
+        end
+      else
+        error
+      end
     end

--- a/tools/pony-dep/fetch.pony
+++ b/tools/pony-dep/fetch.pony
@@ -1,0 +1,235 @@
+use "files"
+use "net"
+use http = "http_client"
+use uri_pkg = "uri"
+
+actor Fetch is (http.HTTPClientConnectionActor & http.RedirectFollowerNotify)
+  """
+  Downloads a `.par` archive from a URL and extracts it to a target directory.
+
+  Supports both HTTP and HTTPS with automatic redirect following. The archive
+  is buffered in memory, decoded, and extracted to the output directory.
+  Reports success or failure through a `FetchNotify`.
+  """
+  let _env: Env
+  let _notify: FetchNotify
+  let _output_dir: String
+  var _redirect: http.RedirectFollower = http.RedirectFollower.none()
+  var _collector: http.ResponseCollector = http.ResponseCollector
+  var _request_path: String val = "/"
+
+  new create(env: Env, notify: FetchNotify, url: String, output_dir: String) =>
+    _env = env
+    _notify = notify
+    _output_dir = output_dir
+
+    let parsed =
+      match \exhaustive\ uri_pkg.ParseURI(url)
+      | let u: uri_pkg.URI val => u
+      | let _: uri_pkg.URIParseError val =>
+        _notify.fetch_failed(
+          FetchError(FetchInvalidURL, "invalid URL: " + url))
+        return
+      end
+
+    let scheme: String val =
+      match \exhaustive\ parsed.scheme
+      | let s: String => s.lower()
+      | None =>
+        _notify.fetch_failed(
+          FetchError(FetchInvalidURL, "URL has no scheme: " + url))
+        return
+      end
+
+    if (scheme != "http") and (scheme != "https") then
+      _notify.fetch_failed(FetchError(
+        FetchInvalidURL,
+        "unsupported URL scheme '" + scheme + "'"))
+      return
+    end
+
+    let authority =
+      match \exhaustive\ parsed.authority
+      | let a: uri_pkg.URIAuthority => a
+      | None =>
+        _notify.fetch_failed(
+          FetchError(FetchInvalidURL, "URL has no host: " + url))
+        return
+      end
+
+    let host = authority.host
+    if host.size() == 0 then
+      _notify.fetch_failed(
+        FetchError(FetchInvalidURL, "URL has empty host: " + url))
+      return
+    end
+
+    let secure = scheme == "https"
+    let port =
+      match \exhaustive\ authority.port
+      | let p: U16 => p.string()
+      | None => if secure then "443" else "80" end
+      end
+
+    _request_path =
+      if parsed.path.size() == 0 then "/" else parsed.path end
+    match parsed.query
+    | let q: String => _request_path = _request_path + "?" + q
+    end
+
+    let tcp_auth = TCPConnectAuth(env.root)
+    let config = http.ClientConnectionConfig
+
+    let conn =
+      if secure then
+        try
+          let ssl_ctx =
+            recover val
+              SSLContext .> set_default_verify_paths()?
+            end
+          http.HTTPClientConnection.ssl(
+            tcp_auth, ssl_ctx, host, port, this, config)
+        else
+          _notify.fetch_failed(FetchError(
+            FetchConnectionFailed, "SSL initialization failed"))
+          return
+        end
+      else
+        http.HTTPClientConnection(tcp_auth, host, port, this, config)
+      end
+
+    let factory =
+      {ref(target: uri_pkg.URI val)
+        (tcp_auth, config, client = this)
+        : http.HTTPClientConnection
+      =>
+        let o = http.Origin.from_uri(target)
+        if o.host.size() == 0 then
+          return http.HTTPClientConnection.none()
+        end
+        if o.secure then
+          try
+            let ssl_ctx =
+              recover val
+                SSLContext .> set_default_verify_paths()?
+              end
+            http.HTTPClientConnection.ssl(
+              tcp_auth, ssl_ctx, o.host, o.port, client, config)
+          else
+            http.HTTPClientConnection.none()
+          end
+        else
+          http.HTTPClientConnection(
+            tcp_auth, o.host, o.port, client, config)
+        end
+      }
+
+    _redirect =
+      http.RedirectFollower(
+        conn, this, factory, 5, http.Origin(secure, host, port))
+
+  fun ref _http_client_connection(): http.HTTPClientConnection =>
+    _redirect.connection()
+
+  fun ref on_connected() =>
+    let request = http.Request.get(_request_path).build()
+    match \exhaustive\ _redirect.send_request(request)
+    | http.SendRequestOK => None
+    | http.ConnectionClosed =>
+      _notify.fetch_failed(FetchError(
+        FetchConnectionFailed,
+        "connection closed before request sent"))
+    | http.ResponsePending =>
+      _Unreachable()
+    end
+
+  fun ref on_response(response: http.Response val) =>
+    _collector = http.ResponseCollector
+    _collector.set_response(response)
+
+  fun ref on_body_chunk(data: Array[U8] val) =>
+    _collector.add_chunk(data)
+
+  fun ref on_response_complete() =>
+    try
+      let response = _collector.build()?
+
+      if (response.status < 200) or (response.status >= 300) then
+        _notify.fetch_failed(FetchError(
+          FetchHTTPError,
+          "HTTP " + response.status.string() + " " + response.reason))
+        _redirect.connection().close()
+        return
+      end
+
+      let file_auth = FileAuth(_env.root)
+      let dir_path = FilePath(file_auth, _output_dir)
+      if not dir_path.mkdir() then
+        try
+          if not FileInfo(dir_path)?.directory then
+            _notify.fetch_failed(FetchError(
+              FetchExtractionFailed,
+              "output path is not a directory: " + _output_dir))
+            _redirect.connection().close()
+            return
+          end
+        else
+          _notify.fetch_failed(FetchError(
+            FetchExtractionFailed,
+            "cannot create output directory: " + _output_dir))
+          _redirect.connection().close()
+          return
+        end
+      end
+
+      let dir =
+        try
+          Directory(dir_path)?
+        else
+          _notify.fetch_failed(FetchError(
+            FetchExtractionFailed,
+            "cannot open output directory: " + _output_dir))
+          _redirect.connection().close()
+          return
+        end
+
+      try
+        ArchiveDecoder.from_bytes(response.body, dir)?
+      else
+        _notify.fetch_failed(
+          FetchError(FetchExtractionFailed, "archive extraction failed"))
+        _redirect.connection().close()
+        return
+      end
+
+      _notify.fetch_succeeded()
+      _redirect.connection().close()
+    else
+      _Unreachable()
+    end
+
+  fun ref on_connection_failure(reason: ConnectionFailureReason) =>
+    let msg =
+      match \exhaustive\ reason
+      | ConnectionFailedDNS => "DNS resolution failed"
+      | ConnectionFailedTCP => "TCP connection failed"
+      | ConnectionFailedSSL => "SSL handshake failed"
+      | ConnectionFailedTimeout => "connection timed out"
+      | ConnectionFailedTimerError => "connection timer error"
+      end
+    _notify.fetch_failed(FetchError(FetchConnectionFailed, msg))
+
+  fun ref on_redirect_error(err: http.RedirectError) =>
+    let msg =
+      match \exhaustive\ err
+      | http.TooManyRedirects => "too many redirects"
+      | http.MissingLocation => "redirect missing Location header"
+      | http.InvalidLocation => "redirect has invalid Location"
+      | http.InsecureRedirect => "HTTPS to HTTP redirect refused"
+      end
+    _notify.fetch_failed(FetchError(FetchConnectionFailed, msg))
+    _redirect.connection().close()
+
+  fun ref on_parse_error(err: http.ParseError) =>
+    _notify.fetch_failed(
+      FetchError(FetchConnectionFailed, "HTTP parse error"))

--- a/tools/pony-dep/fetch_error.pony
+++ b/tools/pony-dep/fetch_error.pony
@@ -1,0 +1,39 @@
+primitive FetchInvalidURL
+  """
+  The URL could not be parsed, has no scheme, has an unsupported scheme,
+  or has no host.
+  """
+
+primitive FetchConnectionFailed
+  """
+  A network-level failure: DNS, TCP, SSL, timeout, redirect error, or
+  HTTP parse error.
+  """
+
+primitive FetchHTTPError
+  """
+  The server returned a non-2xx status code.
+  """
+
+primitive FetchExtractionFailed
+  """
+  The output directory could not be created or the archive could not be
+  decoded.
+  """
+
+type FetchErrorKind is
+  ( FetchInvalidURL
+  | FetchConnectionFailed
+  | FetchHTTPError
+  | FetchExtractionFailed )
+
+class val FetchError
+  """
+  A fetch failure with a category and a human-readable detail.
+  """
+  let kind: FetchErrorKind
+  let message: String val
+
+  new val create(kind': FetchErrorKind, message': String val) =>
+    kind = kind'
+    message = message'

--- a/tools/pony-dep/fetch_notify.pony
+++ b/tools/pony-dep/fetch_notify.pony
@@ -1,0 +1,14 @@
+interface tag FetchNotify
+  """
+  Receives the result of a fetch operation.
+  """
+
+  be fetch_failed(err: FetchError)
+    """
+    Called when the fetch fails at any stage.
+    """
+
+  be fetch_succeeded()
+    """
+    Called when the archive has been downloaded and extracted.
+    """

--- a/tools/pony-dep/main.pony
+++ b/tools/pony-dep/main.pony
@@ -32,7 +32,12 @@ actor Main
               ])?
             CommandSpec.leaf(
               "fetch",
-              "Download and extract a package archive from a URL")?
+              "Download and extract a package archive from a URL",
+              [],
+              [
+                ArgSpec.string("url")
+                ArgSpec.string("directory")
+              ])?
             CommandSpec.leaf(
               "add",
               "Fetch a dependency, hash it, and record it")?
@@ -85,7 +90,12 @@ actor Main
         env.err.print("error: pack failed for '" + dir + "'")
         env.exitcode(1)
       end
-    | "fetch" => _not_implemented(env, "fetch")
+    | "fetch" =>
+      Fetch(
+        env,
+        _FetchHandler(env),
+        cmd.arg("url").string(),
+        cmd.arg("directory").string())
     | "add" => _not_implemented(env, "add")
     | "remove" => _not_implemented(env, "remove")
     | "clean" => _not_implemented(env, "clean")

--- a/tools/pony-dep/test/_test_archive_decoder.pony
+++ b/tools/pony-dep/test/_test_archive_decoder.pony
@@ -291,6 +291,113 @@ class \nodoc\ _TestArchiveDecoderRejectsAbsolutePath is UnitTest
     })
     tmp.dispose()
 
+class \nodoc\ _TestArchiveDecoderFromBytesSingleFile is UnitTest
+  fun name(): String => "ArchiveDecoder/from_bytes single file"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    let dir = Directory(root)?
+
+    let f = dir.create_file("hello.pony")?
+    f.print("actor Main")
+    f.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("hello.pony")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let archive_data: Array[U8] val =
+      match OpenFile(archive_path)
+      | let af: File =>
+        let data = af.read(af.size())
+        af.dispose()
+        consume data
+      else
+        error
+      end
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+    dep.ArchiveDecoder.from_bytes(archive_data, Directory(out_path)?)?
+
+    let extracted = File.open(out_path.join("hello.pony")?)
+    let content: String val = extracted.read_string(extracted.size())
+    extracted.dispose()
+    h.assert_eq[String val](content, "actor Main\n")
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderFromBytesNested is UnitTest
+  fun name(): String => "ArchiveDecoder/from_bytes nested directories"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+    let dir = Directory(root)?
+
+    dir.mkdir("pkg")
+    dir.mkdir("pkg/sub")
+    let f1 = dir.create_file("pkg/top.pony")?
+    f1.print("primitive Top")
+    f1.dispose()
+    let f2 = dir.create_file("pkg/sub/deep.pony")?
+    f2.print("primitive Deep")
+    f2.dispose()
+
+    let encoder = dep.ArchiveEncoder(root)?
+    encoder.add(root.join("pkg")?)?
+
+    let archive_path = root.join("test.par")?
+    encoder.write(archive_path)?
+
+    let archive_data: Array[U8] val =
+      match OpenFile(archive_path)
+      | let af: File =>
+        let data = af.read(af.size())
+        af.dispose()
+        consume data
+      else
+        error
+      end
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+    dep.ArchiveDecoder.from_bytes(archive_data, Directory(out_path)?)?
+
+    let top = File.open(out_path.join("pkg/top.pony")?)
+    let top_content: String val = top.read_string(top.size())
+    top.dispose()
+    h.assert_eq[String val](top_content, "primitive Top\n")
+
+    let deep = File.open(out_path.join("pkg/sub/deep.pony")?)
+    let deep_content: String val = deep.read_string(deep.size())
+    deep.dispose()
+    h.assert_eq[String val](deep_content, "primitive Deep\n")
+    tmp.dispose()
+
+class \nodoc\ _TestArchiveDecoderFromBytesInvalid is UnitTest
+  fun name(): String => "ArchiveDecoder/from_bytes rejects invalid data"
+
+  fun apply(h: TestHelper) ? =>
+    let tmp = _TestHelper.tmp_dir(h)?
+    let root = tmp.path
+
+    let out_path = root.join("output")?
+    out_path.mkdir()
+
+    h.assert_error({() ? =>
+      dep.ArchiveDecoder.from_bytes(
+        [as U8: 99], Directory(out_path)?)?
+    })
+
+    h.assert_error({() ? =>
+      dep.ArchiveDecoder.from_bytes(
+        recover val Array[U8] end, Directory(out_path)?)?
+    })
+    tmp.dispose()
+
 primitive \nodoc\ _WriteRawArchive
   fun apply(path: FilePath, writer: Writer iso) ? =>
     match CreateFile(path)

--- a/tools/pony-dep/test/main.pony
+++ b/tools/pony-dep/test/main.pony
@@ -62,6 +62,9 @@ actor \nodoc\ Main is TestList
     test(_TestArchiveDecoderRejectsUnknownVersion)
     test(_TestArchiveDecoderRejectsUnknownType)
     test(_TestArchiveDecoderRejectsAbsolutePath)
+    test(_TestArchiveDecoderFromBytesSingleFile)
+    test(_TestArchiveDecoderFromBytesNested)
+    test(_TestArchiveDecoderFromBytesInvalid)
 
     // Pack tests
     test(_TestPackRoundTrip)


### PR DESCRIPTION
Implements the fetch-and-place step from the pony-dep plan: a `fetch` subcommand that downloads a `.par` archive over HTTP or HTTPS and extracts it to a target directory.

The `Fetch` actor connects to the URL, follows redirects (up to 5), and verifies TLS certificates against system CA roots via a new `set_default_verify_paths` method on `SSLContext`. The downloaded bytes go directly to `ArchiveDecoder.from_bytes` — a new method extracted from the existing `apply` — so no temp file is needed.

`add_pony_binary` in CMake now passes `PONY_SSL_FLAG` to ponyc. Before this, tool binaries didn't need the SSL version define; now that pony-dep imports `http_client`, they do.

Three new tests cover `from_bytes` (single file, nested directories, invalid data). All counterfactual-tested.

Hash verification of the downloaded archive is noted as a TODO — it belongs in the config-driven workflow that isn't built yet.

Design: #5991
