### PR TITLE
Pass SSL version flag in cross-test.sh

### DIFF
--- a/.ci-dockerfiles/cross-riscv64/Dockerfile
+++ b/.ci-dockerfiles/cross-riscv64/Dockerfile
@@ -4,17 +4,28 @@ LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyc"
 
 USER root
 
-RUN apt-get update \
+# The stdlib's net package links against libssl/libcrypto, so the cross build
+# needs riscv64 versions. Ubuntu's riscv64 packages live on ports.ubuntu.com;
+# pin the existing amd64 sources so apt doesn't try to fetch riscv64 from
+# archive.ubuntu.com (which 404s), then add a ports entry for riscv64.
+RUN dpkg --add-architecture riscv64 \
+ && sed -i '/^Types:/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources \
+ && printf 'Types: deb\nURIs: http://ports.ubuntu.com/ubuntu-ports\nSuites: noble noble-updates noble-security\nComponents: main universe\nArchitectures: riscv64\nSigned-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n' \
+      > /etc/apt/sources.list.d/riscv64-ports.sources \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
   gdb-multiarch \
   qemu-user \
   gcc-10-riscv64-linux-gnu \
   g++-10-riscv64-linux-gnu \
   lldb \
+  libssl-dev:riscv64 \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get -y autoremove --purge \
  && apt-get -y clean \
- && ln -s /usr/riscv64-linux-gnu/lib/* /lib
+ && ln -sf /usr/riscv64-linux-gnu/lib/* /lib \
+ && ln -s /usr/lib/riscv64-linux-gnu/libssl.* /usr/riscv64-linux-gnu/lib/ \
+ && ln -s /usr/lib/riscv64-linux-gnu/libcrypto.* /usr/riscv64-linux-gnu/lib/
 
 RUN cmake --version
 

--- a/.ci-scripts/cross-test.sh
+++ b/.ci-scripts/cross-test.sh
@@ -25,6 +25,17 @@ cross_args="$3"
 cross_runner="$4"
 stdlib_excludes="$5"
 
+# The stdlib's net package requires an SSL version define. Detect the host's
+# SSL library the same way CMakeLists.txt does (via openssl version).
+ssl_version_str=$(openssl version 2>/dev/null) || true
+case "$ssl_version_str" in
+    LibreSSL*) ssl_flag="-Dlibressl" ;;
+    "OpenSSL 4"*|"OpenSSL  4"*) ssl_flag="-Dopenssl_4.0.x" ;;
+    "OpenSSL 3"*|"OpenSSL  3"*) ssl_flag="-Dopenssl_3.0.x" ;;
+    "OpenSSL 1.1"*|"OpenSSL  1.1"*) ssl_flag="-Dopenssl_1.1.x" ;;
+    *) echo "cross-test.sh: cannot detect SSL version from: $ssl_version_str" >&2; exit 1 ;;
+esac
+
 # ponyc's output directory is named after the build type, not after the preset.
 # Map rather than strip a suffix: a preset that sets PONY_USES lands in a
 # directory with those options appended (BUILD.md).
@@ -45,12 +56,12 @@ ctest --preset "$preset" -L ci-core -E stdlib
 # cross_runner, and stdlib_excludes must word-split into multiple arguments.
 cd "build/$config"
 # shellcheck disable=SC2086
-PONYPATH=".:$cross_ponypath" ./ponyc -b stdlib-release --pic --checktree $cross_args ../../packages/stdlib
+PONYPATH=".:$cross_ponypath" ./ponyc -b stdlib-release --pic --checktree $ssl_flag $cross_args ../../packages/stdlib
 echo "Built $(pwd)/stdlib-release"
 # shellcheck disable=SC2086
 $cross_runner ./stdlib-release --sequential $stdlib_excludes
 # shellcheck disable=SC2086
-PONYPATH=".:$cross_ponypath" ./ponyc -d -b stdlib-debug --pic --strip --checktree $cross_args ../../packages/stdlib
+PONYPATH=".:$cross_ponypath" ./ponyc -d -b stdlib-debug --pic --strip --checktree $ssl_flag $cross_args ../../packages/stdlib
 echo "Built $(pwd)/stdlib-debug"
 # shellcheck disable=SC2086
 $cross_runner ./stdlib-debug --sequential $stdlib_excludes

--- a/.github/workflows/ponyc-tier3.yml
+++ b/.github/workflows/ponyc-tier3.yml
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: ghcr.io/ponylang/ponyc-ci-cross-riscv64:20260908
+          - image: ghcr.io/ponylang/ponyc-ci-cross-riscv64:20260912
             name: riscv64 Linux glibc
 
     name: ${{ matrix.name }}


### PR DESCRIPTION
The net package's SSL/DTLS code has compile_error guards that require an SSL version define (-Dopenssl_3.0.x etc.). The native stdlib tests get this from CMake via RunStdlibTest.cmake, but cross-test.sh calls ponyc directly and never passed one — so the riscv64 stdlib cross-compilation fails at dtls_context.pony.

Detect the host's SSL library from `openssl version` and pass the flag to both ponyc invocations.