### PR TITLE
Move example compilation to a weekly workflow

### DIFF
--- a/.ci-scripts/build-examples.sh
+++ b/.ci-scripts/build-examples.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Compile every example package under examples/. Directories whose path
+# contains "ffi-" are skipped (they need C libraries the runner may not have).
+#
+# Usage: build-examples.sh <ponyc> <ssl-flag>
+#
+#   ponyc     Path to the ponyc binary.
+#   ssl-flag  The SSL define flag (e.g. -Dlibressl, -Dopenssl_3.0.x).
+
+set -o errexit
+set -o nounset
+
+PONYC="$1"
+SSL_FLAG="$2"
+
+failed=""
+for dir in $(find examples -name '*.pony' | sed 's|/[^/]*$||' | sort -u); do
+  [ "$dir" = "examples" ] && continue
+  echo "$dir" | grep -q 'ffi-' && continue
+
+  echo "--- $dir ---"
+  if "$PONYC" -d -s --checktree "$SSL_FLAG" -o "$dir" "$dir"; then
+    :
+  else
+    failed="$failed $dir"
+  fi
+done
+
+if [ -n "$failed" ]; then
+  printf '\nFailed examples:%s\n' "$failed"
+  exit 1
+fi

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,0 +1,29 @@
+name: Build Examples
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 6"
+
+jobs:
+  build-examples:
+    runs-on: ubuntu-latest
+    name: Build examples with nightly ponyc
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Build examples
+        run: sh .ci-scripts/build-examples.sh ponyc -Dlibressl
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ The output goes in `build/debug`. Use `--preset release` for a release build. Th
 
 Tests are registered with ctest and grouped by label. Two labels matter:
 
-- **`ci-core`** — built by a normal `cmake --build --preset debug`. The C/C++ compiler tests (`libponyc.tests`), the runtime tests (`libponyrt.tests`), the stdlib suite, full-program integration tests, example compilation, and grammar validation.
+- **`ci-core`** — built by a normal `cmake --build --preset debug`. The C/C++ compiler tests (`libponyc.tests`), the runtime tests (`libponyrt.tests`), the stdlib suite, full-program integration tests, and grammar validation.
 - **`tools`** — **not** built by a normal `cmake --build --preset debug`. The self-hosted tool test suites: pony-compiler, pony-lsp, pony-lint, pony-doc, and pony-dep.
 
 ### Core tests (ci-core)
@@ -57,8 +57,8 @@ Run individual tests by name:
 - `ctest --preset debug -R stdlib-release` — stdlib test suite, release mode
 - `ctest --preset debug -R full-programs-debug` — compile-and-run integration tests, debug mode
 - `ctest --preset debug -R full-programs-release` — compile-and-run integration tests, release mode
-- `ctest --preset debug -R examples` — compiles all examples
 - `ctest --preset debug -R validate-grammar` — checks `pony.g` against the compiler
+- `ctest --preset debug -R examples` — compiles all examples (not part of `ci-core`; runs locally and in the weekly `build-examples.yml` workflow)
 
 #### Per-package stdlib tests
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -958,7 +958,7 @@ else()
 
     set_tests_properties(full-programs-debug full-programs-release
         full-program-runner-rejects-broken-config
-        stdlib-debug stdlib-release examples validate-grammar
+        stdlib-debug stdlib-release validate-grammar
         PROPERTIES LABELS ci-core)
     set_tests_properties(stdlib-debug stdlib-release
         PROPERTIES TIMEOUT 1800)


### PR DESCRIPTION
Moves example compilation out of per-PR CI into a weekly scheduled
workflow. Examples exercise stdlib APIs already covered by the stdlib
and full-program suites, so building them on every PR adds CI time
without catching much.

The `examples` ctest test stays registered (without a label) so a bare
`ctest --preset debug` still compiles them locally — cmake handles SSL
detection there. The weekly workflow uses the shared-docker
libressl-4.2.1 nightly image and a shell script in `.ci-scripts/`.

Closes #6042
