### PR TITLE
Use x86-64-debug preset for cross-runner net SSL tests

### DIFF
--- a/.github/workflows/net-ssl-tests.yml
+++ b/.github/workflows/net-ssl-tests.yml
@@ -35,10 +35,10 @@ jobs:
         run: python3 .ci-scripts/libs-cache/pr_libs_cache.py $LIBS_BRANCH_CACHE --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- cmake -DJOBS=4 -P lib/build-libs.cmake
       - name: Build
         run: |
-          cmake --preset debug -DPONY_INSTALL_SYMLINKS=OFF
-          cmake --build --preset debug
+          cmake --preset x86-64-debug -DPONY_INSTALL_SYMLINKS=OFF
+          cmake --build --preset x86-64-debug
       - name: Install
-        run: cmake --install build/build_debug --prefix install
+        run: cmake --install build/build_x86-64-debug --prefix install
       - name: Upload installed ponyc
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The build job compiled ponyc with the `debug` preset, which inherits `native` and passes `-march=native`. When the binary was distributed to test jobs on runners with different (older) CPU features, the unsupported instructions caused SIGILL.

Switch to `x86-64-debug` — the same baseline instruction set the release builds use — so the binary is portable across GitHub Actions runners.

Closes #6039
