### PR TITLE
Move release builds from PR CI to weekly checks

### DIFF
--- a/.github/workflows/ponyc-weekly-checks.yml
+++ b/.github/workflows/ponyc-weekly-checks.yml
@@ -568,3 +568,156 @@ jobs:
           type: stream
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  # ----- vanilla ci-core full matrix (moved from PR CI) -----
+  # PR CI runs only debug-runtime + debug-ponyc. These jobs cover the three
+  # remaining configurations: debug-runtime + release-ponyc, release-runtime +
+  # debug-ponyc, release-runtime + release-ponyc. Both runtimes are built and
+  # the full ci-core label runs against each.
+  # Chained sequentially behind use_directives to avoid adding to the initial
+  # parallel burst; !cancelled() lets each platform run independently of the
+  # others' pass/fail.
+
+  ci_core_linux:
+    needs: [check-for-changes, use_directives]
+    if: >-
+      !cancelled() &&
+      needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: ubuntu-latest
+    name: ci-core x86-64 Linux glibc
+    container:
+      image: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260908
+      options: --user pony --cap-add=SYS_PTRACE --security-opt seccomp=unconfined
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Build libs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIBS_IMAGE: ghcr.io/ponylang/ponyc-ci-ubuntu26.04-builder:20260908
+          LIBS_TAG: ${{ hashFiles('lib/CMakePresets.json', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/build-libs.cmake', 'lib/llvm/patches/*') }}
+        run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --branch-cache --image "$LIBS_IMAGE" --tag "$LIBS_TAG" -- cmake -DJOBS=4 -P lib/build-libs.cmake
+      - name: Build Debug Runtime
+        run: |
+          cmake --preset x86-64-debug
+          cmake --build --preset x86-64-debug
+      - name: Test with Debug Runtime
+        run: |
+          PONY_TEST_DEBUGGER="$(.ci-scripts/test-debugger.sh lldb)"
+          export PONY_TEST_DEBUGGER
+          ctest --preset x86-64-debug -L ci-core
+      - name: Build Release Runtime
+        run: |
+          cmake --preset x86-64-release
+          cmake --build --preset x86-64-release
+      - name: Test with Release Runtime
+        run: |
+          PONY_TEST_DEBUGGER="$(.ci-scripts/test-debugger.sh lldb)"
+          export PONY_TEST_DEBUGGER
+          ctest --preset x86-64-release -L ci-core
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  ci_core_macos:
+    needs: [check-for-changes, ci_core_linux]
+    if: >-
+      !cancelled() &&
+      needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: macos-26
+    name: ci-core arm64 macOS
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Build libs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIBS_TAG: ${{ hashFiles('lib/CMakePresets.json', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/build-libs.cmake', 'lib/llvm/patches/*') }}
+        run: python3 .ci-scripts/libs-cache/resolve_libs_cache.py --branch-cache --platform arm64-macos-26 --tag "$LIBS_TAG" -- cmake -DJOBS=3 -P lib/build-libs.cmake
+      - name: Build Debug Runtime
+        run: |
+          cmake --preset armv8-debug
+          cmake --build --preset armv8-debug
+      - name: Test with Debug Runtime
+        run: ctest --preset armv8-debug -L ci-core
+      - name: Build Release Runtime
+        run: |
+          cmake --preset armv8-release
+          cmake --build --preset armv8-release
+      - name: Test with Release Runtime
+        run: ctest --preset armv8-release -L ci-core
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  ci_core_windows:
+    needs: [check-for-changes, ci_core_macos]
+    if: >-
+      !cancelled() &&
+      needs.check-for-changes.outputs.has-changes == 'true'
+    runs-on: windows-2025-vs2026
+    defaults:
+      run:
+        shell: pwsh
+    name: ci-core x86-64 Windows MSVC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Install Dependencies
+        run: .\.ci-scripts\windows-install-deps.ps1
+      - name: Install LibreSSL
+        run: .\.ci-scripts\windows-install-libressl.ps1
+      - name: Configure Networking
+        run: .\.ci-scripts\windows-configure-networking.ps1
+      - name: Build libs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LIBS_TAG: ${{ hashFiles('lib/CMakePresets.json', 'CMakeLists.txt', 'lib/CMakeLists.txt', 'lib/build-libs.cmake', 'lib/llvm/patches/*') }}
+        run: python .ci-scripts/libs-cache/resolve_libs_cache.py --branch-cache --platform windows-2025-vs2026 --tag "$env:LIBS_TAG" '--' cmake -DPRESET=libs-windows-x86-64 -DJOBS=4 -P lib/build-libs.cmake
+      - name: Configure
+        run: cmake --preset windows-x86-64
+      - name: Build Debug Runtime
+        run: cmake --build --preset windows-x86-64-debug
+      - name: Test with Debug Runtime
+        run: |
+          $env:PONY_TEST_DEBUGGER = & .ci-scripts/test-debugger.ps1 lldb
+          ctest --preset windows-x86-64-debug -L ci-core
+      - name: Build Release Runtime
+        run: cmake --build --preset windows-x86-64-release
+      - name: Test with Release Runtime
+        run: |
+          $env:PONY_TEST_DEBUGGER = & .ci-scripts/test-debugger.ps1 lldb
+          ctest --preset windows-x86-64-release -L ci-core
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -167,7 +167,7 @@ jobs:
         run: |
           PONY_TEST_DEBUGGER="$(.ci-scripts/test-debugger.sh lldb)"
           export PONY_TEST_DEBUGGER
-          ctest --preset x86-64-debug -L ci-core
+          ctest --preset x86-64-debug -L ci-core -E "(stdlib-release|full-programs-release)"
       - name: Compile generative stress engine
         run: PONYPATH=packages build/debug/ponyc -d --pic -b generative -o build/debug test/rt-stress/generative/
       - name: Detect SSL version
@@ -184,15 +184,6 @@ jobs:
         run: PONYPATH=packages build/debug/ponyc -d ${{ env.PONY_SSL_FLAG }} --pic -b tcp-swarm -o build/debug test/rt-stress/tcp-swarm/
       - name: Compile udp-swarm stress engine
         run: PONYPATH=packages build/debug/ponyc -d ${{ env.PONY_SSL_FLAG }} --pic -b udp-swarm -o build/debug test/rt-stress/udp-swarm/
-      - name: Build Release Runtime
-        run: |
-          cmake --preset x86-64-release
-          cmake --build --preset x86-64-release
-      - name: Test with Release Runtime
-        run: |
-          PONY_TEST_DEBUGGER="$(.ci-scripts/test-debugger.sh lldb)"
-          export PONY_TEST_DEBUGGER
-          ctest --preset x86-64-release -L ci-core
 
   ponyc-arm64-macos:
     needs: [changes, maybe-build-macos]
@@ -218,13 +209,7 @@ jobs:
           cmake --preset armv8-debug
           cmake --build --preset armv8-debug
       - name: Test with Debug Runtime
-        run: ctest --preset armv8-debug -L ci-core
-      - name: Build Release Runtime
-        run: |
-          cmake --preset armv8-release
-          cmake --build --preset armv8-release
-      - name: Test with Release Runtime
-        run: ctest --preset armv8-release -L ci-core
+        run: ctest --preset armv8-debug -L ci-core -E "(stdlib-release|full-programs-release)"
 
   ponyc-x86_64-windows:
     needs: [changes, maybe-build-windows]
@@ -264,13 +249,7 @@ jobs:
       - name: Test with Debug Runtime
         run: |
           $env:PONY_TEST_DEBUGGER = & .ci-scripts/test-debugger.ps1 lldb
-          ctest --preset windows-x86-64-debug -L ci-core
-      - name: Build Release Runtime
-        run: cmake --build --preset windows-x86-64-release
-      - name: Test with Release Runtime
-        run: |
-          $env:PONY_TEST_DEBUGGER = & .ci-scripts/test-debugger.ps1 lldb
-          ctest --preset windows-x86-64-release -L ci-core
+          ctest --preset windows-x86-64-debug -L ci-core -E "(stdlib-release|full-programs-release)"
 
   # ----- pony-compiler suite -----
 


### PR DESCRIPTION
PR CI tested all four configurations per platform: debug and release runtimes × debug and release ponyc. Only the debug-runtime + debug-ponyc combination stays in the PR path — the other three move to the weekly checks workflow.

The three new weekly jobs build both runtimes and run the full ci-core label against each. They chain sequentially behind `use_directives` to stay out of the initial parallel burst.

Closes #6044
